### PR TITLE
Add Matrix View

### DIFF
--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -147,6 +147,14 @@ pub type DictLength = usize;
 /// Useful when keying back into it downstream.
 pub type BytesLength = usize;
 
+/// Physical column stride in elements for a `Matrix`.
+///
+/// Columns are padded to 64-byte boundaries, so the stride may be greater than
+/// the row count. BLAS and LAPACK refer to this value as the leading dimension
+/// (`lda`).
+#[cfg(feature = "matrix")]
+pub type Stride = usize;
+
 // Top-level type
 
 /// Windowed ***V**iew **T**uple* for Array, when one isn't using the
@@ -172,6 +180,26 @@ pub type SuperNdArrayVT<'a, T> = (&'a SuperNdArray<T>, Offset, Length);
 /// axis-0 observation counts.
 #[cfg(feature = "xarray")]
 pub type XArrayVT<'a, T> = (&'a XArray<T>, Offset, Length);
+
+/// Windowed matrix view tuple over a column-major `f64` buffer:
+/// `(data, offset, length, stride)`.
+///
+/// - `data` is the complete backing buffer.
+/// - Column `j` begins at `data[j * stride]`.
+/// - The window covers rows `[offset, offset + length)` of each column.
+/// - For non-empty matrices, the column count is `data.len() / stride`.
+/// - [`Matrix::as_tuple`](crate::Matrix::as_tuple) and
+///   [`MatrixV::as_tuple`](crate::MatrixV::as_tuple) use this representation.
+///
+/// The tuple represents matrix storage without requiring a [`Matrix`](crate::Matrix)
+/// value. Matrix kernels can therefore operate on any compatible stride-aligned
+/// `f64` buffer.
+///
+/// For a matrix with no rows, `stride` is zero and `data` is empty. The column
+/// count cannot be derived from the tuple in that case and must be supplied
+/// separately.
+#[cfg(feature = "matrix")]
+pub type MatrixVT<'a> = (&'a [f64], Offset, Length, Stride);
 
 /// Subset per respective table within the cube
 ///

--- a/src/enums/value/conversions.rs
+++ b/src/enums/value/conversions.rs
@@ -22,6 +22,8 @@ use super::impls::value_variant_name;
 use crate::Cube;
 #[cfg(feature = "matrix")]
 use crate::Matrix;
+#[cfg(all(feature = "matrix", feature = "views"))]
+use crate::MatrixV;
 #[cfg(feature = "ndarray")]
 use crate::NdArray;
 #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -351,6 +353,35 @@ impl Value {
             _ => Err(MinarrowError::TypeError {
                 from: value_variant_name(self),
                 to: "Matrix",
+                message: None,
+            }),
+        }
+    }
+
+    /// Returns the inner `MatrixV` if this is a `Value::MatrixView`.
+    ///
+    /// Panics if the value is not a `MatrixView` variant.
+    #[cfg(all(feature = "matrix", feature = "views"))]
+    #[inline]
+    pub fn matv(&self) -> &MatrixV {
+        match self {
+            Value::MatrixView(mv) => mv,
+            _ => panic!(
+                "Expected Value::MatrixView, found {}",
+                value_variant_name(self)
+            ),
+        }
+    }
+
+    /// Returns the inner `MatrixV` if this is a `Value::MatrixView`, or an error otherwise.
+    #[cfg(all(feature = "matrix", feature = "views"))]
+    #[inline]
+    pub fn try_matv(&self) -> Result<&MatrixV, MinarrowError> {
+        match self {
+            Value::MatrixView(mv) => Ok(mv),
+            _ => Err(MinarrowError::TypeError {
+                from: value_variant_name(self),
+                to: "MatrixV",
                 message: None,
             }),
         }
@@ -908,6 +939,14 @@ impl From<Matrix> for Value {
     }
 }
 
