### PR TITLE
Add ArrowType Decimal32, Decimal64, Decimal128 variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,13 @@ extended_categorical = ["default_categorical_8"]
 # For most analytical use cases, they get upcasted anyway.
 extended_numeric_types = []
 
+# Adds Decimal32, Decimal64, and Decimal128 array types for exact numeric
+# values (monetary, accounting, high-precision columns). All three widths
+# are gated together. Without decimal-specific arithmetic kernels the arrays
+# are fully functional for import, export, grouping, sorting, filtering,
+# and explicit conversion to float.
+decimal = []
+
 # Adds a cube object for stacking tables on an extra axis
 # Useful for time series, and group analytics.
 cube = ["views", "select", "hash"]

--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -2525,6 +2525,10 @@ impl Array {
                 arr.null_mask = Some(mask);
                 Array::from_string32(arr)
             }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("null_array: DecimalArray is not yet available")
+            }
         }
     }
 
@@ -2608,6 +2612,10 @@ impl Array {
             ArrowType::Interval(_) => Array::TemporalArray(crate::TemporalArray::Datetime64(
                 Arc::new(crate::DatetimeArray::<i64>::default()),
             )),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("from_arrow_dtype: DecimalArray is not yet available")
+            }
         }
     }
 

--- a/src/ffi/arrow_c_ffi.rs
+++ b/src/ffi/arrow_c_ffi.rs
@@ -265,6 +265,24 @@ unsafe extern "C" fn release_arrow_schema(s: *mut ArrowSchema) {
 
 /// Constructs the Arrow C FFI format string for the given ArrowType.
 pub fn fmt_c(dtype: ArrowType) -> CString {
+    #[cfg(feature = "decimal")]
+    match &dtype {
+        // Decimal128 is the Arrow default so the bitwidth suffix is omitted.
+        ArrowType::Decimal128(p, s) => {
+            let fmt = format!("d:{p},{s}");
+            return CString::new(fmt).expect("CString formatting failed: invalid bytes");
+        }
+        ArrowType::Decimal32(p, s) => {
+            let fmt = format!("d:{p},{s},32");
+            return CString::new(fmt).expect("CString formatting failed: invalid bytes");
+        }
+        ArrowType::Decimal64(p, s) => {
+            let fmt = format!("d:{p},{s},64");
+            return CString::new(fmt).expect("CString formatting failed: invalid bytes");
+        }
+        _ => {}
+    }
+
     #[cfg(feature = "datetime")]
     if let ArrowType::Timestamp(u, tz) = &dtype {
         let unit_str = match u {
@@ -347,6 +365,11 @@ pub fn fmt_c(dtype: ArrowType) -> CString {
             IntervalUnit::DaysTime => b"tiD",
             IntervalUnit::MonthDaysNs => b"tin",
         },
+
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+            unreachable!("decimal cases handled by the early return above")
+        }
 
         // ---- dictionary (categorical) ----
         ArrowType::Dictionary(idx) => match idx {
@@ -863,6 +886,10 @@ pub unsafe fn import_from_c(arr_ptr: *const ArrowArray, sch_ptr: *const ArrowSch
             ArrowType::Interval(_u) => {
                 panic!("FFI import_from_c: Arrow Interval types are not yet supported");
             }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("FFI import_from_c: Decimal array import is not yet implemented")
+            }
             ArrowType::Null => {
                 panic!("FFI import_from_c: Arrow Null arrays types are not yet supported")
             }
@@ -1007,6 +1034,10 @@ pub unsafe fn import_from_c_owned(
             ArrowType::Interval(_u) => {
                 panic!("FFI import_from_c_owned: Arrow Interval types are not yet supported");
             }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("FFI import_from_c_owned: Decimal array import is not yet implemented")
+            }
             ArrowType::Null => {
                 panic!("FFI import_from_c_owned: Arrow Null arrays types are not yet supported")
             }
@@ -1132,6 +1163,10 @@ unsafe fn import_array_zero_copy(
             #[cfg(feature = "datetime")]
             ArrowType::Interval(_u) => {
                 panic!("import_array_zero_copy: Interval types are not yet supported");
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("import_array_zero_copy: Decimal array import is not yet implemented")
             }
             ArrowType::Null => {
                 panic!("import_array_zero_copy: Null array types are not yet supported");
@@ -3408,6 +3443,38 @@ unsafe fn field_from_c_schema(schema: &ArrowSchema) -> crate::Field {
     crate::Field::new(name, dtype, nullable, metadata)
 }
 
+/// Parses an Arrow C decimal format string (`d:P,S` or `d:P,S,N`) into an ArrowType.
+///
+/// Two-component form (`d:P,S`) is Decimal128 per the Arrow spec where 128
+/// is the default bitwidth. Three-component form (`d:P,S,N`) selects the
+/// bitwidth from N. Accepts `d:P,S,128` as equivalent to `d:P,S`.
+#[cfg(feature = "decimal")]
+fn parse_decimal_format(fmt: &[u8]) -> ArrowType {
+    let s = std::str::from_utf8(&fmt[2..]).unwrap_or_else(|_| {
+        panic!(
+            "FFI parse_decimal_format: non-UTF8 decimal format {:?}",
+            fmt
+        )
+    });
+    let parts: Vec<&str> = s.split(',').collect();
+    let precision: u8 = parts[0].parse().unwrap_or_else(|_| {
+        panic!("FFI parse_decimal_format: invalid precision in {:?}", s)
+    });
+    let scale: i8 = parts[1].parse().unwrap_or_else(|_| {
+        panic!("FFI parse_decimal_format: invalid scale in {:?}", s)
+    });
+    match parts.len() {
+        2 => ArrowType::Decimal128(precision, scale),
+        3 => match parts[2] {
+            "32" => ArrowType::Decimal32(precision, scale),
+            "64" => ArrowType::Decimal64(precision, scale),
+            "128" => ArrowType::Decimal128(precision, scale),
+            w => panic!("FFI parse_decimal_format: unsupported decimal bitwidth {w}"),
+        },
+        _ => panic!("FFI parse_decimal_format: malformed decimal format {:?}", s),
+    }
+}
+
 /// Parses an Arrow C format string into an ArrowType.
 /// Shared between import_from_c, import_from_c_owned, and stream import.
 fn parse_arrow_format(fmt: &[u8]) -> ArrowType {
@@ -3459,6 +3526,10 @@ fn parse_arrow_format(fmt: &[u8]) -> ArrowType {
         #[cfg(feature = "datetime")]
         b"tin" => ArrowType::Interval(crate::IntervalUnit::MonthDaysNs),
         b"+s" => ArrowType::Null, // struct marker (handled at stream level)
+        #[cfg(feature = "decimal")]
+        _ if fmt.starts_with(b"d:") => {
+            parse_decimal_format(fmt)
+        }
         #[cfg(feature = "datetime")]
         _ if fmt.starts_with(b"tss")
             || fmt.starts_with(b"tsm")
@@ -4644,5 +4715,54 @@ mod tests {
             ((*arr_ptr).release.unwrap())(arr_ptr);
             ((*sch_ptr).release.unwrap())(sch_ptr);
         }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_fmt_c_roundtrip() {
+        use super::{fmt_c, parse_arrow_format};
+
+        // Decimal128 emits d:P,S (no bitwidth suffix)
+        let d128 = ArrowType::Decimal128(38, 10);
+        let cstr = fmt_c(d128.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:38,10");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d128);
+
+        // Decimal64 emits d:P,S,64
+        let d64 = ArrowType::Decimal64(18, 4);
+        let cstr = fmt_c(d64.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:18,4,64");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d64);
+
+        // Decimal32 emits d:P,S,32
+        let d32 = ArrowType::Decimal32(9, 2);
+        let cstr = fmt_c(d32.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:9,2,32");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d32);
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_parse_128_explicit_bitwidth() {
+        use super::parse_arrow_format;
+
+        // d:P,S,128 is an alias for Decimal128
+        let parsed = parse_arrow_format(b"d:38,10,128");
+        assert_eq!(parsed, ArrowType::Decimal128(38, 10));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_negative_scale_roundtrip() {
+        use super::{fmt_c, parse_arrow_format};
+
+        let d = ArrowType::Decimal128(10, -3);
+        let cstr = fmt_c(d.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:10,-3");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d);
     }
 }

--- a/src/ffi/arrow_dtype.rs
+++ b/src/ffi/arrow_dtype.rs
@@ -116,6 +116,13 @@ pub enum ArrowType {
     LargeString,
     Utf8View,
 
+    #[cfg(feature = "decimal")]
+    Decimal32(u8, i8),
+    #[cfg(feature = "decimal")]
+    Decimal64(u8, i8),
+    #[cfg(feature = "decimal")]
+    Decimal128(u8, i8),
+
     // Integer size for the categorical dictionary key,
     // and therefore how much storage space for each entry there is,
     // on top of the base string collection.
@@ -141,6 +148,10 @@ impl ArrowType {
             | ArrowType::UInt64
             | ArrowType::Float32
             | ArrowType::Float64 => "Numeric",
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _)
+            | ArrowType::Decimal64(_, _)
+            | ArrowType::Decimal128(_, _) => "Numeric",
             #[cfg(feature = "datetime")]
             ArrowType::Date32
             | ArrowType::Date64
@@ -189,11 +200,14 @@ impl ArrowType {
 
         /// Promotion axis of a numeric type: family plus bit width.
         /// Numeric pairs promote on these two properties alone, so the
-        /// ten numeric types resolve through one set of rules.
+        /// standard numeric types resolve through one set of rules.
+        /// Decimal types carry precision and scale alongside their width.
         enum PromotionVariant {
             Signed(u32),
             Unsigned(u32),
             Float(u32),
+            #[cfg(feature = "decimal")]
+            Decimal(u32, u8, i8),
         }
         /// Classifies a type onto its promotion axis. Exhaustive over
         /// every `ArrowType` variant so a new variant does not compile
@@ -214,6 +228,12 @@ impl ArrowType {
                 ArrowType::UInt64 => Some(PromotionVariant::Unsigned(64)),
                 ArrowType::Float32 => Some(PromotionVariant::Float(32)),
                 ArrowType::Float64 => Some(PromotionVariant::Float(64)),
+                #[cfg(feature = "decimal")]
+                ArrowType::Decimal32(p, s) => Some(PromotionVariant::Decimal(32, *p, *s)),
+                #[cfg(feature = "decimal")]
+                ArrowType::Decimal64(p, s) => Some(PromotionVariant::Decimal(64, *p, *s)),
+                #[cfg(feature = "decimal")]
+                ArrowType::Decimal128(p, s) => Some(PromotionVariant::Decimal(128, *p, *s)),
                 ArrowType::Null | ArrowType::Boolean => None,
                 ArrowType::String | ArrowType::Utf8View | ArrowType::Dictionary(_) => None,
                 #[cfg(feature = "large_string")]
@@ -249,6 +269,14 @@ impl ArrowType {
                 _ => ArrowType::UInt64,
             }
         }
+        #[cfg(feature = "decimal")]
+        fn decimal(bits: u32, precision: u8, scale: i8) -> ArrowType {
+            match bits {
+                32 => ArrowType::Decimal32(precision, scale),
+                64 => ArrowType::Decimal64(precision, scale),
+                _ => ArrowType::Decimal128(precision, scale),
+            }
+        }
 
         if let (Some(a), Some(b)) = (promotion_variant(self), promotion_variant(other)) {
             use PromotionVariant::*;
@@ -273,6 +301,18 @@ impl ArrowType {
                 // at 64 bits where conversion validates the values.
                 (Signed(s), Unsigned(u)) | (Unsigned(u), Signed(s)) => {
                     signed(s.max((u * 2).min(64)))
+                }
+                // Demote to Float64 so the caller accepts the precision trade.
+                #[cfg(feature = "decimal")]
+                (Decimal(_, _, _), Float(_)) | (Float(_), Decimal(_, _, _)) => Float64,
+                // Promote the integer into the decimal's width and scale.
+                #[cfg(feature = "decimal")]
+                (Decimal(w, p, s), Signed(_) | Unsigned(_))
+                | (Signed(_) | Unsigned(_), Decimal(w, p, s)) => decimal(w, p, s),
+                // Widen to the broader width with the finer scale and max precision.
+                #[cfg(feature = "decimal")]
+                (Decimal(w1, p1, s1), Decimal(w2, p2, s2)) => {
+                    decimal(w1.max(w2), p1.max(p2), s1.max(s2))
                 }
             });
         }
@@ -358,12 +398,26 @@ impl ArrowType {
             | (_, Null | Boolean | String | Utf8View | Dictionary(_)) => None,
             #[cfg(feature = "large_string")]
             (LargeString, _) | (_, LargeString) => None,
-            #[cfg(feature = "extended_numeric_types")]
+            #[cfg(all(feature = "extended_numeric_types", feature = "decimal"))]
+            (
+                Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+                Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+            ) => unreachable!("numeric pairs resolve in the numeric rules above"),
+            #[cfg(all(feature = "extended_numeric_types", not(feature = "decimal")))]
             (
                 Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
                 Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
             ) => unreachable!("numeric pairs resolve in the numeric rules above"),
-            #[cfg(not(feature = "extended_numeric_types"))]
+            #[cfg(all(not(feature = "extended_numeric_types"), feature = "decimal"))]
+            (
+                Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+                Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+            ) => unreachable!("numeric pairs resolve in the numeric rules above"),
+            #[cfg(not(any(feature = "extended_numeric_types", feature = "decimal")))]
             (
                 Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
                 Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
@@ -542,6 +596,13 @@ impl Display for ArrowType {
 
             ArrowType::Float32 => f.write_str("Float32"),
             ArrowType::Float64 => f.write_str("Float64"),
+
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(p, s) => write!(f, "Decimal32({p}, {s})"),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => write!(f, "Decimal64({p}, {s})"),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => write!(f, "Decimal128({p}, {s})"),
 
             #[cfg(feature = "datetime")]
             ArrowType::Date32 => f.write_str("Date32"),
@@ -723,5 +784,130 @@ mod tests {
         assert_eq!(Null.upcast(&Null), None);
         assert_eq!(Boolean.upcast(&Boolean), None);
         assert_eq!(String.upcast(&String), None);
+    }
+
+    // ---- Decimal tests ----
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_display() {
+        assert_eq!(ArrowType::Decimal32(9, 2).to_string(), "Decimal32(9, 2)");
+        assert_eq!(ArrowType::Decimal64(18, 4).to_string(), "Decimal64(18, 4)");
+        assert_eq!(
+            ArrowType::Decimal128(38, 10).to_string(),
+            "Decimal128(38, 10)"
+        );
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_negative_scale_display() {
+        assert_eq!(
+            ArrowType::Decimal128(10, -3).to_string(),
+            "Decimal128(10, -3)"
+        );
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_category_label() {
+        assert_eq!(ArrowType::Decimal32(9, 2).minarrow_category_label(), "Numeric");
+        assert_eq!(ArrowType::Decimal64(18, 4).minarrow_category_label(), "Numeric");
+        assert_eq!(
+            ArrowType::Decimal128(38, 10).minarrow_category_label(),
+            "Numeric"
+        );
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_identity() {
+        let d32 = ArrowType::Decimal32(9, 2);
+        let d64 = ArrowType::Decimal64(18, 4);
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d32.upcast(&d32), Some(d32));
+        assert_eq!(d64.upcast(&d64), Some(d64));
+        assert_eq!(d128.upcast(&d128), Some(d128));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_same_width_same_scale_max_precision() {
+        let a = ArrowType::Decimal128(20, 5);
+        let b = ArrowType::Decimal128(30, 5);
+        assert_eq!(a.upcast(&b), Some(ArrowType::Decimal128(30, 5)));
+        assert_eq!(b.upcast(&a), Some(ArrowType::Decimal128(30, 5)));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_different_width() {
+        let d32 = ArrowType::Decimal32(9, 2);
+        let d64 = ArrowType::Decimal64(18, 4);
+        let d128 = ArrowType::Decimal128(38, 10);
+
+        // Wider width wins, finer scale preserved
+        let r = d32.upcast(&d64).unwrap();
+        assert_eq!(r, ArrowType::Decimal64(18, 4));
+
+        let r = d32.upcast(&d128).unwrap();
+        assert_eq!(r, ArrowType::Decimal128(38, 10));
+
+        let r = d64.upcast(&d128).unwrap();
+        assert_eq!(r, ArrowType::Decimal128(38, 10));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_symmetry() {
+        let types = vec![
+            ArrowType::Decimal32(9, 2),
+            ArrowType::Decimal64(18, 4),
+            ArrowType::Decimal128(38, 10),
+        ];
+        for a in &types {
+            for b in &types {
+                assert_eq!(
+                    a.upcast(b),
+                    b.upcast(a),
+                    "decimal upcast symmetry for {a:?} x {b:?}"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_x_integer() {
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d128.upcast(&ArrowType::Int32), Some(d128.clone()));
+        assert_eq!(ArrowType::Int32.upcast(&d128), Some(d128.clone()));
+        assert_eq!(ArrowType::Int64.upcast(&d128), Some(d128.clone()));
+        assert_eq!(ArrowType::UInt64.upcast(&d128), Some(d128.clone()));
+
+        let d32 = ArrowType::Decimal32(9, 2);
+        assert_eq!(d32.upcast(&ArrowType::Int64), Some(d32.clone()));
+        assert_eq!(ArrowType::UInt32.upcast(&d32), Some(d32.clone()));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_x_float() {
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d128.upcast(&ArrowType::Float32), Some(ArrowType::Float64));
+        assert_eq!(d128.upcast(&ArrowType::Float64), Some(ArrowType::Float64));
+        assert_eq!(ArrowType::Float32.upcast(&d128), Some(ArrowType::Float64));
+        assert_eq!(ArrowType::Float64.upcast(&d128), Some(ArrowType::Float64));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_x_non_numeric() {
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d128.upcast(&ArrowType::Boolean), None);
+        assert_eq!(d128.upcast(&ArrowType::String), None);
+        assert_eq!(d128.upcast(&ArrowType::Null), None);
+        assert_eq!(ArrowType::Boolean.upcast(&d128), None);
+        assert_eq!(ArrowType::String.upcast(&d128), None);
     }
 }

--- a/src/ffi/polars.rs
+++ b/src/ffi/polars.rs
@@ -256,6 +256,11 @@ fn arrow_type_to_polars_dtype(dtype: &ArrowType) -> polars_arrow::datatypes::Arr
             crate::IntervalUnit::MonthDaysNs => polars_arrow::datatypes::IntervalUnit::MonthDayNano,
         }),
 
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(p, s) | ArrowType::Decimal64(p, s) | ArrowType::Decimal128(p, s) => {
+            polars_arrow::datatypes::ArrowDataType::Decimal(*p as usize, *s as usize)
+        }
+
         ArrowType::Dictionary(idx) => {
             let key: polars_arrow::datatypes::IntegerType = match idx {
                 #[cfg(feature = "default_categorical_8")]


### PR DESCRIPTION
## Summary
- Adds three feature-gated (`decimal`) ArrowType variants: `Decimal32(u8, i8)`, `Decimal64(u8, i8)`, `Decimal128(u8, i8)`
- Implements Display, `minarrow_category_label()`, `fmt_c()` format strings, format string parsing, and full `upcast()` promotion rules
- Adds decimal mapping to Polars bridge and placeholder arms in Array enum for pending DecimalArray integration
- 16 new tests covering Display, format string round-trip, upcast identity/symmetry/rules

## Test plan
- [x] `cargo test --features decimal` passes (693 tests)
- [x] `cargo test` without decimal passes (680 tests, no impact)
- [x] `cargo check` without decimal clean
- [x] Format strings verified against arrow-rs v59.2.0 source