+#[cfg(all(feature = "matrix", feature = "views"))]
+impl From<MatrixV> for Value {
+    #[inline]
+    fn from(v: MatrixV) -> Self {
+        Value::MatrixView(Arc::new(v))
+    }
+}
+
 #[cfg(feature = "ndarray")]
 impl From<NdArray<f64>> for Value {
     #[inline]
@@ -1085,6 +1124,8 @@ impl TryFrom<Value> for Array {
             Value::SuperTableView(_) => Array::try_from(Table::try_from(v)?),
             #[cfg(feature = "matrix")]
             Value::Matrix(_) => Array::try_from(Table::try_from(v)?),
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(_) => Array::try_from(Table::try_from(v)?),
             #[cfg(feature = "ndarray")]
             Value::NdArray(inner) => {
                 let nd = Arc::try_unwrap(inner).unwrap_or_else(|arc| (*arc).clone());
@@ -1269,6 +1310,8 @@ impl<'a> TryFrom<&'a Value> for BitmaskV<'a> {
             Value::SuperTableView(_) => Err(err(v)),
             #[cfg(feature = "matrix")]
             Value::Matrix(_) => Err(err(v)),
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(_) => Err(err(v)),
             #[cfg(feature = "ndarray")]
             Value::NdArray(_) => Err(err(v)),
             #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -1365,6 +1408,9 @@ impl TryFrom<Value> for Table {
             Value::Matrix(inner) => Ok(Table::from(
                 Arc::try_unwrap(inner).unwrap_or_else(|arc| (*arc).clone()),
             )),
+            // MatrixView is materialised to a Matrix, then converted to Table.
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(inner) => Ok(Table::from(inner.to_matrix())),
             #[cfg(feature = "ndarray")]
             Value::NdArray(inner) => {
                 let nd = Arc::try_unwrap(inner).unwrap_or_else(|arc| (*arc).clone());
@@ -1570,7 +1616,27 @@ impl TryFrom<Value> for Matrix {
             Value::Matrix(inner) => {
                 Ok(Arc::try_unwrap(inner).unwrap_or_else(|arc| (*arc).clone()))
             }
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(inner) => Ok(inner.to_matrix()),
             other => Matrix::try_from(Table::try_from(other)?),
+        }
+    }
+}
+
+#[cfg(all(feature = "matrix", feature = "views"))]
+impl TryFrom<Value> for MatrixV {
+    type Error = MinarrowError;
+
+    /// Accepts any `Value` that resolves to a `Matrix`, viewed over its full
+    /// row extent. An incoming `MatrixView` passes through unchanged. Other
+    /// matrix-like types convert through `Matrix::try_from` first.
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        match v {
+            Value::MatrixView(inner) => {
+                Ok(Arc::try_unwrap(inner).unwrap_or_else(|arc| (*arc).clone()))
+            }
+            Value::Matrix(inner) => Ok(MatrixV::from(inner)),
+            other => Ok(MatrixV::from(Matrix::try_from(other)?)),
         }
     }
 }

--- a/src/enums/value/impls.rs
+++ b/src/enums/value/impls.rs
@@ -48,6 +48,8 @@ impl PartialEq for Value {
             (FieldArray(a), FieldArray(b)) => **a == **b,
             #[cfg(feature = "matrix")]
             (Matrix(a), Matrix(b)) => a == b,
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            (MatrixView(a), MatrixView(b)) => **a == **b,
             #[cfg(feature = "ndarray")]
             (NdArray(a), NdArray(b)) => **a == **b,
             #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -115,6 +117,8 @@ impl Display for Value {
             SuperTableView(stv) => write!(f, "{stv}"),
             #[cfg(feature = "matrix")]
             Matrix(m) => write!(f, "{m}"),
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            MatrixView(mv) => write!(f, "{mv}"),
             #[cfg(feature = "ndarray")]
             NdArray(nd) => write!(f, "{nd}"),
             #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -183,6 +187,8 @@ impl Shape for Value {
             Value::FieldArray(field_array) => field_array.shape(),
             #[cfg(feature = "matrix")]
             Value::Matrix(matrix) => matrix.shape(),
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(view) => view.shape(),
             #[cfg(feature = "ndarray")]
             Value::NdArray(nd) => Shape::shape(nd.as_ref()),
             #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -348,6 +354,14 @@ impl Concatenate for Value {
             (Matrix(a), Matrix(b)) => {
                 let a = Arc::try_unwrap(a).unwrap_or_else(|arc| (*arc).clone());
                 let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
+                Ok(Value::Matrix(Arc::new(a.concat(b)?)))
+            }
+
+            // MatrixView + MatrixView -> Matrix.
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            (MatrixView(a), MatrixView(b)) => {
+                let a = a.to_matrix();
+                let b = b.to_matrix();
                 Ok(Value::Matrix(Arc::new(a.concat(b)?)))
             }
 
@@ -625,6 +639,8 @@ pub(crate) fn value_variant_name(value: &Value) -> &'static str {
         Value::FieldArray(_) => "FieldArray",
         #[cfg(feature = "matrix")]
         Value::Matrix(_) => "Matrix",
+        #[cfg(all(feature = "matrix", feature = "views"))]
+        Value::MatrixView(_) => "MatrixView",
         #[cfg(feature = "ndarray")]
         Value::NdArray(_) => "NdArray",
         #[cfg(all(feature = "ndarray", feature = "views"))]

--- a/src/enums/value/mod.rs
+++ b/src/enums/value/mod.rs
@@ -36,6 +36,8 @@ mod conversions;
 use crate::Cube;
 #[cfg(feature = "matrix")]
 use crate::Matrix;
+#[cfg(all(feature = "matrix", feature = "views"))]
+use crate::MatrixV;
 #[cfg(feature = "ndarray")]
 use crate::NdArray;
 #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -101,6 +103,8 @@ pub enum Value {
     SuperTableView(Arc<SuperTableV>),
     #[cfg(feature = "matrix")]
     Matrix(Arc<Matrix>),
+    #[cfg(all(feature = "matrix", feature = "views"))]
+    MatrixView(Arc<MatrixV>),
     #[cfg(feature = "ndarray")]
     NdArray(Arc<NdArray<f64>>),
     #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -180,6 +184,9 @@ impl Value {
             // window, matching the n-dimensional case below.
             #[cfg(feature = "matrix")]
             Value::Matrix(m) => m.n_rows,
+
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(mv) => mv.len,
 
             #[cfg(feature = "ndarray")]
             Value::NdArray(nd) => nd.shape()[0],
@@ -264,7 +271,15 @@ impl Value {
             }
 
             #[cfg(feature = "matrix")]
-            Value::Matrix(_) => unimplemented!("Matrix slicing"),
+            Value::Matrix(m) => Value::MatrixView(Arc::new(MatrixV::from_arc_matrix(
+                m.clone(),
+                offset,
+                length,
+            ))),
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(mv) => {
+                Value::MatrixView(Arc::new(mv.from_self(offset, length)))
+            }
             #[cfg(feature = "ndarray")]
             Value::NdArray(nd) => {
                 assert!(
@@ -434,5 +449,117 @@ mod tests {
 
         let whole = value.slice(0, value.len());
         assert_eq!(whole.len(), 10);
+    }
+
+    #[cfg(all(feature = "matrix", feature = "views"))]
+    mod matrix_view_variant {
+        use std::sync::Arc;
+
+        use super::Value;
+        use crate::enums::shape_dim::ShapeDim;
+        use crate::traits::shape::Shape;
+        use crate::{Matrix, MatrixV, mat};
+
+        /// A 5-row, 2-column matrix encoding values `row + 10 * col`.
+        fn sample() -> Matrix {
+            mat![
+                [0.0, 1.0, 2.0, 3.0, 4.0],
+                [10.0, 11.0, 12.0, 13.0, 14.0]
+            ]
+        }
+
+        ///`len` reports row count on both matrix arms, matching the slice window axis. 
+        /// Element count would be 10 in this case.
+        #[test]
+        fn len_counts_rows_on_both_matrix_arms() {
+            let owned = Value::Matrix(Arc::new(sample()));
+            assert_eq!(owned.len(), 5);
+
+            let windowed = owned.slice(1, 3);
+            assert_eq!(windowed.len(), 3);
+        }
+
+        #[test]
+        fn slicing_a_matrix_shares_the_backing_allocation() {
+            let backing = Arc::new(sample());
+            let value = Value::Matrix(backing.clone());
+
+            let Value::MatrixView(view) = value.slice(1, 3) else {
+                panic!("Expected Value::MatrixView");
+            };
+            assert!(
+                Arc::ptr_eq(&backing, &view.matrix),
+                "slicing a Matrix must not copy its buffer"
+            );
+            assert_eq!(view.offset, 1);
+            assert_eq!(view.col(0), &[1.0, 2.0, 3.0]);
+        }
+
+        #[test]
+        fn slicing_a_matrix_view_rewindows_against_the_same_backing() {
+            let backing = Arc::new(sample());
+            let value = Value::Matrix(backing.clone()).slice(1, 4);
+
+            let Value::MatrixView(view) = value.slice(1, 2) else {
+                panic!("Expected Value::MatrixView");
+            };
+            assert!(Arc::ptr_eq(&backing, &view.matrix));
+            assert_eq!(view.offset, 2);
+            assert_eq!(view.col(1), &[12.0, 13.0]);
+        }
+
+        #[test]
+        fn shape_and_equality_read_the_window() {
+            let value = Value::Matrix(Arc::new(sample())).slice(1, 3);
+            assert_eq!(value.shape(), ShapeDim::Rank2 { rows: 3, cols: 2 });
+
+            let same = Value::Matrix(Arc::new(sample())).slice(1, 3);
+            assert_eq!(value, same);
+            assert_ne!(value, Value::Matrix(Arc::new(sample())).slice(0, 3));
+        }
+
+        #[test]
+        fn round_trips_through_from_and_try_from() {
+            let view = MatrixV::from_matrix(sample(), 1, 3);
+            let value = Value::from(view.clone());
+            assert_eq!(MatrixV::try_from(value).unwrap(), view);
+
+            // An owned matrix converts as a full-row window.
+            let whole = MatrixV::try_from(Value::Matrix(Arc::new(sample()))).unwrap();
+            assert_eq!(whole.n_rows(), 5);
+            assert!(whole.spans_backing());
+        }
+
+        #[test]
+        fn try_from_reports_a_type_mismatch() {
+            let tuple = Value::Tuple2(Arc::new((
+                Value::Matrix(Arc::new(sample())),
+                Value::Matrix(Arc::new(sample())),
+            )));
+            assert!(MatrixV::try_from(tuple).is_err());
+
+            let view = Value::Matrix(Arc::new(sample())).slice(1, 3);
+            assert!(view.try_matv().is_ok());
+            assert!(Value::Matrix(Arc::new(sample())).try_matv().is_err());
+        }
+
+        #[test]
+        fn converting_to_a_matrix_materialises_the_window() {
+            let value = Value::Matrix(Arc::new(sample())).slice(1, 3);
+            let materialised = Matrix::try_from(value).unwrap();
+            assert_eq!(materialised.n_rows, 3);
+            assert_eq!(materialised.col(0), &[1.0, 2.0, 3.0]);
+            assert_eq!(materialised.col(1), &[11.0, 12.0, 13.0]);
+        }
+
+        #[test]
+        fn converting_to_a_table_carries_the_windowed_rows() {
+            use crate::Table;
+
+            let value = Value::Matrix(Arc::new(sample())).slice(2, 2);
+            let table = Table::try_from(value).unwrap();
+            assert_eq!(table.n_rows, 2);
+            assert_eq!(table.n_cols(), 2);
+        }
     }
 }

--- a/src/kernels/broadcast/mod.rs
+++ b/src/kernels/broadcast/mod.rs
@@ -517,6 +517,17 @@ pub fn broadcast_value(
            matrix::broadcast_array_matrix_add(l, r)
         }
 
+        // Materialises
+        #[cfg(all(feature = "matrix", feature = "views"))]
+        (Value::MatrixView(l), r) => {
+            broadcast_value(op, Value::Matrix(Arc::new(l.to_matrix())), r)
+        }
+
+        #[cfg(all(feature = "matrix", feature = "views"))]
+        (l, Value::MatrixView(r)) => {
+            broadcast_value(op, l, Value::Matrix(Arc::new(r.to_matrix())))
+        }
+
         // Matrix with other complex types - return specific error
         #[cfg(feature = "matrix")]
         (Value::Matrix(_), _) | (_, Value::Matrix(_)) => Err(MinarrowError::TypeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,9 @@ pub mod structs {
         pub mod array_view;
         pub mod bitmask_view;
         #[cfg(feature = "views")]
+        #[cfg(feature = "matrix")]
+        pub mod matrix_view;
+        #[cfg(feature = "views")]
         #[cfg(feature = "ndarray")]
         pub mod ndarray_view;
 
@@ -273,6 +276,8 @@ pub use aliases::{
 
 #[cfg(feature = "datetime")]
 pub use aliases::DatetimeAVT;
+#[cfg(feature = "matrix")]
+pub use aliases::{MatrixVT, Stride};
 pub use enums::array::Array;
 pub use enums::collections::numeric_array::NumericArray;
 #[cfg(feature = "datetime")]
@@ -315,6 +320,8 @@ pub use structs::views::collections::numeric_array_view::NumericArrayV;
 pub use structs::views::collections::temporal_array_view::TemporalArrayV;
 #[cfg(feature = "views")]
 pub use structs::views::collections::text_array_view::TextArrayV;
+#[cfg(all(feature = "views", feature = "matrix"))]
+pub use structs::views::matrix_view::MatrixV;
 #[cfg(all(feature = "views", feature = "ndarray"))]
 pub use structs::views::ndarray_view::NdArrayV;
 

--- a/src/structs/matrix.rs
+++ b/src/structs/matrix.rs
@@ -21,6 +21,7 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use crate::aliases::MatrixVT;
 use crate::enums::error::MinarrowError;
 use crate::enums::shape_dim::ShapeDim;
 use crate::structs::buffer::Buffer;
@@ -47,8 +48,18 @@ use crate::{SharedBuffer, TableV};
 /// - `stride`: Physical elements per column in the buffer. Padded to 8-element
 ///   (64-byte) boundaries so every column starts SIMD-aligned. This is the
 ///   BLAS leading dimension (lda). Always `>= n_rows`.
-/// - `data`: Flat buffer in column-major order with stride padding.
+/// - `data`: Column-major buffer with stride padding, stored in an `Arc`.
+///   Access is provided through [`Matrix::as_slice`] and
+///   [`Matrix::as_mut_slice`].
 /// - `name`: Optional matrix name for diagnostics.
+///
+/// ### Sharing and mutation
+///
+/// Cloning shares the backing buffer through `Arc`. [`MatrixV`](crate::MatrixV)
+/// uses the same allocation for row windows without copying data.
+///
+/// Mutable access uses `Arc::make_mut`, copying the buffer only when the
+/// allocation is shared.
 ///
 /// ### Null handling
 /// - It is contiguous - nulls can be represented through `f64::NAN`
@@ -78,12 +89,19 @@ pub struct Matrix {
     pub n_cols: usize,
     /// Physical column stride in elements, padded so each column is 64-byte aligned.
     pub stride: usize,
-    /// Backing storage. `Buffer<f64>` carries either an owned `Vec64<f64>` or a
-    /// shared view into an existing allocation. The shared variant enables
-    /// zero-copy construction from upstream `TableV` arenas via
-    /// `TableV::try_as_matrix_zc` without sacrificing the contiguous column-major
-    /// stride layout that BLAS/LAPACK expects.
-    pub data: Buffer<f64>,
+    /// Backing storage for the column-major matrix buffer.
+    ///
+    /// The `Arc<Buffer<f64>>` contains either owned `Vec64<f64>` storage or a
+    /// shared view into an existing allocation. Shared storage supports zero-copy
+    /// construction from `TableV` arenas through [`TableV::try_as_matrix_zc`]
+    /// while preserving the stride required by BLAS and LAPACK.
+    ///
+    /// Clones share the same allocation. Mutable access uses `Arc::make_mut`, so
+    /// the buffer is copied only when the allocation has other references.
+    ///
+    /// Read access is provided by [`Matrix::as_slice`], and mutable access by
+    /// [`Matrix::as_mut_slice`].
+    pub(crate) data: Arc<Buffer<f64>>,
     pub name: Option<String>,
 }
 
@@ -104,7 +122,7 @@ impl Matrix {
         let len = stride * n_cols;
         let mut vec = Vec64::with_capacity(len);
         vec.resize(len, 0.0);
-        let data = Buffer::from_vec64(vec);
+        let data = Arc::new(Buffer::from_vec64(vec));
         Matrix {
             n_rows,
             n_cols,
@@ -133,7 +151,7 @@ impl Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(data),
+            data: Arc::new(Buffer::from_vec64(data)),
             name,
         }
     }
@@ -159,7 +177,7 @@ impl Matrix {
                 n_rows,
                 n_cols,
                 stride,
-                data: Buffer::from_vec64(vec),
+                data: Arc::new(Buffer::from_vec64(vec)),
                 name,
             };
         }
@@ -176,7 +194,7 @@ impl Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(vec),
+            data: Arc::new(Buffer::from_vec64(vec)),
             name,
         }
     }
@@ -244,7 +262,7 @@ impl Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(vec),
+            data: Arc::new(Buffer::from_vec64(vec)),
             name: name.map(Into::into),
         })
     }
@@ -263,7 +281,7 @@ impl Matrix {
     pub fn set(&mut self, row: usize, col: usize, value: f64) {
         debug_assert!(row < self.n_rows, "Row out of bounds");
         debug_assert!(col < self.n_cols, "Col out of bounds");
-        self.data.as_mut_slice()[col * self.stride + row] = value;
+        Arc::make_mut(&mut self.data).as_mut_slice()[col * self.stride + row] = value;
     }
 
     /// Returns true if the matrix is empty.
@@ -288,7 +306,7 @@ impl Matrix {
     /// Triggers copy-on-write if the backing buffer is currently shared.
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [f64] {
-        self.data.as_mut_slice()
+        Arc::make_mut(&mut self.data).as_mut_slice()
     }
 
     /// Returns a view of the matrix as a slice of columns (logical rows only, no padding).
@@ -320,7 +338,7 @@ impl Matrix {
             self.data.len() >= total,
             "Matrix::columns_mut: data buffer shorter than stride * n_cols"
         );
-        let ptr = self.data.as_mut_slice().as_mut_ptr();
+        let ptr = Arc::make_mut(&mut self.data).as_mut_slice().as_mut_ptr();
         let mut result = Vec::with_capacity(n_cols);
 
         for col in 0..n_cols {
@@ -351,7 +369,7 @@ impl Matrix {
     pub fn col_mut(&mut self, col: usize) -> &mut [f64] {
         assert!(col < self.n_cols, "Col out of bounds");
         let start = col * self.stride;
-        &mut self.data.as_mut_slice()[start..start + self.n_rows]
+        &mut Arc::make_mut(&mut self.data).as_mut_slice()[start..start + self.n_rows]
     }
 
     /// Returns a single row as an owned Vec.
@@ -370,7 +388,7 @@ impl Matrix {
         let mut dst = Matrix::new(self.n_cols, self.n_rows, self.name.clone());
         let src = self.data.as_slice();
         let dst_stride = dst.stride;
-        let dst_slice = dst.data.as_mut_slice();
+        let dst_slice = Arc::make_mut(&mut dst.data).as_mut_slice();
         for j in 0..self.n_cols {
             for i in 0..self.n_rows {
                 dst_slice[i * dst_stride + j] = src[j * self.stride + i];
@@ -446,6 +464,16 @@ impl Matrix {
         (self.data.as_slice(), self.stride as i32)
     }
 
+    /// Returns the matrix as `(data, offset, length, stride)`.
+    ///
+    /// For a complete matrix, `offset` is zero and `length` is the row count.
+    /// [`MatrixV::as_tuple`](crate::MatrixV::as_tuple) uses the same representation
+    /// for a row window.
+    #[inline]
+    pub fn as_tuple(&self) -> MatrixVT<'_> {
+        (self.data.as_slice(), 0, self.n_rows, self.stride)
+    }
+
     /// Mutable counterpart to [`as_strided`]. Returns `(data, lda)` where
     /// `data` is a `&mut [f64]` view of the backing buffer (triggering
     /// copy-on-write if the buffer is currently shared). The leading
@@ -454,7 +482,7 @@ impl Matrix {
     #[inline]
     pub fn as_mut_strided(&mut self) -> (&mut [f64], i32) {
         let lda = self.stride as i32;
-        (self.data.as_mut_slice(), lda)
+        (Arc::make_mut(&mut self.data).as_mut_slice(), lda)
     }
 
     // ********************** Table conversion **********************
@@ -484,11 +512,12 @@ impl Matrix {
         let stride = self.stride;
         let name = self.name;
 
-        // Surface the backing SharedBuffer and its element-level base offset.
-        // Owned data is frozen into a new SharedBuffer; already-shared data
-        // reuses its owner so to_table stays zero-copy across repeat calls.
+        // Extract the backing `SharedBuffer` and element offset. Owned data is wrapped
+        // in a new `SharedBuffer`; shared data reuses the existing owner. `Arc::try_unwrap`
+        // copies only when the allocation has other references.
+        let buffer = Arc::try_unwrap(self.data).unwrap_or_else(|arc| (*arc).clone());
         // SAFETY: f64 has no drop logic or interior invariants.
-        let (shared, base_offset, _len) = unsafe { self.data.into_shared_parts() };
+        let (shared, base_offset, _len) = unsafe { buffer.into_shared_parts() };
 
         let mut cols = Vec::with_capacity(n_cols);
         for (i, field) in fields.into_iter().enumerate() {
@@ -640,7 +669,11 @@ impl TableV {
             });
         }
 
-        let data = Buffer::from_shared_column(base_owner.unwrap(), base_offset, total_elems);
+        let data = Arc::new(Buffer::from_shared_column(
+            base_owner.unwrap(),
+            base_offset,
+            total_elems,
+        ));
         let name = if self.name().is_empty() {
             None
         } else {
@@ -712,7 +745,7 @@ impl Concatenate for Matrix {
             n_rows: result_n_rows,
             n_cols: result_n_cols,
             stride: result_stride,
-            data: Buffer::from_vec64(result_vec),
+            data: Arc::new(Buffer::from_vec64(result_vec)),
             name: None,
         })
     }
@@ -791,7 +824,7 @@ impl From<Vec<FloatArray<f64>>> for Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(vec),
+            data: Arc::new(Buffer::from_vec64(vec)),
             name: None,
         }
     }
@@ -827,7 +860,7 @@ impl From<&[FloatArray<f64>]> for Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(vec),
+            data: Arc::new(Buffer::from_vec64(vec)),
             name: None,
         }
     }
@@ -882,7 +915,7 @@ impl TryFrom<&Table> for Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(vec),
+            data: Arc::new(Buffer::from_vec64(vec)),
             name,
         })
     }
@@ -917,7 +950,7 @@ impl From<&[Vec<f64>]> for Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(vec),
+            data: Arc::new(Buffer::from_vec64(vec)),
             name: None,
         }
     }
@@ -984,7 +1017,7 @@ impl TryFrom<&TableV> for Matrix {
             n_rows,
             n_cols,
             stride,
-            data: Buffer::from_vec64(vec),
+            data: Arc::new(Buffer::from_vec64(vec)),
             name,
         })
     }
@@ -1016,16 +1049,24 @@ impl<'a> IntoIterator for &'a mut Matrix {
     type IntoIter = std::slice::IterMut<'a, f64>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.data.as_mut_slice().iter_mut()
+        Arc::make_mut(&mut self.data).as_mut_slice().iter_mut()
     }
 }
 
 impl IntoIterator for Matrix {
     type Item = f64;
     type IntoIter = <Vec64<f64> as IntoIterator>::IntoIter;
+
+    /// Consumes the matrix and iterates over the complete backing buffer, including
+    /// stride padding.
+    ///
+    /// `Arc::try_unwrap` copies the buffer only when the allocation has other
+    /// references.
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.data.into_iter()
+        Arc::try_unwrap(self.data)
+            .unwrap_or_else(|arc| (*arc).clone())
+            .into_iter()
     }
 }
 
@@ -1323,6 +1364,60 @@ impl From<Matrix> for Table {
     /// position where the matrix carries no field names of its own.
     fn from(value: Matrix) -> Self {
         value.to_table_gen()
+    }
+}
+
+#[cfg(test)]
+mod buffer_sharing_tests {
+    use super::*;
+
+    #[test]
+    fn clone_shares_the_buffer() {
+        let a = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        let b = a.clone();
+        assert_eq!(
+            a.as_slice().as_ptr(),
+            b.as_slice().as_ptr(),
+            "cloning a matrix must share the buffer rather than copy it"
+        );
+    }
+
+    #[test]
+    fn writing_to_a_clone_copies_and_leaves_the_original() {
+        let a = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        let mut b = a.clone();
+        b.set(0, 0, 99.0);
+
+        assert_eq!(b.get(0, 0), 99.0);
+        assert_eq!(a.get(0, 0), 1.0, "the original must not see the write");
+        assert_ne!(a.as_slice().as_ptr(), b.as_slice().as_ptr());
+    }
+
+    #[test]
+    fn writing_to_a_sole_owner_stays_in_place() {
+        let mut a = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        let before = a.as_slice().as_ptr();
+        a.set(0, 0, 99.0);
+
+        assert_eq!(a.get(0, 0), 99.0);
+        assert_eq!(
+            a.as_slice().as_ptr(),
+            before,
+            "a sole owner must write in place rather than copy"
+        );
+    }
+
+    #[test]
+    fn as_tuple_describes_the_whole_matrix() {
+        let m = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]];
+        let (data, offset, len, stride) = m.as_tuple();
+
+        assert_eq!((offset, len, stride), (0, 3, 8));
+        assert_eq!(data.len() / stride, 2);
+        for j in 0..2 {
+            let start = j * stride + offset;
+            assert_eq!(&data[start..start + len], m.col(j));
+        }
     }
 }
 

--- a/src/structs/ndarray.rs
+++ b/src/structs/ndarray.rs
@@ -986,7 +986,7 @@ impl NdArray<f64> {
                 n_rows,
                 n_cols,
                 stride: strides[1],
-                data: Arc::try_unwrap(self.data).unwrap_or_else(|arc| (*arc).clone()),
+                data: self.data,
                 name: self.name,
             });
         }
@@ -1881,7 +1881,7 @@ impl From<Matrix> for NdArray<f64> {
         let shape = [mat.n_rows, mat.n_cols];
         let strides = [1, mat.stride];
         NdArray {
-            data: Arc::new(mat.data),
+            data: mat.data,
             dims: NdDims::from_shape_and_strides(&shape, &strides),
             name: mat.name,
         }

--- a/src/structs/views/matrix_view.rs
+++ b/src/structs/views/matrix_view.rs
@@ -1,0 +1,834 @@
+// Copyright 2025 Peter Garfield Bower
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # MatrixV - Windowed Matrix View
+//!
+//! `MatrixV` represents a row window over a [`Matrix`], covering rows
+//! `[offset .. offset + len)` across all columns while sharing the underlying
+//! column-major buffer.
+//!
+//! ## Purpose
+//!
+//! Matrix windows allow row ranges to be partitioned or processed in batches
+//! without copying or repacking the stride-aligned storage required by BLAS and
+//! LAPACK, which are well-established packages for numerical linear algebra routines. 
+//! Each view retains the backing matrix through `Arc<Matrix>` and stores
+//! only its row offset and length.
+//!
+//! ## Behaviour
+//!
+//! - Column storage remains contiguous within the selected row range.
+//!   [`MatrixV::col`] returns a `&[f64]` for one column.
+//! - [`MatrixV::from_self`] creates a sub-window without copying data.
+//! - [`MatrixV::to_matrix`] materialises the window as a new owned [`Matrix`],
+//!   including any padding required for the new row count.
+//! - Columns are positional and have no names or null masks. Column selection
+//!   is not supported. Use [`MatrixV::col`] for individual columns or convert
+//!   to `Table` for named-column operations.
+//!
+//! ## Example
+//!
+//! ```rust
+//! use minarrow::{Matrix, MatrixV, mat};
+//!
+//! let m = mat![[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]];
+//!
+//! // Rows 1..3 from both columns, sharing the backing matrix.
+//! let v = MatrixV::from_matrix(m, 1, 2);
+//! assert_eq!(v.n_rows(), 2);
+//! assert_eq!(v.n_cols(), 2);
+//! assert_eq!(v.col(0), &[2.0, 3.0]);
+//! assert_eq!(v.col(1), &[20.0, 30.0]);
+//!
+//! // Materialise the window as an owned matrix.
+//! let owned = v.to_matrix();
+//! assert_eq!(owned.n_rows, 2);
+//! ```
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+use crate::aliases::MatrixVT;
+use crate::enums::error::MinarrowError;
+use crate::enums::shape_dim::ShapeDim;
+use crate::structs::matrix::Matrix;
+use crate::traits::concatenate::Concatenate;
+use crate::traits::print::print_float_grid;
+use crate::traits::shape::Shape;
+#[cfg(feature = "select")]
+use crate::traits::selection::{DataSelector, RowSelection};
+
+/// # MatrixView
+///
+/// Row window over a [`Matrix`] covering rows `[offset .. offset + len)`.
+///
+/// ## Fields
+///
+/// - `matrix`: backing matrix shared through `Arc`.
+/// - `offset`: index of the first row in the backing matrix.
+/// - `len`: number of rows in the window.
+///
+/// ## Behaviour
+///
+/// - Construction and re-windowing do not copy column data. Use
+///   [`MatrixV::to_matrix`] to materialise the window as an independent
+///   [`Matrix`].
+/// - [`MatrixV::as_strided`] returns `(data, lda)` for BLAS and LAPACK, with
+///   `data` positioned at the first row of the window.
+/// - [`MatrixV::as_tuple`] returns `(data, offset, length, stride)` for kernels
+///   that operate without the view type.
+/// - Columns are positional and have no names or null masks. Column selection
+///   is not supported. Use [`MatrixV::col`] for individual columns or convert
+///   to `Table` for named-column operations.
+#[derive(Clone)]
+pub struct MatrixV {
+    /// Backing matrix shared by all views over the same data.
+    pub matrix: Arc<Matrix>,
+    /// Index of the first row in the backing matrix.
+    pub offset: usize,
+    /// Number of rows in the window.
+    pub len: usize,
+}
+
+impl MatrixV {
+    /// Creates a view over rows `[offset .. offset + len)` of the matrix.
+    ///
+    /// The matrix is moved into shared `Arc` storage for this view and any
+    /// subsequent views derived from it.
+    #[inline]
+    pub fn from_matrix(matrix: Matrix, offset: usize, len: usize) -> Self {
+        Self::from_arc_matrix(Arc::new(matrix), offset, len)
+    }
+
+    /// Creates a zero-copy view over `matrix[offset .. offset+len)` rows of an
+    /// already-shared matrix.    /// Creates a view over rows `[offset .. offset + len)` of a shared matrix.
+    #[inline]
+    pub fn from_arc_matrix(matrix: Arc<Matrix>, offset: usize, len: usize) -> Self {
+        assert!(
+            offset <= matrix.n_rows && len <= matrix.n_rows - offset,
+            "MatrixV::from_arc_matrix: window [{}, {}) out of bounds for a matrix of {} rows",
+            offset,
+            offset.saturating_add(len),
+            matrix.n_rows
+        );
+        MatrixV {
+            matrix,
+            offset,
+            len,
+        }
+    }
+
+    /// Creates a sub-window with `offset` relative to this view.
+    #[inline]
+    pub fn from_self(&self, offset: usize, len: usize) -> Self {
+        assert!(
+            offset <= self.len && len <= self.len - offset,
+            "MatrixV::from_self: window [{}, {}) out of bounds for a view of {} rows",
+            offset,
+            offset.saturating_add(len),
+            self.len
+        );
+        MatrixV {
+            matrix: self.matrix.clone(),
+            offset: self.offset + offset,
+            len,
+        }
+    }
+
+    /// Returns the number of rows in the window.
+    #[inline]
+    pub fn n_rows(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the number of columns in the backing matrix.
+    ///
+    /// Windowing affects rows only, so every backing column remains present.
+    #[inline]
+    pub fn n_cols(&self) -> usize {
+        self.matrix.n_cols
+    }
+
+    /// Returns the number of rows in the window.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the window has no rows or the backing matrix has no
+    /// columns.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0 || self.matrix.n_cols == 0
+    }
+
+    /// Returns the exclusive end row of the window in backing-matrix
+    /// coordinates.
+    #[inline]
+    pub fn end(&self) -> usize {
+        self.offset + self.len
+    }
+
+    /// Returns `true` if the window covers every row of the backing matrix.
+    ///
+    /// Full-span views can be materialised by cloning the backing matrix rather
+    /// than constructing a new row window.
+    #[inline]
+    pub fn spans_backing(&self) -> bool {
+        self.offset == 0 && self.len == self.matrix.n_rows
+    }
+
+    /// Returns the backing matrix name.
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        self.matrix.name.as_deref()
+    }
+
+    /// Returns the backing matrix column stride in elements.
+    ///
+    /// This is the BLAS leading dimension (`lda`).
+    #[inline]
+    pub fn stride(&self) -> usize {
+        self.matrix.stride
+    }
+
+    /// Returns column `col` over the current row window.
+    ///
+    /// The returned slice is contiguous. Panics if `col` is outside the
+    /// backing matrix.
+    #[inline]
+    pub fn col(&self, col: usize) -> &[f64] {
+        assert!(
+            col < self.matrix.n_cols,
+            "MatrixV::col: column {} out of bounds for {} columns",
+            col,
+            self.matrix.n_cols
+        );
+        let start = col * self.matrix.stride + self.offset;
+        &self.matrix.data.as_slice()[start..start + self.len]
+    }
+
+    /// Returns all column windows in column order.
+    pub fn columns(&self) -> Vec<&[f64]> {
+        (0..self.matrix.n_cols).map(|c| self.col(c)).collect()
+    }
+
+    /// Returns the value at `(row, col)`.
+    ///
+    /// `row` is relative to the current window.
+    #[inline]
+    pub fn get(&self, row: usize, col: usize) -> f64 {
+        debug_assert!(row < self.len, "Row out of bounds");
+        self.matrix.get(self.offset + row, col)
+    }
+
+    /// Returns one window-relative row as an owned `Vec<f64>`.
+    #[inline]
+    pub fn row(&self, row: usize) -> Vec<f64> {
+        debug_assert!(row < self.len, "Row out of bounds");
+        self.matrix.row(self.offset + row)
+    }
+
+    /// Returns the view as `(data, offset, length, stride)`.
+    ///
+    /// `data` references the complete backing buffer. `offset` and `length`
+    /// identify the current row window, and `stride` gives the physical spacing
+    /// between columns.
+    #[inline]
+    pub fn as_tuple(&self) -> MatrixVT<'_> {
+        (
+            self.matrix.data.as_slice(),
+            self.offset,
+            self.len,
+            self.matrix.stride,
+        )
+    }
+
+    // ********************** BLAS/LAPACK Compatibility **************
+
+    /// Returns the window row count as `i32` for BLAS and LAPACK calls.
+    #[inline]
+    pub fn m(&self) -> i32 {
+        self.len as i32
+    }
+
+    /// Returns the column count as `i32` for BLAS and LAPACK calls.
+    #[inline]
+    pub fn n(&self) -> i32 {
+        self.matrix.n_cols as i32
+    }
+
+    /// Returns the BLAS leading dimension (`lda`).
+    ///
+    /// Row windowing does not change the physical spacing between backing
+    /// columns.
+    #[inline]
+    pub fn lda(&self) -> i32 {
+        self.matrix.stride as i32
+    }
+
+    /// Returns the window as `(data, lda)` for BLAS and LAPACK.
+    ///
+    /// `data` begins at the first row of the window. Element `(i, j)` is located
+    /// at `data[j * lda + i]` for the `m() × n()` view.
+    #[inline]
+    pub fn as_strided(&self) -> (&[f64], i32) {
+        (
+            &self.matrix.data.as_slice()[self.offset..],
+            self.matrix.stride as i32,
+        )
+    }
+
+    /// Returns mutable strided storage for BLAS and LAPACK routines.
+    ///
+    /// `Arc::make_mut` provides copy-on-write behaviour when the backing matrix
+    /// is shared. Mutations affect only the resulting backing allocation after
+    /// any required copy.
+    #[inline]
+    pub fn as_mut_strided(&mut self) -> (&mut [f64], i32) {
+        let lda = self.matrix.stride as i32;
+        let offset = self.offset;
+        (
+            &mut Arc::make_mut(&mut self.matrix).as_mut_slice()[offset..],
+            lda,
+        )
+    }
+
+    /// Materialises the window as an owned `Matrix`.
+    ///
+    /// Partial windows are copied into a new 64-byte-aligned column-major
+    /// buffer with stride appropriate to the new row count. Full-span windows
+    /// use the backing matrix's `Clone` implementation.
+    pub fn to_matrix(&self) -> Matrix {
+        if self.spans_backing() {
+            return (*self.matrix).clone();
+        }
+        let mut out = Matrix::new(self.len, self.matrix.n_cols, self.matrix.name.clone());
+        for col in 0..self.matrix.n_cols {
+            out.col_mut(col).copy_from_slice(self.col(col));
+        }
+        out
+    }
+
+    /// Gathers window-relative rows into a new owned `Matrix`.
+    ///
+    /// Output rows follow the order of `indices`. Panics if any index is outside
+    /// the current window.
+    pub fn gather_rows(&self, indices: &[usize]) -> Matrix {
+        let absolute: Vec<usize> = indices
+            .iter()
+            .map(|&i| {
+                assert!(
+                    i < self.len,
+                    "MatrixV::gather_rows: row {} out of bounds for a view of {} rows",
+                    i,
+                    self.len
+                );
+                self.offset + i
+            })
+            .collect();
+        self.matrix.extract_rows(&absolute)
+    }
+}
+
+impl Shape for MatrixV {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank2 {
+            rows: self.n_rows(),
+            cols: self.n_cols(),
+        }
+    }
+}
+impl Concatenate for MatrixV {
+    /// Concatenates two row windows into one owned matrix.
+    ///
+    /// Both windows must have the same number of columns. The result is returned
+    /// as a full-span view over the concatenated matrix.
+    fn concat(self, other: Self) -> Result<Self, MinarrowError> {
+        let joined = self.to_matrix().concat(other.to_matrix())?;
+        Ok(MatrixV::from(joined))
+    }
+}
+
+/// Equality is based on shape and values rather than backing storage.
+impl PartialEq for MatrixV {
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len
+            && self.n_cols() == other.n_cols()
+            && (0..self.n_cols()).all(|c| self.col(c) == other.col(c))
+    }
+}
+
+impl fmt::Debug for MatrixV {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MatrixV{}: {} × {} [col-major, rows {}..{} of {}]",
+            self.matrix
+                .name
+                .as_deref()
+                .map_or(String::new(), |n| format!(" '{}'", n)),
+            self.len,
+            self.n_cols(),
+            self.offset,
+            self.end(),
+            self.matrix.n_rows
+        )
+    }
+}
+
+impl Display for MatrixV {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let n_rows = self.n_rows();
+        let n_cols = self.n_cols();
+        match &self.matrix.name {
+            Some(name) => writeln!(
+                f,
+                "MatrixView \"{}\" [{} rows × {} cols, f64] (rows {}..{} of {})",
+                name,
+                n_rows,
+                n_cols,
+                self.offset,
+                self.end(),
+                self.matrix.n_rows
+            )?,
+            None => writeln!(
+                f,
+                "MatrixView [{} rows × {} cols, f64] (rows {}..{} of {})",
+                n_rows,
+                n_cols,
+                self.offset,
+                self.end(),
+                self.matrix.n_rows
+            )?,
+        }
+        if n_cols == 0 {
+            return Ok(());
+        }
+        let headers: Vec<String> = (0..n_cols).map(|c| format!("col_{c}")).collect();
+        print_float_grid(f, &headers, n_rows, |row, col| self.get(row, col))
+    }
+}
+
+/// Converts an owned `Matrix` to a full-span `MatrixV`.
+impl From<Matrix> for MatrixV {
+    fn from(matrix: Matrix) -> Self {
+        let len = matrix.n_rows;
+        MatrixV::from_matrix(matrix, 0, len)
+    }
+}
+
+/// Converts a shared `Arc<Matrix>` to a full-span `MatrixV`.
+impl From<Arc<Matrix>> for MatrixV {
+    fn from(matrix: Arc<Matrix>) -> Self {
+        let len = matrix.n_rows;
+        MatrixV::from_arc_matrix(matrix, 0, len)
+    }
+}
+
+/// Materialises a `MatrixV` as an owned `Matrix`.
+impl From<MatrixV> for Matrix {
+    fn from(view: MatrixV) -> Self {
+        view.to_matrix()
+    }
+}
+
+// ===== Selection Trait Implementations =====
+
+/// Row selection over a matrix.
+///
+/// Contiguous selections return a view over the existing row range. Non-
+/// contiguous selections gather the requested rows into a new owned matrix and
+/// return a full-span view over it.
+#[cfg(feature = "select")]
+impl RowSelection for Matrix {
+    type View = MatrixV;
+
+    fn r<S: DataSelector>(&self, selection: S) -> MatrixV {
+        let indices = selection.resolve_indices(self.n_rows);
+        if selection.is_contiguous() {
+            let start = indices.first().copied().unwrap_or(0);
+            return MatrixV::from_matrix(self.clone(), start, indices.len());
+        }
+        MatrixV::from(self.extract_rows(&indices))
+    }
+
+    fn get_row_count(&self) -> usize {
+        self.n_rows
+    }
+}
+
+/// Row selection over an existing matrix view.
+///
+/// Contiguous selections return a sub-window over the same backing matrix.
+/// Non-contiguous selections gather the requested rows into a new owned matrix
+/// and return a full-span view over it.
+#[cfg(feature = "select")]
+impl RowSelection for MatrixV {
+    type View = MatrixV;
+
+    fn r<S: DataSelector>(&self, selection: S) -> MatrixV {
+        let indices = selection.resolve_indices(self.len);
+        if selection.is_contiguous() {
+            let start = indices.first().copied().unwrap_or(0);
+            return self.from_self(start, indices.len());
+        }
+        MatrixV::from(self.gather_rows(&indices))
+    }
+
+    fn get_row_count(&self) -> usize {
+        self.len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mat;
+
+    /// A 5-row, 3-column matrix whose values encode `row + 10 * col`.
+    fn sample() -> Matrix {
+        Matrix::from_f64_unaligned(
+            &[
+                0.0, 1.0, 2.0, 3.0, 4.0, // col 0
+                10.0, 11.0, 12.0, 13.0, 14.0, // col 1
+                20.0, 21.0, 22.0, 23.0, 24.0, // col 2
+            ],
+            5,
+            3,
+            Some("m".to_string()),
+        )
+    }
+
+    #[test]
+    fn from_matrix_windows_rows_and_keeps_every_column() {
+        let v = MatrixV::from_matrix(sample(), 1, 3);
+        assert_eq!(v.offset, 1);
+        assert_eq!(v.len, 3);
+        assert_eq!(v.n_rows(), 3);
+        assert_eq!(v.len(), 3);
+        assert_eq!(v.n_cols(), 3);
+        assert_eq!(v.end(), 4);
+        assert_eq!(v.name(), Some("m"));
+        assert_eq!(v.stride(), 8);
+        assert!(!v.is_empty());
+        assert!(!v.spans_backing());
+    }
+
+    #[test]
+    fn from_arc_matrix_shares_the_backing_allocation() {
+        let arc = Arc::new(sample());
+        let v = MatrixV::from_arc_matrix(arc.clone(), 2, 2);
+        assert!(Arc::ptr_eq(&arc, &v.matrix));
+        assert_eq!(v.col(0), &[2.0, 3.0]);
+        assert_eq!(v.col(2), &[22.0, 23.0]);
+    }
+
+    #[test]
+    fn whole_matrix_window_spans_backing() {
+        let v = MatrixV::from(sample());
+        assert!(v.spans_backing());
+        assert_eq!(v.n_rows(), 5);
+        assert_eq!(v.end(), 5);
+    }
+
+    #[test]
+    fn from_self_rewindows_relative_to_the_view() {
+        let v = MatrixV::from_matrix(sample(), 1, 4);
+        let inner = v.from_self(1, 2);
+        assert_eq!(inner.offset, 2);
+        assert_eq!(inner.len, 2);
+        assert_eq!(inner.col(0), &[2.0, 3.0]);
+        // Multiple re-windowing operations compose against the same backing matrix.
+        let innermost = inner.from_self(1, 1);
+        assert_eq!(innermost.offset, 3);
+        assert_eq!(innermost.col(1), &[13.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "MatrixV::from_arc_matrix: window [3, 6) out of bounds")]
+    fn construction_past_the_backing_row_count_panics() {
+        let _ = MatrixV::from_matrix(sample(), 3, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "MatrixV::from_self: window [1, 4) out of bounds")]
+    fn rewindow_past_the_view_row_count_panics() {
+        let v = MatrixV::from_matrix(sample(), 1, 3);
+        let _ = v.from_self(1, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "MatrixV::col: column 3 out of bounds")]
+    fn column_index_past_the_column_count_panics() {
+        let v = MatrixV::from_matrix(sample(), 0, 5);
+        let _ = v.col(3);
+    }
+
+    #[test]
+    fn col_windows_are_sub_slices_of_the_backing_buffer() {
+        let arc = Arc::new(sample());
+        let v = MatrixV::from_arc_matrix(arc.clone(), 1, 3);
+        let backing = arc.data.as_slice().as_ptr_range();
+        for c in 0..v.n_cols() {
+            let window = v.col(c).as_ptr_range();
+            assert!(
+                backing.contains(&window.start) && window.end <= backing.end,
+                "column {c} window must lie inside the backing buffer"
+            );
+        }
+    }
+
+    #[test]
+    fn to_matrix_copies_the_window_and_matches_the_source_rows() {
+        let src = sample();
+        let v = MatrixV::from_matrix(src.clone(), 1, 3);
+        let owned = v.to_matrix();
+
+        assert_eq!(owned.n_rows, 3);
+        assert_eq!(owned.n_cols, 3);
+        assert_eq!(owned.name.as_deref(), Some("m"));
+        for c in 0..3 {
+            assert_eq!(owned.col(c), v.col(c));
+            assert_eq!(owned.col(c), &src.col(c)[1..4]);
+        }
+        // The materialised matrix is independent of the source and backing allocation.
+        assert!(!std::ptr::eq(
+            owned.as_slice().as_ptr(),
+            v.matrix.as_slice().as_ptr()
+        ));
+    }
+
+    #[test]
+    fn to_matrix_round_trips_through_a_view() {
+        let v = MatrixV::from_matrix(sample(), 1, 3);
+        let round_tripped = MatrixV::from(v.to_matrix());
+        assert_eq!(round_tripped, v);
+    }
+
+    #[test]
+    fn columns_and_row_read_the_window() {
+        let v = MatrixV::from_matrix(sample(), 2, 2);
+        let cols = v.columns();
+        assert_eq!(cols.len(), 3);
+        assert_eq!(cols[0], &[2.0, 3.0]);
+        assert_eq!(cols[1], &[12.0, 13.0]);
+        assert_eq!(v.get(0, 1), 12.0);
+        assert_eq!(v.row(1), vec![3.0, 13.0, 23.0]);
+    }
+
+    #[test]
+    fn as_tuple_describes_the_window_over_the_flat_buffer() {
+        let m = sample();
+        let v = MatrixV::from_matrix(m.clone(), 1, 3);
+        let (data, offset, len, stride) = v.as_tuple();
+
+        assert_eq!(offset, 1);
+        assert_eq!(len, 3);
+        assert_eq!(stride, 8);
+        // Column count is derived from buffer length and stride.
+        assert_eq!(data.len() / stride, 3);
+        // Column j of the window is accessible through the tuple.
+        for j in 0..3 {
+            let start = j * stride + offset;
+            assert_eq!(&data[start..start + len], v.col(j));
+        }
+
+        // A full matrix produces the same tuple shape (zero offset) so kernels
+        // can accept either form without knowing which was passed.
+        let (whole, offset, len, stride) = m.as_tuple();
+        assert_eq!((offset, len, stride), (0, 5, 8));
+        assert_eq!(whole.len() / stride, 3);
+    }
+
+    #[test]
+    fn as_strided_hands_blas_the_window_start_and_leading_dimension() {
+        let v = MatrixV::from_matrix(sample(), 1, 3);
+        let (a, lda) = v.as_strided();
+
+        assert_eq!(lda, 8);
+        assert_eq!((v.m(), v.n()), (3, 3));
+        assert_eq!(v.lda(), lda);
+        // Element (i, j) is at index j * lda + i in the BLAS layout.
+        for j in 0..v.n_cols() {
+            for i in 0..v.n_rows() {
+                assert_eq!(a[j * lda as usize + i], v.get(i, j));
+            }
+        }
+        // The last column's data is within the borrowed slice.
+        assert!((v.n_cols() - 1) * lda as usize + v.n_rows() <= a.len());
+    }
+
+    #[test]
+    fn as_mut_strided_writes_through_to_the_backing_matrix() {
+        let backing = Arc::new(sample());
+        let mut v = MatrixV::from_arc_matrix(backing.clone(), 1, 3);
+
+        let (a, lda) = v.as_mut_strided();
+        a[lda as usize] = 99.0;
+
+        // The backing matrix is shared. Arc::make_mut copied the buffer. The write
+        // affects only this view's copy, leaving the original unchanged.
+        assert_eq!(v.get(0, 1), 99.0);
+        assert_eq!(backing.get(1, 1), 11.0);
+        assert!(!Arc::ptr_eq(&backing, &v.matrix));
+
+        // With sole ownership of the backing matrix, writes modify it directly.
+        let mut sole = MatrixV::from_matrix(sample(), 1, 3);
+        let backing_ptr = sole.matrix.as_slice().as_ptr();
+        let (a, _) = sole.as_mut_strided();
+        a[0] = 42.0;
+        assert_eq!(sole.matrix.get(1, 0), 42.0);
+        assert_eq!(sole.matrix.as_slice().as_ptr(), backing_ptr);
+    }
+
+    #[test]
+    fn gather_rows_reads_window_relative_indices() {
+        let v = MatrixV::from_matrix(sample(), 1, 4);
+        let gathered = v.gather_rows(&[2, 0]);
+        assert_eq!(gathered.n_rows, 2);
+        assert_eq!(gathered.col(0), &[3.0, 1.0]);
+        assert_eq!(gathered.col(2), &[23.0, 21.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "MatrixV::gather_rows: row 4 out of bounds")]
+    fn gather_rows_past_the_window_panics() {
+        let v = MatrixV::from_matrix(sample(), 1, 4);
+        let _ = v.gather_rows(&[4]);
+    }
+
+    #[test]
+    fn empty_window_reads_as_empty() {
+        let v = MatrixV::from_matrix(sample(), 2, 0);
+        assert!(v.is_empty());
+        assert_eq!(v.n_rows(), 0);
+        assert!(v.col(0).is_empty());
+        assert_eq!(v.to_matrix().n_rows, 0);
+    }
+
+    #[test]
+    fn shape_reports_the_window() {
+        let v = MatrixV::from_matrix(sample(), 1, 3);
+        assert_eq!(Shape::shape(&v), ShapeDim::Rank2 { rows: 3, cols: 3 });
+    }
+
+    #[test]
+    fn equality_compares_window_contents_not_backing_matrices() {
+        let a = MatrixV::from_matrix(sample(), 1, 3);
+        let b = MatrixV::from(a.to_matrix());
+        assert_eq!(a, b);
+        assert_ne!(a, MatrixV::from_matrix(sample(), 0, 3));
+    }
+
+    #[test]
+    fn concat_stacks_two_windows_into_one_owned_matrix() {
+        let m = sample();
+        let top = MatrixV::from_matrix(m.clone(), 0, 2);
+        let bottom = MatrixV::from_matrix(m, 3, 2);
+        let joined = top.concat(bottom).unwrap();
+        assert_eq!(joined.n_rows(), 4);
+        assert_eq!(joined.n_cols(), 3);
+        assert!(joined.spans_backing());
+        assert_eq!(joined.col(0), &[0.0, 1.0, 3.0, 4.0]);
+        assert_eq!(joined.col(2), &[20.0, 21.0, 23.0, 24.0]);
+    }
+
+    #[test]
+    fn concat_rejects_a_column_count_mismatch() {
+        let a = MatrixV::from(mat![[1.0, 2.0]]);
+        let b = MatrixV::from(mat![[1.0, 2.0], [3.0, 4.0]]);
+        assert!(a.concat(b).is_err());
+    }
+
+    #[test]
+    fn display_states_the_window_over_its_backing_matrix() {
+        let v = MatrixV::from_matrix(sample(), 1, 2);
+        let rendered = format!("{v}");
+        assert!(
+            rendered.starts_with("MatrixView \"m\" [2 rows × 3 cols, f64] (rows 1..3 of 5)"),
+            "unexpected header: {rendered}"
+        );
+        assert!(rendered.contains("col_0"));
+        assert!(rendered.contains("11"));
+        // Only rows in the window are rendered, not the full backing matrix.
+        assert!(!rendered.contains("14"));
+    }
+
+    #[test]
+    fn debug_states_the_window_over_its_backing_matrix() {
+        let v = MatrixV::from_matrix(sample(), 1, 2);
+        assert_eq!(
+            format!("{v:?}"),
+            "MatrixV 'm': 2 × 3 [col-major, rows 1..3 of 5]"
+        );
+    }
+
+    #[cfg(feature = "select")]
+    #[test]
+    fn row_selection_on_a_matrix_windows_a_contiguous_range() {
+        let selected = sample().r(1..4);
+        assert_eq!(selected.n_rows(), 3);
+        assert_eq!(selected.offset, 1);
+        assert_eq!(selected.col(0), &[1.0, 2.0, 3.0]);
+    }
+
+    #[cfg(feature = "select")]
+    #[test]
+    fn row_selection_on_a_matrix_moves_no_data() {
+        let m = sample();
+        let backing = m.as_slice().as_ptr();
+        let selected = m.r(1..4);
+        assert_eq!(
+            selected.matrix.as_slice().as_ptr(),
+            backing,
+            "a range selection must share the matrix buffer, not copy it"
+        );
+    }
+
+    #[cfg(feature = "select")]
+    #[test]
+    fn row_selection_on_a_matrix_gathers_an_index_array() {
+        let selected = sample().r(&[3usize, 0][..]);
+        assert_eq!(selected.n_rows(), 2);
+        assert!(selected.spans_backing());
+        assert_eq!(selected.col(1), &[13.0, 10.0]);
+    }
+
+    #[cfg(feature = "select")]
+    #[test]
+    fn row_selection_on_a_view_composes_windows() {
+        let v = MatrixV::from_matrix(sample(), 1, 4);
+        let chained = v.r(1..4).r(0..2);
+        assert_eq!(chained.offset, 2);
+        assert_eq!(chained.n_rows(), 2);
+        assert_eq!(chained.col(0), &[2.0, 3.0]);
+        assert_eq!(chained.get_row_count(), 2);
+
+        // Non-contiguous selections gather rows into a new matrix.
+        let picked = v.r(&[3usize, 1][..]);
+        assert_eq!(picked.col(0), &[4.0, 2.0]);
+    }
+
+    #[cfg(feature = "size")]
+    #[test]
+    fn est_bytes_scales_with_the_window() {
+        use crate::ByteSize;
+
+        let full = MatrixV::from(sample());
+        let half = MatrixV::from_matrix(sample(), 0, 2);
+        assert!(half.est_bytes() < full.est_bytes());
+        assert_eq!(half.est_bytes(), full.est_bytes() * 2 / 5);
+    }
+}

--- a/src/traits/byte_size.rs
+++ b/src/traits/byte_size.rs
@@ -658,6 +658,27 @@ impl ByteSize for Matrix {
     }
 }
 
+/// Estimate bytes for MatrixV based on the window's proportional share of
+/// the backing matrix. Calculates `(backing_bytes * window_rows) / total_rows`.
+#[cfg(all(feature = "matrix", feature = "views"))]
+use crate::MatrixV;
+
+#[cfg(all(feature = "matrix", feature = "views"))]
+impl ByteSize for MatrixV {
+    fn est_bytes(&self) -> usize {
+        let full_rows = self.matrix.n_rows;
+        if full_rows > 0 {
+            (self.matrix.est_bytes() * self.len()) / full_rows
+        } else {
+            0
+        }
+    }
+
+    fn logical_bytes(&self) -> usize {
+        unimplemented!("MatrixV has not yet implemented logical bytes.")
+    }
+}
+
 /// ByteSize for NdArray (when ndarray feature is enabled)
 #[cfg(feature = "ndarray")]
 use crate::structs::ndarray::NdArray;
@@ -886,6 +907,8 @@ impl ByteSize for Value {
             Value::FieldArray(fa) => fa.est_bytes(),
             #[cfg(feature = "matrix")]
             Value::Matrix(m) => m.est_bytes(),
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(mv) => mv.est_bytes(),
             #[cfg(feature = "ndarray")]
             Value::NdArray(nd) => nd.est_bytes(),
             #[cfg(all(feature = "ndarray", feature = "views"))]
@@ -961,6 +984,10 @@ impl ByteSize for Value {
             #[cfg(feature = "matrix")]
             Value::Matrix(_) => {
                 unimplemented!("Matrix does not define logical byte accounting")
+            }
+            #[cfg(all(feature = "matrix", feature = "views"))]
+            Value::MatrixView(_) => {
+                unimplemented!("MatrixV does not define logical byte accounting")
             }
             #[cfg(feature = "ndarray")]
             Value::NdArray(_) => {


### PR DESCRIPTION
1. Add MatrixV row-window view over Matrix with Value integration
2. Move Matrix buffer behind Arc
3. Make MatrixVT slice-based

Note this is a breaking change however the Arc is required to share the Matrix zero-copy without materialisation.