### PR TITLE
Wire DecimalArray into NumericArray, Array, Scalar with From impls

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1167,6 +1167,50 @@ impl View for FloatArray<f64> {
     type BufferT = f64;
 }
 
+// --------- DecimalArray Variants ---------
+
+#[cfg(feature = "decimal")]
+impl From<crate::DecimalArray<i32>> for Array {
+    fn from(a: crate::DecimalArray<i32>) -> Self {
+        Array::NumericArray(NumericArray::Decimal32(Arc::new(a)))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<crate::DecimalArray<i64>> for Array {
+    fn from(a: crate::DecimalArray<i64>) -> Self {
+        Array::NumericArray(NumericArray::Decimal64(Arc::new(a)))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<crate::DecimalArray<i128>> for Array {
+    fn from(a: crate::DecimalArray<i128>) -> Self {
+        Array::NumericArray(NumericArray::Decimal128(Arc::new(a)))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<crate::DecimalArray<i32>>> for Array {
+    fn from(a: Arc<crate::DecimalArray<i32>>) -> Self {
+        Array::NumericArray(NumericArray::Decimal32(a))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<crate::DecimalArray<i64>>> for Array {
+    fn from(a: Arc<crate::DecimalArray<i64>>) -> Self {
+        Array::NumericArray(NumericArray::Decimal64(a))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<crate::DecimalArray<i128>>> for Array {
+    fn from(a: Arc<crate::DecimalArray<i128>>) -> Self {
+        Array::NumericArray(NumericArray::Decimal128(a))
+    }
+}
+
 // --------- TemporalArray Variants ---------
 
 #[cfg(feature = "datetime")]
@@ -1393,6 +1437,18 @@ impl From<Scalar> for Array {
             Datetime64(v) => Array::from_datetime_i64(DatetimeArray::from_slice(&[v], None)),
             #[cfg(feature = "datetime")]
             Interval => Array::from_int32(IntegerArray::from_slice(&[0i32])),
+            #[cfg(feature = "decimal")]
+            Decimal32(v, s) => Array::from_decimal32(
+                crate::DecimalArray::from_slice(&[v], 0, s),
+            ),
+            #[cfg(feature = "decimal")]
+            Decimal64(v, s) => Array::from_decimal64(
+                crate::DecimalArray::from_slice(&[v], 0, s),
+            ),
+            #[cfg(feature = "decimal")]
+            Decimal128(v, s) => Array::from_decimal128(
+                crate::DecimalArray::from_slice(&[v], 0, s),
+            ),
         }
     }
 }

--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -230,6 +230,24 @@ impl Array {
         Array::TemporalArray(TemporalArray::Datetime64(Arc::new(arr)))
     }
 
+    /// Creates an Array enum with a Decimal32 array.
+    #[cfg(feature = "decimal")]
+    pub fn from_decimal32(arr: crate::DecimalArray<i32>) -> Self {
+        Array::NumericArray(NumericArray::Decimal32(Arc::new(arr)))
+    }
+
+    /// Creates an Array enum with a Decimal64 array.
+    #[cfg(feature = "decimal")]
+    pub fn from_decimal64(arr: crate::DecimalArray<i64>) -> Self {
+        Array::NumericArray(NumericArray::Decimal64(Arc::new(arr)))
+    }
+
+    /// Creates an Array enum with a Decimal128 array.
+    #[cfg(feature = "decimal")]
+    pub fn from_decimal128(arr: crate::DecimalArray<i128>) -> Self {
+        Array::NumericArray(NumericArray::Decimal128(Arc::new(arr)))
+    }
+
     /// Creates an Array enum with a Boolean array.
     pub fn from_bool(arr: BooleanArray<()>) -> Self {
         Array::BooleanArray(Arc::new(arr))
@@ -870,6 +888,19 @@ impl Array {
                 NumericArray::Float64(a) => {
                     Arc::make_mut(a).push(value.try_f64().ok_or_else(unsupported)?)
                 }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    Arc::make_mut(a).push(value.try_i32().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    Arc::make_mut(a).push(value.try_i64().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)?;
+                    Arc::make_mut(a).push(v as i128)
+                }
                 NumericArray::Null => return Err(unsupported()),
             },
             Array::BooleanArray(a) => {
@@ -944,6 +975,12 @@ impl Array {
                 NumericArray::UInt64(a) => Arc::make_mut(a).push_null(),
                 NumericArray::Float32(a) => Arc::make_mut(a).push_null(),
                 NumericArray::Float64(a) => Arc::make_mut(a).push_null(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => Arc::make_mut(a).push_null(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => Arc::make_mut(a).push_null(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => Arc::make_mut(a).push_null(),
                 NumericArray::Null => return Err(unsupported()),
             },
             Array::BooleanArray(a) => Arc::make_mut(a).push_null(),
@@ -1036,6 +1073,19 @@ impl Array {
                 }
                 NumericArray::Float64(a) => {
                     Arc::make_mut(a).set(idx, value.try_f64().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    Arc::make_mut(a).set(idx, value.try_i32().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    Arc::make_mut(a).set(idx, value.try_i64().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)?;
+                    Arc::make_mut(a).set(idx, v as i128)
                 }
                 NumericArray::Null => return Err(unsupported()),
             },
@@ -1213,6 +1263,33 @@ impl Array {
                 }
                 NumericArray::Float64(a) => {
                     let v = value.try_f64().ok_or_else(unsupported)?;
+                    let arr = Arc::make_mut(a);
+                    arr.data.as_mut_slice()[range.clone()].fill(v);
+                    if let Some(mask) = &mut arr.null_mask {
+                        mask.set_range(range.start, range.end, true);
+                    }
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    let v = value.try_i32().ok_or_else(unsupported)?;
+                    let arr = Arc::make_mut(a);
+                    arr.data.as_mut_slice()[range.clone()].fill(v);
+                    if let Some(mask) = &mut arr.null_mask {
+                        mask.set_range(range.start, range.end, true);
+                    }
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)?;
+                    let arr = Arc::make_mut(a);
+                    arr.data.as_mut_slice()[range.clone()].fill(v);
+                    if let Some(mask) = &mut arr.null_mask {
+                        mask.set_range(range.start, range.end, true);
+                    }
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)? as i128;
                     let arr = Arc::make_mut(a);
                     arr.data.as_mut_slice()[range.clone()].fill(v);
                     if let Some(mask) = &mut arr.null_mask {
@@ -1687,6 +1764,21 @@ impl Array {
                     cast_slice::<f64, T>(arr.data(), offset, len).expect("cast failed")
                 }
 
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    cast_slice::<i32, T>(arr.data(), offset, len).expect("cast failed")
+                }
+
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    cast_slice::<i64, T>(arr.data(), offset, len).expect("cast failed")
+                }
+
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    cast_slice::<i128, T>(arr.data(), offset, len).expect("cast failed")
+                }
+
                 NumericArray::Null => panic!("Null array has no data payload"),
             },
 
@@ -1861,6 +1953,12 @@ impl Array {
                 NumericArray::UInt64(arr) => NumericArray::UInt64(arr.slice_clone(offset, len)),
                 NumericArray::Float32(arr) => NumericArray::Float32(arr.slice_clone(offset, len)),
                 NumericArray::Float64(arr) => NumericArray::Float64(arr.slice_clone(offset, len)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => NumericArray::Decimal32(arr.slice_clone(offset, len)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => NumericArray::Decimal64(arr.slice_clone(offset, len)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => NumericArray::Decimal128(arr.slice_clone(offset, len)),
                 NumericArray::Null => NumericArray::Null,
             }),
             Array::TextArray(inner) => Self::TextArray(match inner {
@@ -1921,6 +2019,12 @@ impl Array {
                 NumericArray::UInt64(_) => ArrowType::UInt64,
                 NumericArray::Float32(_) => ArrowType::Float32,
                 NumericArray::Float64(_) => ArrowType::Float64,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.arrow_type(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.arrow_type(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.arrow_type(),
                 NumericArray::Null => ArrowType::Null,
             },
             Array::TextArray(inner) => match inner {
@@ -2080,6 +2184,12 @@ impl Array {
                 NumericArray::UInt64(_) => true,
                 NumericArray::Float32(_) => false,
                 NumericArray::Float64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => false,
                 NumericArray::Null => false,
             },
             Array::TextArray(_) => false,
@@ -2109,6 +2219,12 @@ impl Array {
                 NumericArray::UInt16(_) => false,
                 NumericArray::UInt32(_) => false,
                 NumericArray::UInt64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => false,
                 NumericArray::Null => false,
             },
             Array::TextArray(_) => false,
@@ -2138,6 +2254,12 @@ impl Array {
                 NumericArray::UInt64(_) => true,
                 NumericArray::Float32(_) => true,
                 NumericArray::Float64(_) => true,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => true,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => true,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => true,
                 NumericArray::Null => false,
             },
             Array::TextArray(_) => false,
@@ -2183,6 +2305,12 @@ impl Array {
                 NumericArray::UInt64(arr) => arr.null_mask.as_ref(),
                 NumericArray::Float32(arr) => arr.null_mask.as_ref(),
                 NumericArray::Float64(arr) => arr.null_mask.as_ref(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => arr.null_mask.as_ref(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => arr.null_mask.as_ref(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => arr.null_mask.as_ref(),
                 NumericArray::Null => None,
             },
             Array::BooleanArray(arr) => arr.null_mask.as_ref(),
@@ -2380,6 +2508,12 @@ impl Array {
                 NumericArray::UInt64(a) => Some(Scalar::UInt64(a.data[idx])),
                 NumericArray::Float32(a) => Some(Scalar::Float32(a.data[idx])),
                 NumericArray::Float64(a) => Some(Scalar::Float64(a.data[idx])),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => Some(Scalar::Decimal32(a.data[idx], a.scale)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => Some(Scalar::Decimal64(a.data[idx], a.scale)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => Some(Scalar::Decimal128(a.data[idx], a.scale)),
                 NumericArray::Null => Some(Scalar::Null),
             },
             Array::TextArray(text) => match text {
@@ -2526,8 +2660,25 @@ impl Array {
                 Array::from_string32(arr)
             }
             #[cfg(feature = "decimal")]
-            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
-                panic!("null_array: DecimalArray is not yet available")
+            ArrowType::Decimal32(p, s) => {
+                let arr = crate::DecimalArray::<i32>::new(
+                    Vec64::from_slice(&vec![0i32; n_rows]), Some(mask), *p, *s,
+                );
+                Array::NumericArray(NumericArray::Decimal32(Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => {
+                let arr = crate::DecimalArray::<i64>::new(
+                    Vec64::from_slice(&vec![0i64; n_rows]), Some(mask), *p, *s,
+                );
+                Array::NumericArray(NumericArray::Decimal64(Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => {
+                let arr = crate::DecimalArray::<i128>::new(
+                    Vec64::from_slice(&vec![0i128; n_rows]), Some(mask), *p, *s,
+                );
+                Array::NumericArray(NumericArray::Decimal128(Arc::new(arr)))
             }
         }
     }
@@ -2613,8 +2764,22 @@ impl Array {
                 Arc::new(crate::DatetimeArray::<i64>::default()),
             )),
             #[cfg(feature = "decimal")]
-            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
-                panic!("from_arrow_dtype: DecimalArray is not yet available")
+            ArrowType::Decimal32(p, s) => {
+                Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                    crate::DecimalArray::<i32>::new(Vec64::new(), None, *p, *s),
+                )))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => {
+                Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                    crate::DecimalArray::<i64>::new(Vec64::new(), None, *p, *s),
+                )))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => {
+                Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                    crate::DecimalArray::<i128>::new(Vec64::new(), None, *p, *s),
+                )))
             }
         }
     }
@@ -2947,6 +3112,75 @@ impl Array {
                     if has_nulls { Some(mask) } else { None },
                 ))
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, scale) => {
+                let scale = *scale;
+                let mut data = Vec64::<i32>::with_capacity(scalars.len());
+                let mut mask = Bitmask::new_set_all(scalars.len(), true);
+                for (i, s) in scalars.iter().enumerate() {
+                    match s {
+                        Scalar::Decimal32(v, _) => data.push(*v),
+                        Scalar::Null => {
+                            data.push(0);
+                            mask.set(i, false);
+                        }
+                        _ => data.push(s.i32()),
+                    }
+                }
+                let has_nulls = mask.count_zeros() > 0;
+                Array::from_decimal32(crate::DecimalArray::new(
+                    data,
+                    if has_nulls { Some(mask) } else { None },
+                    0,
+                    scale,
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(_, scale) => {
+                let scale = *scale;
+                let mut data = Vec64::<i64>::with_capacity(scalars.len());
+                let mut mask = Bitmask::new_set_all(scalars.len(), true);
+                for (i, s) in scalars.iter().enumerate() {
+                    match s {
+                        Scalar::Decimal64(v, _) => data.push(*v),
+                        Scalar::Null => {
+                            data.push(0);
+                            mask.set(i, false);
+                        }
+                        _ => data.push(s.i64()),
+                    }
+                }
+                let has_nulls = mask.count_zeros() > 0;
+                Array::from_decimal64(crate::DecimalArray::new(
+                    data,
+                    if has_nulls { Some(mask) } else { None },
+                    0,
+                    scale,
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(_, scale) => {
+                let scale = *scale;
+                let mut data = Vec64::<i128>::with_capacity(scalars.len());
+                let mut mask = Bitmask::new_set_all(scalars.len(), true);
+                for (i, s) in scalars.iter().enumerate() {
+                    match s {
+                        Scalar::Decimal128(v, _) => data.push(*v),
+                        Scalar::Null => {
+                            data.push(0);
+                            mask.set(i, false);
+                        }
+                        _ => data.push(s.i64() as i128),
+                    }
+                }
+                let has_nulls = mask.count_zeros() > 0;
+                Array::from_decimal128(crate::DecimalArray::new(
+                    data,
+                    if has_nulls { Some(mask) } else { None },
+                    0,
+                    scale,
+                ))
+            }
             Scalar::Null => Array::Null,
         }
     }
@@ -2985,6 +3219,12 @@ impl Array {
                 NumericArray::UInt16(a) => a.data[i].cmp(&a.data[j]),
                 NumericArray::Float32(a) => a.data[i].total_cmp(&a.data[j]),
                 NumericArray::Float64(a) => a.data[i].total_cmp(&a.data[j]),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.data[i].cmp(&a.data[j]),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.data[i].cmp(&a.data[j]),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.data[i].cmp(&a.data[j]),
                 NumericArray::Null => Ordering::Equal,
             },
             Array::BooleanArray(b) => b.data.get(i).cmp(&b.data.get(j)),
@@ -3075,6 +3315,18 @@ impl Array {
                 (NumericArray::Float64(x), NumericArray::Float64(y)) => {
                     let (a, b) = (x.data[idx], y.data[other_idx]);
                     if a.is_nan() { b.is_nan() } else { a == b }
+                }
+                #[cfg(feature = "decimal")]
+                (NumericArray::Decimal32(x), NumericArray::Decimal32(y)) => {
+                    x.data[idx] == y.data[other_idx]
+                }
+                #[cfg(feature = "decimal")]
+                (NumericArray::Decimal64(x), NumericArray::Decimal64(y)) => {
+                    x.data[idx] == y.data[other_idx]
+                }
+                #[cfg(feature = "decimal")]
+                (NumericArray::Decimal128(x), NumericArray::Decimal128(y)) => {
+                    x.data[idx] == y.data[other_idx]
                 }
                 (NumericArray::Null, NumericArray::Null) => true,
                 _ => false,
@@ -3173,6 +3425,12 @@ impl Array {
                         if v.is_nan() { 0x7ff8_0000_0000_0000u64 } else { (v + 0.0).to_bits() };
                     bits.hash(state);
                 }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.data[idx].hash(state),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.data[idx].hash(state),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.data[idx].hash(state),
                 NumericArray::Null => 0xDEAD_BEEF_u64.hash(state),
             },
             Array::BooleanArray(b) => b.data.get(idx).hash(state),
@@ -3240,6 +3498,18 @@ impl Array {
                         Arc::make_mut(arr).set_null_mask(Some(mask));
                     }
                     NumericArray::UInt64(arr) => {
+                        Arc::make_mut(arr).set_null_mask(Some(mask));
+                    }
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal32(arr) => {
+                        Arc::make_mut(arr).set_null_mask(Some(mask));
+                    }
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal64(arr) => {
+                        Arc::make_mut(arr).set_null_mask(Some(mask));
+                    }
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal128(arr) => {
                         Arc::make_mut(arr).set_null_mask(Some(mask));
                     }
                     NumericArray::Null => {} // No-op for null arrays
@@ -3352,6 +3622,24 @@ impl Array {
                     a.len(),
                     std::mem::size_of::<f64>(),
                 ),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => (
+                    a.data.as_ptr() as *const u8,
+                    a.len(),
+                    std::mem::size_of::<i32>(),
+                ),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => (
+                    a.data.as_ptr() as *const u8,
+                    a.len(),
+                    std::mem::size_of::<i64>(),
+                ),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => (
+                    a.data.as_ptr() as *const u8,
+                    a.len(),
+                    std::mem::size_of::<i128>(),
+                ),
                 NumericArray::Null => (std::ptr::null(), 0, 0),
             },
             Array::BooleanArray(a) => (a.data.as_ptr() as *const u8, a.data.len(), 1),
@@ -3426,6 +3714,18 @@ impl Array {
                     a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
                 }
                 NumericArray::Float64(a) => {
+                    a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
                     a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
                 }
                 NumericArray::Null => None,
@@ -3507,6 +3807,12 @@ impl Array {
                 NumericArray::UInt64(a) => a.null_count(),
                 NumericArray::Float32(a) => a.null_count(),
                 NumericArray::Float64(a) => a.null_count(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.null_count(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.null_count(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.null_count(),
                 NumericArray::Null => 0,
             },
             Array::BooleanArray(a) => a.null_count(),
@@ -6860,5 +7166,170 @@ mod arr_macro_extensions_tests {
         assert_eq!(arr.get::<FloatArray<f64>>(0), Some(1.0));
         assert_eq!(arr.get::<FloatArray<f64>>(1), None);
         assert_eq!(arr.get::<FloatArray<f64>>(3), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Decimal Array integration
+    // -----------------------------------------------------------------------
+
+    #[cfg(feature = "decimal")]
+    mod decimal_integration {
+        use super::*;
+        use crate::DecimalArray;
+        use std::sync::Arc;
+
+        #[test]
+        fn from_decimal_constructors() {
+            let d32 = DecimalArray::<i32>::from_slice(&[12345], 9, 2);
+            let arr = Array::from_decimal32(d32);
+            assert_eq!(arr.len(), 1);
+            assert_eq!(arr.arrow_type(), crate::ffi::arrow_dtype::ArrowType::Decimal32(9, 2));
+
+            let d64 = DecimalArray::<i64>::from_slice(&[99999], 18, 4);
+            let arr = Array::from_decimal64(d64);
+            assert_eq!(arr.len(), 1);
+
+            let d128 = DecimalArray::<i128>::from_slice(&[1000000], 38, 10);
+            let arr = Array::from_decimal128(d128);
+            assert_eq!(arr.len(), 1);
+        }
+
+        #[test]
+        fn from_impl_decimal_to_array() {
+            let d = DecimalArray::<i64>::from_slice(&[42], 18, 4);
+            let arr: Array = d.into();
+            assert_eq!(arr.len(), 1);
+            assert!(arr.is_numerical_array());
+        }
+
+        #[test]
+        fn from_arc_decimal_to_array() {
+            let d = Arc::new(DecimalArray::<i128>::from_slice(&[999], 38, 10));
+            let arr: Array = d.into();
+            assert_eq!(arr.len(), 1);
+        }
+
+        #[test]
+        fn decimal_through_num_accessor() {
+            let d = DecimalArray::<i64>::from_slice(&[12345, 67890], 18, 2);
+            let arr = Array::from_decimal64(d);
+            let num = arr.num();
+            let inner = num.dec64();
+            assert_eq!(inner.len(), 2);
+            assert_eq!(inner.get(0), Some(12345i64));
+        }
+
+        #[test]
+        fn decimal_try_dec128_widening_through_array() {
+            let d = DecimalArray::<i32>::from_slice(&[42], 9, 3);
+            let arr = Array::from_decimal32(d);
+            let num = arr.num();
+            let wide = num.try_dec128().unwrap();
+            assert_eq!(wide.get(0), Some(42i128));
+            assert_eq!(wide.scale, 3);
+        }
+
+        #[test]
+        fn decimal_null_mask_through_array() {
+            let mut d = DecimalArray::<i32>::with_capacity(2, true, 9, 2);
+            d.push(10);
+            d.push_null();
+            let arr = Array::from_decimal32(d);
+            assert!(arr.null_mask().is_some());
+            assert!(arr.has_nulls());
+        }
+
+        #[test]
+        fn decimal_len_and_delete_range() {
+            let d = DecimalArray::<i64>::from_slice(&[1, 2, 3, 4], 18, 0);
+            let mut arr = Array::from_decimal64(d);
+            assert_eq!(arr.len(), 4);
+            arr.delete_range(1, 3);
+            assert_eq!(arr.len(), 2);
+        }
+
+        #[test]
+        fn decimal_from_arrow_dtype() {
+            use crate::ffi::arrow_dtype::ArrowType;
+            let arr = Array::from_arrow_dtype(&ArrowType::Decimal64(18, 4));
+            assert_eq!(arr.len(), 0);
+            assert_eq!(arr.arrow_type(), ArrowType::Decimal64(18, 4));
+        }
+
+        #[test]
+        fn decimal_null_array() {
+            use crate::ffi::arrow_dtype::ArrowType;
+            let arr = Array::null_array(&ArrowType::Decimal128(38, 10), 5);
+            assert_eq!(arr.len(), 5);
+            assert!(arr.null_mask().is_some());
+        }
+
+        #[test]
+        fn field_array_round_trip() {
+            let d = DecimalArray::<i64>::from_slice(&[12345, 67890], 18, 2);
+            let arr = Array::from_decimal64(d);
+            let fa = arr.fa("amount");
+            assert_eq!(fa.field.name, "amount");
+            assert_eq!(fa.len(), 2);
+            assert_eq!(
+                fa.arrow_type(),
+                crate::ffi::arrow_dtype::ArrowType::Decimal64(18, 2)
+            );
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn get_scalar_decimal() {
+            let d = DecimalArray::<i32>::from_slice(&[12345], 9, 2);
+            let arr = Array::from_decimal32(d);
+            let s = arr.get_scalar(0).unwrap();
+            match s {
+                crate::Scalar::Decimal32(v, scale) => {
+                    assert_eq!(v, 12345);
+                    assert_eq!(scale, 2);
+                }
+                _ => panic!("expected Scalar::Decimal32"),
+            }
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn scalar_decimal_display() {
+            let s = crate::Scalar::Decimal64(12345, 2);
+            assert_eq!(format!("{}", s), "123.45");
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn scalar_decimal_zero_scale() {
+            let s = crate::Scalar::Decimal128(42, 0);
+            assert_eq!(format!("{}", s), "42");
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn scalar_decimal_negative_scale() {
+            let s = crate::Scalar::Decimal32(5, -2);
+            assert_eq!(format!("{}", s), "500");
+        }
+
+        #[cfg(feature = "hash")]
+        #[test]
+        fn decimal_value_eq_and_hash_agree() {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::Hasher;
+
+            let a = Array::from_decimal64(DecimalArray::<i64>::from_slice(&[100, 200], 18, 2));
+            let b = Array::from_decimal64(DecimalArray::<i64>::from_slice(&[100, 300], 18, 2));
+
+            assert!(a.value_eq(0, &b, 0));
+            assert!(!a.value_eq(1, &b, 1));
+
+            let mut h1 = DefaultHasher::new();
+            let mut h2 = DefaultHasher::new();
+            a.hash_element_at(0, &mut h1);
+            b.hash_element_at(0, &mut h2);
+            assert_eq!(h1.finish(), h2.finish());
+        }
     }
 }

--- a/src/enums/collections/numeric_array.rs
+++ b/src/enums/collections/numeric_array.rs
@@ -34,6 +34,8 @@ use crate::{Bitmask, FloatArray, IntegerArray, MaskedArray, Vec64};
 use crate::{BooleanArray, StringArray};
 #[cfg(feature = "decimal")]
 use crate::DecimalArray;
+#[cfg(feature = "decimal")]
+use crate::structs::variants::decimal::format_decimal_value;
 use crate::{
     enums::{error::MinarrowError, shape_dim::ShapeDim},
     traits::{concatenate::Concatenate, shape::Shape},
@@ -103,6 +105,87 @@ pub enum NumericArray {
     Decimal128(Arc<DecimalArray<i128>>),
     #[default]
     Null, // Default Marker for mem::take
+}
+
+// Decimal-to-integer conversion: divides raw value by 10^scale (truncating),
+// then converts to the target integer type via TryFrom.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_integer {
+    ($arc:expr, $target:ty) => {{
+        use num_traits::ToPrimitive;
+        let scale_divisor = 10i128.pow($arc.scale.max(0) as u32);
+        let data: Result<Vec64<$target>, _> = $arc
+            .data
+            .as_slice()
+            .iter()
+            .map(|v| {
+                let scaled = v.to_i128().unwrap() / scale_divisor;
+                <$target as TryFrom<i128>>::try_from(scaled).map_err(|_| {
+                    MinarrowError::TypeError {
+                        from: "DecimalArray",
+                        to: stringify!(IntegerArray<$target>),
+                        message: Some(format!(
+                            "overflow converting {scaled} to {}",
+                            stringify!($target)
+                        )),
+                    }
+                })
+            })
+            .collect();
+        Ok(Arc::new(IntegerArray::new(data?, $arc.null_mask.clone())))
+    }};
+}
+
+// Decimal-to-float conversion: raw as f_type / 10^scale.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_float {
+    ($arc:expr, f32) => {{
+        use num_traits::ToPrimitive;
+        let scale_factor = 10f32.powi($arc.scale as i32);
+        let data: Vec64<f32> = $arc
+            .data
+            .as_slice()
+            .iter()
+            .map(|v| v.to_f64().unwrap() as f32 / scale_factor)
+            .collect();
+        Ok(Arc::new(FloatArray::new(data, $arc.null_mask.clone())))
+    }};
+    ($arc:expr, f64) => {{
+        use num_traits::ToPrimitive;
+        let scale_factor = 10f64.powi($arc.scale as i32);
+        let data: Vec64<f64> = $arc
+            .data
+            .as_slice()
+            .iter()
+            .map(|v| v.to_f64().unwrap() / scale_factor)
+            .collect();
+        Ok(Arc::new(FloatArray::new(data, $arc.null_mask.clone())))
+    }};
+}
+
+// Decimal-to-bool conversion: non-zero raw values are true.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_bool {
+    ($arc:expr) => {{
+        let mut data = Bitmask::with_capacity($arc.data.len());
+        for (i, v) in $arc.data.as_slice().iter().enumerate() {
+            data.set(i, !num_traits::Zero::is_zero(v));
+        }
+        Ok(Arc::new(BooleanArray::new(data, $arc.null_mask.clone())))
+    }};
+}
+
+// Decimal-to-string conversion: scale-aware formatting per element.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_str {
+    ($arc:expr) => {{
+        let mut arr = StringArray::<u32>::with_capacity($arc.len(), $arc.len() * 8, false);
+        for v in $arc.data.as_slice() {
+            arr.push(format_decimal_value(*v, $arc.scale));
+        }
+        arr.null_mask = $arc.null_mask.clone();
+        Ok(Arc::new(arr))
+    }};
 }
 
 impl NumericArray {
@@ -579,13 +662,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "IntegerArray<i32>",
-                    message: Some("decimal-to-integer conversion requires explicit .to_int32_array()".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, i32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, i32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, i32),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -619,13 +700,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "IntegerArray<i64>",
-                    message: Some("decimal-to-integer conversion requires explicit .to_int64_array()".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, i64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, i64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, i64),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -659,13 +738,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "IntegerArray<u32>",
-                    message: Some("decimal-to-integer conversion requires explicit .to_uint32_array()".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, u32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, u32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, u32),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -699,13 +776,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<u64>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<u64>::try_from(&**a)?)),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "IntegerArray<u64>",
-                    message: Some("decimal-to-integer conversion requires explicit .to_uint64_array()".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, u64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, u64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, u64),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -739,13 +814,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(a.clone()),
             NumericArray::Float64(a) => Ok(Arc::new(FloatArray::<f32>::from(&**a))),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "FloatArray<f32>",
-                    message: Some("decimal-to-float conversion requires explicit .to_float32_array()".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_float!(a, f32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_float!(a, f32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_float!(a, f32),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -776,6 +849,36 @@ impl NumericArray {
                 }
             };
         }
+        #[cfg(feature = "decimal")]
+        macro_rules! decimal_cow_f64 {
+            ($arc:expr) => {{
+                use num_traits::ToPrimitive;
+                let scale_factor = 10f64.powi($arc.scale as i32);
+                match Arc::try_unwrap($arc) {
+                    Ok(owned) => {
+                        let data: Vec64<f64> = owned
+                            .data
+                            .as_slice()
+                            .iter()
+                            .map(|v| v.to_f64().unwrap() / scale_factor)
+                            .collect();
+                        NumericArray::Float64(Arc::new(FloatArray::new(data, owned.null_mask)))
+                    }
+                    Err(shared) => {
+                        let data: Vec64<f64> = shared
+                            .data
+                            .as_slice()
+                            .iter()
+                            .map(|v| v.to_f64().unwrap() / scale_factor)
+                            .collect();
+                        NumericArray::Float64(Arc::new(FloatArray::new(
+                            data,
+                            shared.null_mask.clone(),
+                        )))
+                    }
+                }
+            }};
+        }
 
         match self {
             NumericArray::Float64(_) => self,
@@ -793,11 +896,11 @@ impl NumericArray {
             #[cfg(feature = "extended_numeric_types")]
             NumericArray::UInt16(arc) => cast_arc!(arc),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(arc) => cast_arc!(arc),
+            NumericArray::Decimal32(arc) => decimal_cow_f64!(arc),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal64(arc) => cast_arc!(arc),
+            NumericArray::Decimal64(arc) => decimal_cow_f64!(arc),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal128(arc) => cast_arc!(arc),
+            NumericArray::Decimal128(arc) => decimal_cow_f64!(arc),
             NumericArray::Null => {
                 NumericArray::Float64(Arc::new(FloatArray::new(Vec64::new(), None)))
             }
@@ -833,13 +936,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(Arc::new(FloatArray::<f64>::from(&**a))),
             NumericArray::Float64(a) => Ok(a.clone()),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "FloatArray<f64>",
-                    message: Some("decimal-to-float conversion requires explicit .to_float64_array()".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_float!(a, f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_float!(a, f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_float!(a, f64),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -873,13 +974,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
             NumericArray::Float64(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "BooleanArray<u8>",
-                    message: Some("decimal-to-boolean conversion is not supported".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_bool!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_bool!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_bool!(a),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -913,13 +1012,11 @@ impl NumericArray {
             NumericArray::Float32(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
             NumericArray::Float64(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
-                Err(MinarrowError::TypeError {
-                    from: "DecimalArray",
-                    to: "StringArray<u32>",
-                    message: Some("decimal-to-string conversion is not yet supported".to_string()),
-                })
-            }
+            NumericArray::Decimal32(a) => decimal_to_str!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_str!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_str!(a),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }

--- a/src/enums/collections/numeric_array.rs
+++ b/src/enums/collections/numeric_array.rs
@@ -32,6 +32,8 @@ use std::{
 
 use crate::{Bitmask, FloatArray, IntegerArray, MaskedArray, Vec64};
 use crate::{BooleanArray, StringArray};
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 use crate::{
     enums::{error::MinarrowError, shape_dim::ShapeDim},
     traits::{concatenate::Concatenate, shape::Shape},
@@ -93,6 +95,12 @@ pub enum NumericArray {
     UInt64(Arc<IntegerArray<u64>>),
     Float32(Arc<FloatArray<f32>>),
     Float64(Arc<FloatArray<f64>>),
+    #[cfg(feature = "decimal")]
+    Decimal32(Arc<DecimalArray<i32>>),
+    #[cfg(feature = "decimal")]
+    Decimal64(Arc<DecimalArray<i64>>),
+    #[cfg(feature = "decimal")]
+    Decimal128(Arc<DecimalArray<i128>>),
     #[default]
     Null, // Default Marker for mem::take
 }
@@ -116,6 +124,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.len(),
             NumericArray::Float32(arr) => arr.len(),
             NumericArray::Float64(arr) => arr.len(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.len(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.len(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.len(),
             NumericArray::Null => 0,
         }
     }
@@ -141,6 +155,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.delete_range(start, end),
             NumericArray::Float32(arr) => arr.delete_range(start, end),
             NumericArray::Float64(arr) => arr.delete_range(start, end),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.delete_range(start, end),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.delete_range(start, end),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.delete_range(start, end),
             NumericArray::Null => {
                 assert!(
                     start == 0 && end == 0,
@@ -168,6 +188,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.null_mask.as_ref(),
             NumericArray::Float32(arr) => arr.null_mask.as_ref(),
             NumericArray::Float64(arr) => arr.null_mask.as_ref(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.null_mask.as_ref(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.null_mask.as_ref(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.null_mask.as_ref(),
             NumericArray::Null => None,
         }
     }
@@ -193,6 +219,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.has_nulls(),
             NumericArray::Float32(arr) => arr.has_nulls(),
             NumericArray::Float64(arr) => arr.has_nulls(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.has_nulls(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.has_nulls(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.has_nulls(),
             NumericArray::Null => false,
         }
     }
@@ -228,6 +260,19 @@ impl NumericArray {
                 Arc::make_mut(a).append_array(b)
             }
             (NumericArray::Float64(a), NumericArray::Float64(b)) => {
+                Arc::make_mut(a).append_array(b)
+            }
+
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                Arc::make_mut(a).append_array(b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                Arc::make_mut(a).append_array(b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
                 Arc::make_mut(a).append_array(b)
             }
 
@@ -275,6 +320,18 @@ impl NumericArray {
                 Arc::make_mut(a).append_range(b, offset, len)
             }
             (NumericArray::Float64(a), NumericArray::Float64(b)) => {
+                Arc::make_mut(a).append_range(b, offset, len)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                Arc::make_mut(a).append_range(b, offset, len)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                Arc::make_mut(a).append_range(b, offset, len)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
                 Arc::make_mut(a).append_range(b, offset, len)
             }
             (NumericArray::Null, NumericArray::Null) => Ok(()),
@@ -330,6 +387,19 @@ impl NumericArray {
                 Arc::make_mut(a).insert_rows(index, b)
             }
             (NumericArray::Float64(a), NumericArray::Float64(b)) => {
+                Arc::make_mut(a).insert_rows(index, b)
+            }
+
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                Arc::make_mut(a).insert_rows(index, b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                Arc::make_mut(a).insert_rows(index, b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
                 Arc::make_mut(a).insert_rows(index, b)
             }
 
@@ -444,6 +514,36 @@ impl NumericArray {
                     NumericArray::Float64(Arc::new(right)),
                 ))
             }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => {
+                let (left, right) = Arc::try_unwrap(a)
+                    .unwrap_or_else(|arc| (*arc).clone())
+                    .split(index)?;
+                Ok((
+                    NumericArray::Decimal32(Arc::new(left)),
+                    NumericArray::Decimal32(Arc::new(right)),
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => {
+                let (left, right) = Arc::try_unwrap(a)
+                    .unwrap_or_else(|arc| (*arc).clone())
+                    .split(index)?;
+                Ok((
+                    NumericArray::Decimal64(Arc::new(left)),
+                    NumericArray::Decimal64(Arc::new(right)),
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => {
+                let (left, right) = Arc::try_unwrap(a)
+                    .unwrap_or_else(|arc| (*arc).clone())
+                    .split(index)?;
+                Ok((
+                    NumericArray::Decimal128(Arc::new(left)),
+                    NumericArray::Decimal128(Arc::new(right)),
+                ))
+            }
             NumericArray::Null => Err(MinarrowError::IndexError(
                 "Cannot split Null array".to_string(),
             )),
@@ -478,6 +578,14 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "IntegerArray<i32>",
+                    message: Some("decimal-to-integer conversion requires explicit .to_int32_array()".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -510,6 +618,14 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "IntegerArray<i64>",
+                    message: Some("decimal-to-integer conversion requires explicit .to_int64_array()".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -542,6 +658,14 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "IntegerArray<u32>",
+                    message: Some("decimal-to-integer conversion requires explicit .to_uint32_array()".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -574,6 +698,14 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(a.clone()),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<u64>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<u64>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "IntegerArray<u64>",
+                    message: Some("decimal-to-integer conversion requires explicit .to_uint64_array()".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -606,6 +738,14 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(FloatArray::<f32>::from(&**a))),
             NumericArray::Float32(a) => Ok(a.clone()),
             NumericArray::Float64(a) => Ok(Arc::new(FloatArray::<f32>::from(&**a))),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "FloatArray<f32>",
+                    message: Some("decimal-to-float conversion requires explicit .to_float32_array()".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -652,6 +792,12 @@ impl NumericArray {
             NumericArray::UInt8(arc) => cast_arc!(arc),
             #[cfg(feature = "extended_numeric_types")]
             NumericArray::UInt16(arc) => cast_arc!(arc),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arc) => cast_arc!(arc),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arc) => cast_arc!(arc),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arc) => cast_arc!(arc),
             NumericArray::Null => {
                 NumericArray::Float64(Arc::new(FloatArray::new(Vec64::new(), None)))
             }
@@ -686,6 +832,14 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(FloatArray::<f64>::from(&**a))),
             NumericArray::Float32(a) => Ok(Arc::new(FloatArray::<f64>::from(&**a))),
             NumericArray::Float64(a) => Ok(a.clone()),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "FloatArray<f64>",
+                    message: Some("decimal-to-float conversion requires explicit .to_float64_array()".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -718,6 +872,14 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
             NumericArray::Float32(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
             NumericArray::Float64(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "BooleanArray<u8>",
+                    message: Some("decimal-to-boolean conversion is not supported".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -750,7 +912,97 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
             NumericArray::Float32(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
             NumericArray::Float64(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) | NumericArray::Decimal64(_) | NumericArray::Decimal128(_) => {
+                Err(MinarrowError::TypeError {
+                    from: "DecimalArray",
+                    to: "StringArray<u32>",
+                    message: Some("decimal-to-string conversion is not yet supported".to_string()),
+                })
+            }
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
+        }
+    }
+
+    /// Returns the inner array as `Arc<DecimalArray<i32>>`.
+    ///
+    /// - Panics on failure. Consider the try variant for a safe alternative.
+    #[cfg(feature = "decimal")]
+    #[inline]
+    pub fn dec32(&self) -> Arc<DecimalArray<i32>> {
+        self.try_dec32().unwrap()
+    }
+
+    /// Retrieve a DecimalArray<i32> from this NumericArray.
+    ///
+    /// The matching variant returns as a shared handle without copying data.
+    /// Decimal64 and Decimal128 variants cannot be narrowed to Decimal32.
+    #[cfg(feature = "decimal")]
+    pub fn try_dec32(&self) -> Result<Arc<DecimalArray<i32>>, MinarrowError> {
+        match self {
+            NumericArray::Decimal32(a) => Ok(a.clone()),
+            _ => Err(MinarrowError::TypeError {
+                from: "NumericArray",
+                to: "DecimalArray<i32>",
+                message: Some("variant is not Decimal32".to_string()),
+            }),
+        }
+    }
+
+    /// Returns the inner array as `Arc<DecimalArray<i64>>`.
+    ///
+    /// - Panics on failure. Consider the try variant for a safe alternative.
+    #[cfg(feature = "decimal")]
+    #[inline]
+    pub fn dec64(&self) -> Arc<DecimalArray<i64>> {
+        self.try_dec64().unwrap()
+    }
+
+    /// Retrieve a DecimalArray<i64> from this NumericArray.
+    ///
+    /// The matching variant returns as a shared handle without copying data.
+    /// A Decimal32 variant is widened to DecimalArray<i64> losslessly.
+    /// Decimal128 cannot be narrowed to Decimal64.
+    #[cfg(feature = "decimal")]
+    pub fn try_dec64(&self) -> Result<Arc<DecimalArray<i64>>, MinarrowError> {
+        match self {
+            NumericArray::Decimal64(a) => Ok(a.clone()),
+            NumericArray::Decimal32(a) => Ok(Arc::new(DecimalArray::<i64>::from((**a).clone()))),
+            _ => Err(MinarrowError::TypeError {
+                from: "NumericArray",
+                to: "DecimalArray<i64>",
+                message: Some("variant is not Decimal32 or Decimal64".to_string()),
+            }),
+        }
+    }
+
+    /// Returns the inner array as `Arc<DecimalArray<i128>>`.
+    ///
+    /// - Panics on failure. Consider the try variant for a safe alternative.
+    #[cfg(feature = "decimal")]
+    #[inline]
+    pub fn dec128(&self) -> Arc<DecimalArray<i128>> {
+        self.try_dec128().unwrap()
+    }
+
+    /// Retrieve a DecimalArray<i128> from this NumericArray.
+    ///
+    /// The matching variant returns as a shared handle without copying data.
+    /// Decimal32 and Decimal64 variants are widened to DecimalArray<i128> losslessly.
+    #[cfg(feature = "decimal")]
+    pub fn try_dec128(&self) -> Result<Arc<DecimalArray<i128>>, MinarrowError> {
+        match self {
+            NumericArray::Decimal128(a) => Ok(a.clone()),
+            NumericArray::Decimal64(a) => Ok(Arc::new(DecimalArray::<i128>::from((**a).clone()))),
+            NumericArray::Decimal32(a) => {
+                let intermediate = DecimalArray::<i64>::from((**a).clone());
+                Ok(Arc::new(DecimalArray::<i128>::from(intermediate)))
+            }
+            _ => Err(MinarrowError::TypeError {
+                from: "NumericArray",
+                to: "DecimalArray<i128>",
+                message: Some("variant is not a decimal type".to_string()),
+            }),
         }
     }
 }
@@ -775,6 +1027,18 @@ impl Display for NumericArray {
             }
             NumericArray::Float64(arr) => {
                 write_numeric_array_with_header(f, "Float64", arr.as_ref())
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => {
+                write_numeric_array_with_header(f, "Decimal32", arr.as_ref())
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => {
+                write_numeric_array_with_header(f, "Decimal64", arr.as_ref())
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => {
+                write_numeric_array_with_header(f, "Decimal128", arr.as_ref())
             }
             NumericArray::Null => writeln!(f, "NullNumericArray [0 values]"),
         }
@@ -861,6 +1125,24 @@ impl Concatenate for NumericArray {
                 let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
                 Ok(NumericArray::Float64(Arc::new(a.concat(b)?)))
             }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                let a = Arc::try_unwrap(a).unwrap_or_else(|arc| (*arc).clone());
+                let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
+                Ok(NumericArray::Decimal32(Arc::new(a.concat(b)?)))
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                let a = Arc::try_unwrap(a).unwrap_or_else(|arc| (*arc).clone());
+                let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
+                Ok(NumericArray::Decimal64(Arc::new(a.concat(b)?)))
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
+                let a = Arc::try_unwrap(a).unwrap_or_else(|arc| (*arc).clone());
+                let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
+                Ok(NumericArray::Decimal128(Arc::new(a.concat(b)?)))
+            }
             (NumericArray::Null, NumericArray::Null) => Ok(NumericArray::Null),
             (lhs, rhs) => Err(MinarrowError::IncompatibleTypeError {
                 from: "NumericArray",
@@ -892,6 +1174,223 @@ fn variant_name(arr: &NumericArray) -> &'static str {
         NumericArray::UInt64(_) => "UInt64",
         NumericArray::Float32(_) => "Float32",
         NumericArray::Float64(_) => "Float64",
+        #[cfg(feature = "decimal")]
+        NumericArray::Decimal32(_) => "Decimal32",
+        #[cfg(feature = "decimal")]
+        NumericArray::Decimal64(_) => "Decimal64",
+        #[cfg(feature = "decimal")]
+        NumericArray::Decimal128(_) => "Decimal128",
         NumericArray::Null => "Null",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// From impls - DecimalArray -> NumericArray
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "decimal")]
+impl From<DecimalArray<i32>> for NumericArray {
+    fn from(arr: DecimalArray<i32>) -> Self {
+        NumericArray::Decimal32(Arc::new(arr))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<DecimalArray<i64>> for NumericArray {
+    fn from(arr: DecimalArray<i64>) -> Self {
+        NumericArray::Decimal64(Arc::new(arr))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<DecimalArray<i128>> for NumericArray {
+    fn from(arr: DecimalArray<i128>) -> Self {
+        NumericArray::Decimal128(Arc::new(arr))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<DecimalArray<i32>>> for NumericArray {
+    fn from(arr: Arc<DecimalArray<i32>>) -> Self {
+        NumericArray::Decimal32(arr)
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<DecimalArray<i64>>> for NumericArray {
+    fn from(arr: Arc<DecimalArray<i64>>) -> Self {
+        NumericArray::Decimal64(arr)
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<DecimalArray<i128>>> for NumericArray {
+    fn from(arr: Arc<DecimalArray<i128>>) -> Self {
+        NumericArray::Decimal128(arr)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "decimal")]
+mod decimal_tests {
+    use super::*;
+    use crate::{DecimalArray, MaskedArray};
+
+    #[test]
+    fn from_decimal_array_into_numeric() {
+        let dec = DecimalArray::<i32>::from_slice(&[12345, 67890], 9, 2);
+        let num = NumericArray::from(dec);
+        assert_eq!(num.len(), 2);
+        match &num {
+            NumericArray::Decimal32(a) => {
+                assert_eq!(a.get(0), Some(12345));
+                assert_eq!(a.precision, 9);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal32"),
+        }
+    }
+
+    #[test]
+    fn from_arc_decimal_array_into_numeric() {
+        let dec = Arc::new(DecimalArray::<i64>::from_slice(&[100, 200], 18, 4));
+        let num = NumericArray::from(dec);
+        assert_eq!(num.len(), 2);
+        match &num {
+            NumericArray::Decimal64(a) => assert_eq!(a.scale, 4),
+            _ => panic!("expected Decimal64"),
+        }
+    }
+
+    #[test]
+    fn accessor_dec32() {
+        let dec = DecimalArray::<i32>::from_slice(&[42], 9, 2);
+        let num = NumericArray::from(dec);
+        let inner = num.dec32();
+        assert_eq!(inner.get(0), Some(42));
+    }
+
+    #[test]
+    fn accessor_dec64() {
+        let dec = DecimalArray::<i64>::from_slice(&[99], 18, 4);
+        let num = NumericArray::from(dec);
+        let inner = num.dec64();
+        assert_eq!(inner.get(0), Some(99));
+    }
+
+    #[test]
+    fn accessor_dec128() {
+        let dec = DecimalArray::<i128>::from_slice(&[1000], 38, 10);
+        let num = NumericArray::from(dec);
+        let inner = num.dec128();
+        assert_eq!(inner.get(0), Some(1000));
+    }
+
+    #[test]
+    fn try_dec128_widens_from_decimal64() {
+        let dec = DecimalArray::<i64>::from_slice(&[500], 18, 4);
+        let num = NumericArray::from(dec);
+        let widened = num.try_dec128().unwrap();
+        assert_eq!(widened.get(0), Some(500i128));
+        assert_eq!(widened.scale, 4);
+    }
+
+    #[test]
+    fn try_dec128_widens_from_decimal32() {
+        let dec = DecimalArray::<i32>::from_slice(&[42], 9, 2);
+        let num = NumericArray::from(dec);
+        let widened = num.try_dec128().unwrap();
+        assert_eq!(widened.get(0), Some(42i128));
+        assert_eq!(widened.scale, 2);
+    }
+
+    #[test]
+    fn try_dec64_widens_from_decimal32() {
+        let dec = DecimalArray::<i32>::from_slice(&[7], 9, 3);
+        let num = NumericArray::from(dec);
+        let widened = num.try_dec64().unwrap();
+        assert_eq!(widened.get(0), Some(7i64));
+        assert_eq!(widened.scale, 3);
+    }
+
+    #[test]
+    fn try_dec32_on_non_decimal_returns_error() {
+        let num = NumericArray::Int32(Arc::new(crate::IntegerArray::<i32>::from_slice(&[1])));
+        assert!(num.try_dec32().is_err());
+    }
+
+    #[test]
+    fn decimal_len_and_is_empty() {
+        let dec = DecimalArray::<i32>::from_slice(&[1, 2, 3], 9, 2);
+        let num = NumericArray::from(dec);
+        assert_eq!(num.len(), 3);
+
+        let empty = DecimalArray::<i64>::from_slice(&[], 18, 0);
+        let num_empty = NumericArray::from(empty);
+        assert_eq!(num_empty.len(), 0);
+    }
+
+    #[test]
+    fn decimal_null_mask() {
+        let mut dec = DecimalArray::<i32>::with_capacity(3, true, 9, 2);
+        dec.push(10);
+        dec.push_null();
+        dec.push(30);
+        let num = NumericArray::from(dec);
+        assert!(num.null_mask().is_some());
+        assert!(num.has_nulls());
+    }
+
+    #[test]
+    fn decimal_delete_range() {
+        let dec = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40], 9, 2);
+        let mut num = NumericArray::from(dec);
+        num.delete_range(1, 3);
+        assert_eq!(num.len(), 2);
+        let inner = num.dec32();
+        assert_eq!(inner.get(0), Some(10));
+        assert_eq!(inner.get(1), Some(40));
+    }
+
+    #[test]
+    fn decimal_append_array() {
+        let a = DecimalArray::<i64>::from_slice(&[10, 20], 18, 4);
+        let b = DecimalArray::<i64>::from_slice(&[30, 40], 18, 4);
+        let mut num_a = NumericArray::from(a);
+        let num_b = NumericArray::from(b);
+        num_a.append_array(&num_b);
+        assert_eq!(num_a.len(), 4);
+    }
+
+    #[test]
+    fn decimal_split() {
+        let dec = DecimalArray::<i128>::from_slice(&[100, 200, 300, 400], 38, 10);
+        let num = NumericArray::from(dec);
+        let (left, right) = num.split(2).unwrap();
+        assert_eq!(left.len(), 2);
+        assert_eq!(right.len(), 2);
+        assert_eq!(left.dec128().get(0), Some(100i128));
+        assert_eq!(right.dec128().get(0), Some(300i128));
+    }
+
+    #[test]
+    fn decimal_concat() {
+        use crate::traits::concatenate::Concatenate;
+        let a = NumericArray::from(DecimalArray::<i32>::from_slice(&[1, 2], 9, 2));
+        let b = NumericArray::from(DecimalArray::<i32>::from_slice(&[3, 4], 9, 2));
+        let result = a.concat(b).unwrap();
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn decimal_display() {
+        let dec = DecimalArray::<i32>::from_slice(&[12345], 9, 2);
+        let num = NumericArray::from(dec);
+        let display = format!("{}", num);
+        assert!(display.contains("Decimal32"), "got: {display}");
     }
 }

--- a/src/enums/scalar.rs
+++ b/src/enums/scalar.rs
@@ -39,6 +39,37 @@ use crate::{
     Array, ArrowType, Bitmask, BooleanArray, FloatArray, IntegerArray, MaskedArray, StringArray
 };
 
+/// Scale-aware formatting for decimal scalar values.
+#[cfg(all(feature = "scalar_type", feature = "decimal"))]
+fn format_decimal_scalar(raw: i128, scale: i8) -> String {
+    let raw_str = format!("{}", raw);
+    if scale == 0 {
+        return raw_str;
+    }
+    if scale < 0 {
+        let zeros = (-scale) as usize;
+        return format!("{}{}", raw_str, "0".repeat(zeros));
+    }
+    let scale_usize = scale as usize;
+    let (is_negative, digits) = if raw_str.starts_with('-') {
+        (true, &raw_str[1..])
+    } else {
+        (false, raw_str.as_str())
+    };
+    let padded = if digits.len() <= scale_usize {
+        format!("{:0>width$}", digits, width = scale_usize + 1)
+    } else {
+        digits.to_string()
+    };
+    let split_pos = padded.len() - scale_usize;
+    let (int_part, frac_part) = padded.split_at(split_pos);
+    if is_negative {
+        format!("-{}.{}", int_part, frac_part)
+    } else {
+        format!("{}.{}", int_part, frac_part)
+    }
+}
+
 /// # Scalar
 ///
 /// Scalar literals (single values) covering all supported types.
@@ -72,6 +103,13 @@ pub enum Scalar {
     // Floats
     Float32(f32),
     Float64(f64),
+    // Decimals - unscaled integer value + scale
+    #[cfg(feature = "decimal")]
+    Decimal32(i32, i8),
+    #[cfg(feature = "decimal")]
+    Decimal64(i64, i8),
+    #[cfg(feature = "decimal")]
+    Decimal128(i128, i8),
     // String strings
     String32(String),
     #[cfg(feature = "large_string")]
@@ -104,6 +142,12 @@ impl Display for Scalar {
             Scalar::UInt64(v) => Display::fmt(v, f),
             Scalar::Float32(v) => Display::fmt(v, f),
             Scalar::Float64(v) => Display::fmt(v, f),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, scale) => write!(f, "{}", format_decimal_scalar(*v as i128, *scale)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, scale) => write!(f, "{}", format_decimal_scalar(*v as i128, *scale)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, scale) => write!(f, "{}", format_decimal_scalar(*v, *scale)),
             Scalar::String32(v) => f.write_str(v),
             #[cfg(feature = "large_string")]
             Scalar::String64(v) => f.write_str(v),
@@ -141,6 +185,12 @@ impl Scalar {
             Scalar::UInt64(v) => *v != 0,
             Scalar::Float32(v) => *v != 0.0,
             Scalar::Float64(v) => *v != 0.0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => *v != 0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => *v != 0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => *v != 0,
             Scalar::Null => panic!("Cannot convert Null to bool"),
             Scalar::String32(s) => {
                 let s = s.trim();
@@ -206,6 +256,12 @@ impl Scalar {
             Scalar::UInt64(v) => i8::try_from(*v).expect("u64 out of range for i8"),
             Scalar::Float32(v) => i8::try_from(*v as i32).expect("f32 out of range for i8"),
             Scalar::Float64(v) => i8::try_from(*v as i32).expect("f64 out of range for i8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i8::try_from(*v).expect("Decimal32 out of range for i8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i8::try_from(*v).expect("Decimal64 out of range for i8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i8::try_from(*v).expect("Decimal128 out of range for i8"),
             Scalar::Null => panic!("Cannot convert Null to i8"),
             Scalar::String32(s) => s.parse::<i8>().expect("Cannot parse string as i8"),
             #[cfg(feature = "large_string")]
@@ -244,6 +300,12 @@ impl Scalar {
             Scalar::UInt64(v) => i16::try_from(*v).expect("u64 out of range for i16"),
             Scalar::Float32(v) => i16::try_from(*v as i32).expect("f32 out of range for i16"),
             Scalar::Float64(v) => i16::try_from(*v as i32).expect("f64 out of range for i16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i16::try_from(*v).expect("Decimal32 out of range for i16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i16::try_from(*v).expect("Decimal64 out of range for i16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i16::try_from(*v).expect("Decimal128 out of range for i16"),
             Scalar::Null => panic!("Cannot convert Null to i16"),
             Scalar::String32(s) => s.parse::<i16>().expect("Cannot parse string as i16"),
             #[cfg(feature = "large_string")]
@@ -285,6 +347,12 @@ impl Scalar {
             Scalar::UInt64(v) => i32::try_from(*v).expect("u64 out of range for i32"),
             Scalar::Float32(v) => *v as i32,
             Scalar::Float64(v) => *v as i32,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => *v,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i32::try_from(*v).expect("Decimal64 out of range for i32"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i32::try_from(*v).expect("Decimal128 out of range for i32"),
             Scalar::Null => panic!("Cannot convert Null to i32"),
             Scalar::String32(s) => s.parse::<i32>().expect("Cannot parse string as i32"),
             #[cfg(feature = "large_string")]
@@ -332,6 +400,12 @@ impl Scalar {
             }
             Scalar::Float32(v) => *v as i64,
             Scalar::Float64(v) => *v as i64,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => *v as i64,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => *v,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i64::try_from(*v).expect("Decimal128 out of range for i64"),
             Scalar::Null => panic!("Cannot convert Null to i64"),
             Scalar::String32(s) => s.parse::<i64>().expect("Cannot parse string as i64"),
             #[cfg(feature = "large_string")]
@@ -373,6 +447,12 @@ impl Scalar {
             Scalar::UInt64(v) => u8::try_from(*v).expect("u64 out of range for u8"),
             Scalar::Float32(v) => u8::try_from(*v as i32).expect("f32 out of range for u8"),
             Scalar::Float64(v) => u8::try_from(*v as i32).expect("f64 out of range for u8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u8::try_from(*v).expect("Decimal32 out of range for u8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u8::try_from(*v).expect("Decimal64 out of range for u8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u8::try_from(*v).expect("Decimal128 out of range for u8"),
             Scalar::Null => panic!("Cannot convert Null to u8"),
             Scalar::String32(s) => s.parse::<u8>().expect("Cannot parse string as u8"),
             #[cfg(feature = "large_string")]
@@ -414,6 +494,12 @@ impl Scalar {
             Scalar::UInt64(v) => u16::try_from(*v).expect("u64 out of range for u16"),
             Scalar::Float32(v) => u16::try_from(*v as i32).expect("f32 out of range for u16"),
             Scalar::Float64(v) => u16::try_from(*v as i32).expect("f64 out of range for u16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u16::try_from(*v).expect("Decimal32 out of range for u16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u16::try_from(*v).expect("Decimal64 out of range for u16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u16::try_from(*v).expect("Decimal128 out of range for u16"),
             Scalar::Null => panic!("Cannot convert Null to u16"),
             Scalar::String32(s) => s.parse::<u16>().expect("Cannot parse string as u16"),
             #[cfg(feature = "large_string")]
@@ -455,6 +541,12 @@ impl Scalar {
             Scalar::UInt64(v) => u32::try_from(*v).expect("u64 out of range for u32"),
             Scalar::Float32(v) => *v as u32,
             Scalar::Float64(v) => *v as u32,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u32::try_from(*v).expect("Decimal32 out of range for u32"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u32::try_from(*v).expect("Decimal64 out of range for u32"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u32::try_from(*v).expect("Decimal128 out of range for u32"),
             Scalar::Null => panic!("Cannot convert Null to u32"),
             Scalar::String32(s) => s.parse::<u32>().expect("Cannot parse string as u32"),
             #[cfg(feature = "large_string")]
@@ -532,6 +624,16 @@ impl Scalar {
                     panic!("f64 out of range for u64")
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => {
+                if *v >= 0 { *v as u64 } else { panic!("Decimal32 out of range for u64") }
+            },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => {
+                if *v >= 0 { *v as u64 } else { panic!("Decimal64 out of range for u64") }
+            },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u64::try_from(*v).expect("Decimal128 out of range for u64"),
             Scalar::Null => panic!("Cannot convert Null to u64"),
             Scalar::String32(s) => s.parse::<u64>().expect("Cannot parse string as u64"),
             #[cfg(feature = "large_string")]
@@ -573,6 +675,12 @@ impl Scalar {
             Scalar::UInt64(v) => *v as f32,
             Scalar::Float32(v) => *v,
             Scalar::Float64(v) => *v as f32,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => *v as f32 / 10f32.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => *v as f32 / 10f32.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => *v as f32 / 10f32.powi(*s as i32),
             Scalar::Boolean(v) => {
                 if *v {
                     1.0
@@ -614,6 +722,12 @@ impl Scalar {
             Scalar::UInt64(v) => *v as f64,
             Scalar::Float32(v) => *v as f64,
             Scalar::Float64(v) => *v,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => *v as f64 / 10f64.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => *v as f64 / 10f64.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => *v as f64 / 10f64.powi(*s as i32),
             Scalar::Boolean(v) => {
                 if *v {
                     1.0
@@ -659,6 +773,12 @@ impl Scalar {
             Scalar::UInt64(v) => v.to_string(),
             Scalar::Float32(v) => v.to_string(),
             Scalar::Float64(v) => v.to_string(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => format_decimal_scalar(*v as i128, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => format_decimal_scalar(*v as i128, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => format_decimal_scalar(*v, *s),
             Scalar::Null => panic!("Cannot convert Null to String"),
             #[cfg(feature = "datetime")]
             Scalar::Datetime32(v) => v.to_string(),
@@ -728,6 +848,8 @@ impl Scalar {
                     panic!("f64 out of range for dt32")
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => panic!("Cannot convert Decimal to dt32"),
             Scalar::String32(s) => s.parse::<u32>().expect("Cannot parse string as dt32"),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u32>().expect("Cannot parse string as dt32"),
@@ -815,6 +937,8 @@ impl Scalar {
                     panic!("f64 out of range for dt64")
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => panic!("Cannot convert Decimal to dt64"),
             Scalar::String32(s) => s.parse::<u64>().expect("Cannot parse string as dt64"),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u64>().expect("Cannot parse string as dt64"),
@@ -854,6 +978,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(*v != 0),
             Scalar::Float32(v) => Some(*v != 0.0),
             Scalar::Float64(v) => Some(*v != 0.0),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => Some(*v != 0),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => Some(*v != 0),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => Some(*v != 0),
             Scalar::Null => None,
             Scalar::String32(s) => {
                 let s = s.trim();
@@ -916,6 +1046,12 @@ impl Scalar {
             Scalar::UInt64(v) => i8::try_from(*v).ok(),
             Scalar::Float32(v) => i8::try_from(*v as i32).ok(),
             Scalar::Float64(v) => i8::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i8::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i8>().ok(),
             #[cfg(feature = "large_string")]
@@ -945,6 +1081,12 @@ impl Scalar {
             Scalar::UInt64(v) => i16::try_from(*v).ok(),
             Scalar::Float32(v) => i16::try_from(*v as i32).ok(),
             Scalar::Float64(v) => i16::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i16::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i16>().ok(),
             #[cfg(feature = "large_string")]
@@ -977,6 +1119,12 @@ impl Scalar {
             Scalar::UInt64(v) => i32::try_from(*v).ok(),
             Scalar::Float32(v) => Some(*v as i32),
             Scalar::Float64(v) => Some(*v as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => Some(*v),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i32::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i32::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i32>().ok(),
             #[cfg(feature = "large_string")]
@@ -1015,6 +1163,12 @@ impl Scalar {
             }
             Scalar::Float32(v) => Some(*v as i64),
             Scalar::Float64(v) => Some(*v as i64),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => Some(*v as i64),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => Some(*v),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i64::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i64>().ok(),
             #[cfg(feature = "large_string")]
@@ -1047,6 +1201,12 @@ impl Scalar {
             Scalar::UInt64(v) => u8::try_from(*v).ok(),
             Scalar::Float32(v) => u8::try_from(*v as i32).ok(),
             Scalar::Float64(v) => u8::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u8::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u8>().ok(),
             #[cfg(feature = "large_string")]
@@ -1079,6 +1239,12 @@ impl Scalar {
             Scalar::UInt64(v) => u16::try_from(*v).ok(),
             Scalar::Float32(v) => u16::try_from(*v as i32).ok(),
             Scalar::Float64(v) => u16::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u16::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u16>().ok(),
             #[cfg(feature = "large_string")]
@@ -1111,6 +1277,12 @@ impl Scalar {
             Scalar::UInt64(v) => u32::try_from(*v).ok(),
             Scalar::Float32(v) => Some(*v as u32),
             Scalar::Float64(v) => Some(*v as u32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u32::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u32::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u32::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u32>().ok(),
             #[cfg(feature = "large_string")]
@@ -1179,6 +1351,12 @@ impl Scalar {
                     None
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => if *v >= 0 { Some(*v as u64) } else { None },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => if *v >= 0 { Some(*v as u64) } else { None },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u64::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u64>().ok(),
             #[cfg(feature = "large_string")]
@@ -1223,6 +1401,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(*v as f32),
             Scalar::Float32(v) => Some(*v),
             Scalar::Float64(v) => Some(*v as f32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => Some(*v as f32 / 10f32.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => Some(*v as f32 / 10f32.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => Some(*v as f32 / 10f32.powi(*s as i32)),
             Scalar::Boolean(v) => Some(if *v { 1.0 } else { 0.0 }),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<f32>().ok(),
@@ -1255,6 +1439,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(*v as f64),
             Scalar::Float32(v) => Some(*v as f64),
             Scalar::Float64(v) => Some(*v),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => Some(*v as f64 / 10f64.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => Some(*v as f64 / 10f64.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => Some(*v as f64 / 10f64.powi(*s as i32)),
             Scalar::Boolean(v) => Some(if *v { 1.0 } else { 0.0 }),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<f64>().ok(),
@@ -1291,6 +1481,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(v.to_string()),
             Scalar::Float32(v) => Some(v.to_string()),
             Scalar::Float64(v) => Some(v.to_string()),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => Some(format_decimal_scalar(*v as i128, *s)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => Some(format_decimal_scalar(*v as i128, *s)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => Some(format_decimal_scalar(*v, *s)),
             Scalar::Null => None,
             #[cfg(feature = "datetime")]
             Scalar::Datetime32(v) => Some(v.to_string()),
@@ -1351,6 +1547,8 @@ impl Scalar {
                     None
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => None,
             Scalar::String32(s) => s.parse::<u32>().ok(),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u32>().ok(),
@@ -1429,6 +1627,8 @@ impl Scalar {
                     None
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => None,
             Scalar::String32(s) => s.parse::<u64>().ok(),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u64>().ok(),
@@ -1476,6 +1676,12 @@ impl Scalar {
             Scalar::UInt64(_) => ArrowType::UInt64,
             Scalar::Float32(_) => ArrowType::Float32,
             Scalar::Float64(_) => ArrowType::Float64,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, s) => ArrowType::Decimal32(0, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(_, s) => ArrowType::Decimal64(0, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(_, s) => ArrowType::Decimal128(0, *s),
             Scalar::String32(_) => ArrowType::String,
             #[cfg(feature = "large_string")]
             Scalar::String64(_) => ArrowType::LargeString,
@@ -1565,6 +1771,30 @@ impl Scalar {
                 }
                 Array::from_float64(arr)
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => {
+                let mut arr = crate::DecimalArray::<i32>::with_capacity(len, false, 0, s);
+                for _ in 0..len {
+                    arr.push(v);
+                }
+                Array::NumericArray(crate::NumericArray::Decimal32(std::sync::Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => {
+                let mut arr = crate::DecimalArray::<i64>::with_capacity(len, false, 0, s);
+                for _ in 0..len {
+                    arr.push(v);
+                }
+                Array::NumericArray(crate::NumericArray::Decimal64(std::sync::Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => {
+                let mut arr = crate::DecimalArray::<i128>::with_capacity(len, false, 0, s);
+                for _ in 0..len {
+                    arr.push(v);
+                }
+                Array::NumericArray(crate::NumericArray::Decimal128(std::sync::Arc::new(arr)))
+            }
             Scalar::Boolean(v) => {
                 let mut arr = BooleanArray::with_capacity(len, false);
                 for _ in 0..len {
@@ -1642,6 +1872,12 @@ impl PartialEq for Scalar {
             // equal to itself when used as a map or group key.
             (Float32(a), Float32(b)) => if a.is_nan() { b.is_nan() } else { a == b },
             (Float64(a), Float64(b)) => if a.is_nan() { b.is_nan() } else { a == b },
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, sa), Decimal32(b, sb)) => a == b && sa == sb,
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, sa), Decimal64(b, sb)) => a == b && sa == sb,
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, sa), Decimal128(b, sb)) => a == b && sa == sb,
             (String32(a), String32(b)) => a == b,
             #[cfg(feature = "large_string")]
             (String64(a), String64(b)) => a == b,
@@ -1690,6 +1926,12 @@ impl std::hash::Hash for Scalar {
                     if v.is_nan() { 0x7ff8_0000_0000_0000u64 } else { (*v + 0.0).to_bits() };
                 bits.hash(state);
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => { v.hash(state); s.hash(state); }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => { v.hash(state); s.hash(state); }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => { v.hash(state); s.hash(state); }
             Scalar::String32(v) => v.hash(state),
             #[cfg(feature = "large_string")]
             Scalar::String64(v) => v.hash(state),
@@ -1808,6 +2050,20 @@ impl Add for Scalar {
             // Nulls propagate
             (Null, _) | (_, Null) => Null,
 
+            // Decimal promotes to f64
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) + b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64() + b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) + b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64() + b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) + b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64() + b as f64 / 10f64.powi(s as i32)),
+
             // Float promotion
             (Float64(a), b) => Float64(a + b.f64()),
             (a, Float64(b)) => Float64(a.f64() + b),
@@ -1891,6 +2147,19 @@ impl Sub for Scalar {
         match (self, rhs) {
             (Null, _) | (_, Null) => Null,
 
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) - b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64() - b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) - b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64() - b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) - b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64() - b as f64 / 10f64.powi(s as i32)),
+
             (Float64(a), b) => Float64(a - b.f64()),
             (a, Float64(b)) => Float64(a.f64() - b),
             (Float32(a), b) => Float32(a - b.f32()),
@@ -1961,6 +2230,19 @@ impl Mul for Scalar {
 
         match (self, rhs) {
             (Null, _) | (_, Null) => Null,
+
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) * b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64() * (b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) * b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64() * (b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) * b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64() * (b as f64 / 10f64.powi(s as i32))),
 
             (Float64(a), b) => Float64(a * b.f64()),
             (a, Float64(b)) => Float64(a.f64() * b),
@@ -2059,6 +2341,19 @@ impl Pow<Scalar> for Scalar {
         match (self, rhs) {
             // Nulls propagate
             (Null, _) | (_, Null) => Null,
+
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64((a as f64 / 10f64.powi(s as i32)).powf(b.f64())),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64().powf(b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64((a as f64 / 10f64.powi(s as i32)).powf(b.f64())),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64().powf(b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64((a as f64 / 10f64.powi(s as i32)).powf(b.f64())),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64().powf(b as f64 / 10f64.powi(s as i32))),
 
             #[cfg(feature = "datetime")]
             (Interval, _) => panic!("Cannot exponentiate Interval"),

--- a/src/enums/value/impls.rs
+++ b/src/enums/value/impls.rs
@@ -614,6 +614,12 @@ fn scalar_variant_name(scalar: &crate::Scalar) -> &'static str {
         Datetime64(_) => "Datetime64",
         #[cfg(feature = "datetime")]
         Interval => "Interval",
+        #[cfg(feature = "decimal")]
+        Decimal32(_, _) => "Decimal32",
+        #[cfg(feature = "decimal")]
+        Decimal64(_, _) => "Decimal64",
+        #[cfg(feature = "decimal")]
+        Decimal128(_, _) => "Decimal128",
     }
 }
 

--- a/src/kernels/broadcast/array.rs
+++ b/src/kernels/broadcast/array.rs
@@ -172,6 +172,18 @@ pub fn broadcast_array_to_scalar(
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
         Scalar::Interval => {

--- a/src/kernels/broadcast/scalar.rs
+++ b/src/kernels/broadcast/scalar.rs
@@ -202,6 +202,18 @@ pub fn broadcast_scalar_to_array(
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
         Scalar::Interval => {
@@ -634,6 +646,14 @@ pub fn broadcast_scalar_to_text_arrayview(
                 feature: "Float scalar with TextArrayView".to_string(),
             });
         }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(_, _), _)
+        | (Scalar::Decimal64(_, _), _)
+        | (Scalar::Decimal128(_, _), _) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TextArrayView".to_string(),
+            });
+        }
         #[cfg(feature = "datetime")]
         (Scalar::Datetime32(_), _) | (Scalar::Datetime64(_), _) | (Scalar::Interval, _) => {
             return Err(MinarrowError::NotImplemented {
@@ -742,6 +762,14 @@ pub fn broadcast_text_arrayview_to_scalar(
                 feature: "Float scalar with TextArrayView".to_string(),
             });
         }
+        #[cfg(feature = "decimal")]
+        (_, Scalar::Decimal32(_, _))
+        | (_, Scalar::Decimal64(_, _))
+        | (_, Scalar::Decimal128(_, _)) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TextArrayView".to_string(),
+            });
+        }
         #[cfg(feature = "datetime")]
         (_, Scalar::Datetime32(_)) | (_, Scalar::Datetime64(_)) | (_, Scalar::Interval) => {
             return Err(MinarrowError::NotImplemented {
@@ -793,6 +821,18 @@ pub fn broadcast_scalar_to_fieldarray(
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
         Scalar::Interval => {
@@ -837,6 +877,18 @@ pub fn broadcast_fieldarray_to_scalar(
         #[cfg(feature = "datetime")]
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
         }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
@@ -894,6 +946,12 @@ pub fn broadcast_scalar_to_temporal_arrayview(
                 feature: "String scalar with TemporalArrayView".to_string(),
             });
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TemporalArrayView".to_string(),
+            });
+        }
         Scalar::Null => {
             return Err(MinarrowError::NullError { message: None });
         }
@@ -944,6 +1002,12 @@ pub fn broadcast_temporal_arrayview_to_scalar(
         Scalar::String64(_) => {
             return Err(MinarrowError::NotImplemented {
                 feature: "String scalar with TemporalArrayView".to_string(),
+            });
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TemporalArrayView".to_string(),
             });
         }
         Scalar::Null => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -743,6 +743,12 @@ macro_rules! match_array {
                 NumericArray::UInt64(a)         => a.$method($($args),*),
                 NumericArray::Float32(a)        => a.$method($($args),*),
                 NumericArray::Float64(a)        => a.$method($($args),*),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a)      => a.$method($($args),*),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a)      => a.$method($($args),*),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a)     => a.$method($($args),*),
                 NumericArray::Null              => Default::default(),
             },
             Array::BooleanArray(a)                  => a.$method($($args),*),

--- a/src/structs/arena.rs
+++ b/src/structs/arena.rs
@@ -841,6 +841,12 @@ pub(crate) fn consolidate_array_arena(chunks: &[&Array], dtype: &ArrowType) -> A
                 NumericArray::UInt8(_) => 1,
                 #[cfg(feature = "extended_numeric_types")]
                 NumericArray::UInt16(_) => 2,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => 4,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => 8,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => 16,
                 NumericArray::Null => 0,
             };
             total_bytes += align64(n_rows * elem);
@@ -950,6 +956,12 @@ pub(crate) fn consolidate_array_arena(chunks: &[&Array], dtype: &ArrowType) -> A
                 NumericArray::UInt8(_) => write_numeric!(UInt8, u8),
                 #[cfg(feature = "extended_numeric_types")]
                 NumericArray::UInt16(_) => write_numeric!(UInt16, u16),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => write_numeric!(Decimal32, i32),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => write_numeric!(Decimal64, i64),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => write_numeric!(Decimal128, i128),
                 NumericArray::Null => AAMaker::Primitive {
                     data: ArenaRegion::EMPTY,
                     mask: None,
@@ -1233,6 +1245,12 @@ pub(crate) fn consolidate_tables_arena(
                     NumericArray::UInt8(_) => 1,
                     #[cfg(feature = "extended_numeric_types")]
                     NumericArray::UInt16(_) => 2,
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal32(_) => 4,
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal64(_) => 8,
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal128(_) => 16,
                     NumericArray::Null => 0,
                 };
                 total_bytes += align64(n_rows * elem);
@@ -1354,6 +1372,12 @@ pub(crate) fn consolidate_tables_arena(
                     NumericArray::UInt8(_) => write_numeric!(UInt8, u8),
                     #[cfg(feature = "extended_numeric_types")]
                     NumericArray::UInt16(_) => write_numeric!(UInt16, u16),
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal32(_) => write_numeric!(Decimal32, i32),
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal64(_) => write_numeric!(Decimal64, i64),
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal128(_) => write_numeric!(Decimal128, i128),
                     NumericArray::Null => AAMaker::Primitive {
                         data: ArenaRegion::EMPTY,
                         mask: None,

--- a/src/structs/field.rs
+++ b/src/structs/field.rs
@@ -144,6 +144,18 @@ impl Field {
                 NumericArray::Float64(a) => {
                     Field::new(name, ArrowType::Float64, a.is_nullable(), Some(metadata))
                 }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    Field::new(name, a.arrow_type(), a.is_nullable(), Some(metadata))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    Field::new(name, a.arrow_type(), a.is_nullable(), Some(metadata))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    Field::new(name, a.arrow_type(), a.is_nullable(), Some(metadata))
+                }
                 NumericArray::Null => Field::new(name, ArrowType::Null, false, Some(metadata)),
             },
             Array::BooleanArray(a) => {

--- a/src/structs/field_array.rs
+++ b/src/structs/field_array.rs
@@ -493,6 +493,12 @@ pub fn create_field_for_array(
             NumericArray::UInt64(_) => ArrowType::UInt64,
             NumericArray::Float32(_) => ArrowType::Float32,
             NumericArray::Float64(_) => ArrowType::Float64,
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => a.arrow_type(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => a.arrow_type(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => a.arrow_type(),
             NumericArray::Null => ArrowType::Null,
         },
         Array::TextArray(text_arr) => match text_arr {

--- a/src/structs/variants/decimal.rs
+++ b/src/structs/variants/decimal.rs
@@ -62,7 +62,8 @@ use crate::traits::concatenate::Concatenate;
 use crate::traits::print::MAX_PREVIEW;
 use crate::traits::shape::Shape;
 use crate::traits::type_unions::Integer;
-use crate::{Bitmask, Buffer, Length, MaskedArray, Offset, impl_array_ref_deref};
+use crate::ffi::arrow_dtype::ArrowType;
+use crate::{Bitmask, Buffer, Length, MaskedArray, Offset, impl_arc_masked_array, impl_array_ref_deref};
 use vec64::Vec64;
 
 /// # DecimalArray
@@ -199,11 +200,21 @@ impl<T: Integer> DecimalArray<T> {
         Self::from_vec64(data.into(), None, precision, scale)
     }
 
-    // TODO(TSK376): Add `arrow_type(&self) -> ArrowType` method once
-    // ArrowType::Decimal32/64/128(u8, i8) variants are available.
-    // Implementation: match TypeId::of::<T>() returning the variant for
-    // i32 -> Decimal32, i64 -> Decimal64, i128 -> Decimal128, each
-    // carrying (self.precision, self.scale).
+    /// Returns the `ArrowType` for this decimal array, determined by the
+    /// backing integer width (i32, i64, or i128).
+    pub fn arrow_type(&self) -> ArrowType {
+        use std::any::TypeId;
+        let tid = TypeId::of::<T>();
+        if tid == TypeId::of::<i32>() {
+            ArrowType::Decimal32(self.precision, self.scale)
+        } else if tid == TypeId::of::<i64>() {
+            ArrowType::Decimal64(self.precision, self.scale)
+        } else if tid == TypeId::of::<i128>() {
+            ArrowType::Decimal128(self.precision, self.scale)
+        } else {
+            panic!("DecimalArray::arrow_type: unsupported backing type")
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -634,6 +645,16 @@ impl<T: Integer> MaskedArray for DecimalArray<T> {
 // ---------------------------------------------------------------------------
 
 impl_array_ref_deref!(DecimalArray<T>);
+impl_arc_masked_array!(
+    Inner = DecimalArray<T>,
+    T = T,
+    Container = Buffer<T>,
+    LogicalType = T,
+    CopyType = T,
+    BufferT = T,
+    Variant = NumericArray,
+    Bound = Integer,
+);
 
 // ---------------------------------------------------------------------------
 // Display - scale-aware formatting
@@ -750,6 +771,34 @@ impl<T: Integer> Concatenate for DecimalArray<T> {
         self.precision = self.precision.max(other.precision);
         self.append_array(&other);
         Ok(self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Widening conversions (lossless)
+// ---------------------------------------------------------------------------
+
+impl From<DecimalArray<i32>> for DecimalArray<i64> {
+    fn from(src: DecimalArray<i32>) -> Self {
+        let data: Vec64<i64> = src.data.iter().map(|&v| v as i64).collect();
+        DecimalArray {
+            data: data.into(),
+            null_mask: src.null_mask,
+            precision: src.precision,
+            scale: src.scale,
+        }
+    }
+}
+
+impl From<DecimalArray<i64>> for DecimalArray<i128> {
+    fn from(src: DecimalArray<i64>) -> Self {
+        let data: Vec64<i128> = src.data.iter().map(|&v| v as i128).collect();
+        DecimalArray {
+            data: data.into(),
+            null_mask: src.null_mask,
+            precision: src.precision,
+            scale: src.scale,
+        }
     }
 }
 
@@ -1484,5 +1533,88 @@ mod tests {
         let arr2 = DecimalArray::<i32>::from_slice(&[20, 30], 10, 2);
         let result = arr1.append_range(&arr2, 1, 5);
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // arrow_type
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_arrow_type_decimal32() {
+        use crate::ffi::arrow_dtype::ArrowType;
+        let arr = DecimalArray::<i32>::from_slice(&[1], 9, 2);
+        assert_eq!(arr.arrow_type(), ArrowType::Decimal32(9, 2));
+    }
+
+    #[test]
+    fn test_arrow_type_decimal64() {
+        use crate::ffi::arrow_dtype::ArrowType;
+        let arr = DecimalArray::<i64>::from_slice(&[1], 18, 4);
+        assert_eq!(arr.arrow_type(), ArrowType::Decimal64(18, 4));
+    }
+
+    #[test]
+    fn test_arrow_type_decimal128() {
+        use crate::ffi::arrow_dtype::ArrowType;
+        let arr = DecimalArray::<i128>::from_slice(&[1], 38, 10);
+        assert_eq!(arr.arrow_type(), ArrowType::Decimal128(38, 10));
+    }
+
+    // -----------------------------------------------------------------------
+    // Widening From impls
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_widen_decimal32_to_decimal64() {
+        let arr32 = DecimalArray::<i32>::from_slice(&[12345, -67890], 9, 2);
+        let arr64 = DecimalArray::<i64>::from(arr32);
+        assert_eq!(arr64.len(), 2);
+        assert_eq!(arr64.get(0), Some(12345i64));
+        assert_eq!(arr64.get(1), Some(-67890i64));
+        assert_eq!(arr64.precision, 9);
+        assert_eq!(arr64.scale, 2);
+    }
+
+    #[test]
+    fn test_widen_decimal64_to_decimal128() {
+        let arr64 = DecimalArray::<i64>::from_slice(&[999999999999, -1], 18, 6);
+        let arr128 = DecimalArray::<i128>::from(arr64);
+        assert_eq!(arr128.len(), 2);
+        assert_eq!(arr128.get(0), Some(999999999999i128));
+        assert_eq!(arr128.get(1), Some(-1i128));
+        assert_eq!(arr128.precision, 18);
+        assert_eq!(arr128.scale, 6);
+    }
+
+    #[test]
+    fn test_widen_preserves_null_mask() {
+        let mut arr32 = DecimalArray::<i32>::with_capacity(3, true, 9, 2);
+        arr32.push(100);
+        arr32.push_null();
+        arr32.push(300);
+        let arr64 = DecimalArray::<i64>::from(arr32);
+        assert_eq!(arr64.len(), 3);
+        assert_eq!(arr64.get(0), Some(100i64));
+        assert_eq!(arr64.get(1), None);
+        assert_eq!(arr64.get(2), Some(300i64));
+        assert_eq!(arr64.null_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Arc<DecimalArray> MaskedArray delegation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_arc_masked_array_delegation() {
+        let mut arc_arr = std::sync::Arc::new(
+            DecimalArray::<i32>::from_slice(&[10, 20, 30], 9, 2),
+        );
+        assert_eq!(arc_arr.len(), 3);
+        assert_eq!(arc_arr.get(0), Some(10));
+
+        // Copy-on-write push
+        arc_arr.push(40);
+        assert_eq!(arc_arr.len(), 4);
+        assert_eq!(arc_arr.get(3), Some(40));
     }
 }

--- a/src/structs/variants/decimal.rs
+++ b/src/structs/variants/decimal.rs
@@ -667,7 +667,7 @@ impl_arc_masked_array!(
 /// inserts the decimal point `scale` digits from the right, padding with leading
 /// zeros if the value has fewer digits than scale. When scale is negative,
 /// appends `|scale|` trailing zeros.
-fn format_decimal_value<T: Integer + Display>(raw: T, scale: i8) -> String {
+pub(crate) fn format_decimal_value<T: Integer + Display>(raw: T, scale: i8) -> String {
     let raw_str = format!("{}", raw);
 
     if scale == 0 {

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -42,6 +42,8 @@
 //! - `len` reflects the **logical** number of elements in the view.
 
 use std::fmt::{self, Debug, Display, Formatter};
+#[cfg(feature = "decimal")]
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use crate::enums::error::MinarrowError;
@@ -386,6 +388,12 @@ impl ArrayV {
                 NumericArray::UInt8(a) => cast_slice!(a),
                 #[cfg(feature = "extended_numeric_types")]
                 NumericArray::UInt16(a) => cast_slice!(a),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => cast_slice!(a),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => cast_slice!(a),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => cast_slice!(a),
                 NumericArray::Null => {
                     Err(KernelError::UnsupportedType("null numeric array".into()))
                 }
@@ -535,6 +543,27 @@ impl ArrayV {
                 NumericArray::UInt16(arr) => {
                     let (d, m) = gather_idx_prim!(self, arr, indices, u16);
                     Array::from_uint16(IntegerArray::new(d, m))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    let (d, m) = gather_idx_prim!(self, arr, indices, i32);
+                    Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    let (d, m) = gather_idx_prim!(self, arr, indices, i64);
+                    Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    let (d, m) = gather_idx_prim!(self, arr, indices, i128);
+                    Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
                 }
                 NumericArray::Null => Array::Null,
             },
@@ -745,6 +774,27 @@ impl ArrayV {
                 NumericArray::UInt16(arr) => {
                     let (d, m) = gather_pad_prim!(self, arr, indices, pad, u16);
                     Array::from_uint16(IntegerArray::new(d, m))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    let (d, m) = gather_pad_prim!(self, arr, indices, pad, i32);
+                    Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    let (d, m) = gather_pad_prim!(self, arr, indices, pad, i64);
+                    Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    let (d, m) = gather_pad_prim!(self, arr, indices, pad, i128);
+                    Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
                 }
                 NumericArray::Null => Array::Null,
             },
@@ -1015,6 +1065,27 @@ impl ArrayV {
                 NumericArray::UInt16(arr) => {
                     let (d, m) = gather_mask_prim!(self, arr, mask, kept, u16);
                     Array::from_uint16(IntegerArray::new(d, m))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    let (d, m) = gather_mask_prim!(self, arr, mask, kept, i32);
+                    Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    let (d, m) = gather_mask_prim!(self, arr, mask, kept, i64);
+                    Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    let (d, m) = gather_mask_prim!(self, arr, mask, kept, i128);
+                    Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
                 }
                 NumericArray::Null => Array::Null,
             },

--- a/src/structs/views/collections/numeric_array_view.rs
+++ b/src/structs/views/collections/numeric_array_view.rs
@@ -155,6 +155,12 @@ impl NumericArrayV {
             NumericArray::UInt64(arr) => arr.get(phys_idx).map(|v| v as f64),
             NumericArray::Float32(arr) => arr.get(phys_idx).map(|v| v as f64),
             NumericArray::Float64(arr) => arr.get(phys_idx),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.get(phys_idx).map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.get(phys_idx).map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.get(phys_idx).map(|v| v as f64),
             NumericArray::Null => None,
             #[cfg(feature = "extended_numeric_types")]
             NumericArray::Int8(arr) => arr.get(phys_idx).map(|v| v as f64),
@@ -181,6 +187,12 @@ impl NumericArrayV {
             NumericArray::UInt64(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
             NumericArray::Float32(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
             NumericArray::Float64(arr) => unsafe { arr.get_unchecked(phys_idx) },
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
             NumericArray::Null => None,
             #[cfg(feature = "extended_numeric_types")]
             NumericArray::Int8(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
@@ -439,6 +451,12 @@ impl Display for NumericArrayV {
             NumericArray::UInt64(_) => "UInt64",
             NumericArray::Float32(_) => "Float32",
             NumericArray::Float64(_) => "Float64",
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) => "Decimal32",
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(_) => "Decimal64",
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(_) => "Decimal128",
             NumericArray::Null => "Null",
         };
 

--- a/src/structs/xarray.rs
+++ b/src/structs/xarray.rs
@@ -827,6 +827,15 @@ impl Axis {
                     value.try_f64().and_then(|t| a.data.iter().position(|&v| v as f64 == t)),
                 NumericArray::Float64(a) =>
                     value.try_f64().and_then(|t| a.data.iter().position(|&v| v == t)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) =>
+                    value.try_i32().and_then(|t| a.data.iter().position(|&v| v == t)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) =>
+                    value.try_i64().and_then(|t| a.data.iter().position(|&v| v == t)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) =>
+                    value.try_i64().and_then(|t| a.data.iter().position(|&v| v == t as i128)),
                 NumericArray::Null => None,
             },
             #[cfg(feature = "datetime")]
@@ -934,6 +943,18 @@ impl Axis {
                 NumericArray::Float64(a) => if let (Some(lo), Some(hi)) = (low.try_f64(), high.try_f64()) {
                     coord_window!(a.data, lo, hi, f64, start, end, count);
                 },
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => if let (Some(lo), Some(hi)) = (low.try_i64(), high.try_i64()) {
+                    coord_window!(a.data, lo, hi, i64, start, end, count);
+                },
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => if let (Some(lo), Some(hi)) = (low.try_i64(), high.try_i64()) {
+                    coord_window!(a.data, lo, hi, i64, start, end, count);
+                },
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => if let (Some(lo), Some(hi)) = (low.try_i64(), high.try_i64()) {
+                    coord_window!(a.data, lo, hi, i64, start, end, count);
+                },
                 NumericArray::Null => {}
             },
             #[cfg(feature = "datetime")]
@@ -1018,6 +1039,15 @@ impl Axis {
                     value.try_f64().and_then(|t| coord_nearest!(a.data, |v| (v as f64 - t).abs())),
                 NumericArray::Float64(a) =>
                     value.try_f64().and_then(|t| coord_nearest!(a.data, |v| (v - t).abs())),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) =>
+                    value.try_i64().and_then(|t| coord_nearest!(a.data, |v| (v as i64).abs_diff(t))),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) =>
+                    value.try_i64().and_then(|t| coord_nearest!(a.data, |v| v.abs_diff(t))),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) =>
+                    value.try_i64().and_then(|t| coord_nearest!(a.data, |v| (v as i64).abs_diff(t))),
                 NumericArray::Null => None,
             },
             #[cfg(feature = "datetime")]

--- a/src/traits/byte_size.rs
+++ b/src/traits/byte_size.rs
@@ -168,6 +168,22 @@ impl<T> ByteSize for FloatArray<T> {
     }
 }
 
+/// ByteSize for DecimalArray<T>
+#[cfg(feature = "decimal")]
+impl<T> ByteSize for crate::DecimalArray<T> {
+    #[inline]
+    fn est_bytes(&self) -> usize {
+        let data_bytes = self.data.est_bytes();
+        let mask_bytes = self.null_mask.as_ref().map_or(0, |m| m.est_bytes());
+        data_bytes + mask_bytes
+    }
+
+    #[inline]
+    fn logical_bytes(&self) -> usize {
+        self.data.logical_bytes() + self.null_mask.as_ref().map_or(0, |m| m.logical_bytes())
+    }
+}
+
 /// ByteSize for StringArray<T>
 impl<T> ByteSize for StringArray<T> {
     #[inline]
@@ -274,6 +290,12 @@ impl ByteSize for NumericArray {
             NumericArray::UInt64(arr) => arr.est_bytes(),
             NumericArray::Float32(arr) => arr.est_bytes(),
             NumericArray::Float64(arr) => arr.est_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.est_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.est_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.est_bytes(),
             NumericArray::Null => 0,
         }
     }
@@ -294,6 +316,12 @@ impl ByteSize for NumericArray {
             NumericArray::UInt64(arr) => arr.logical_bytes(),
             NumericArray::Float32(arr) => arr.logical_bytes(),
             NumericArray::Float64(arr) => arr.logical_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.logical_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.logical_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.logical_bytes(),
             NumericArray::Null => 0,
         }
     }
@@ -518,6 +546,21 @@ impl ByteSize for ArrayV {
                 }
                 NumericArray::Float64(arr) => {
                     len * size_of::<f64>()
+                        + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    len * size_of::<i32>()
+                        + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    len * size_of::<i64>()
+                        + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    len * size_of::<i128>()
                         + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
                 }
                 NumericArray::Null => 0,
@@ -879,6 +922,12 @@ impl ByteSize for Scalar {
             // The variant carries no value
             #[cfg(feature = "datetime")]
             Scalar::Interval => 0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) => size_of::<i32>(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(_, _) => size_of::<i64>(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(_, _) => size_of::<i128>(),
         }
     }
 }

--- a/src/traits/consolidate.rs
+++ b/src/traits/consolidate.rs
@@ -215,6 +215,18 @@ impl<'a> Consolidate for Vec<crate::aliases::ArrayVT<'a>> {
             Array::NumericArray(NumericArray::UInt8(_)) => gather_numeric!(UInt8, u8),
             #[cfg(feature = "extended_numeric_types")]
             Array::NumericArray(NumericArray::UInt16(_)) => gather_numeric!(UInt16, u16),
+            #[cfg(feature = "decimal")]
+            Array::NumericArray(NumericArray::Decimal32(_)) => {
+                panic!("Consolidate is not yet implemented for DecimalArray")
+            }
+            #[cfg(feature = "decimal")]
+            Array::NumericArray(NumericArray::Decimal64(_)) => {
+                panic!("Consolidate is not yet implemented for DecimalArray")
+            }
+            #[cfg(feature = "decimal")]
+            Array::NumericArray(NumericArray::Decimal128(_)) => {
+                panic!("Consolidate is not yet implemented for DecimalArray")
+            }
             Array::NumericArray(NumericArray::Null) => Array::Null,
 
             Array::TextArray(TextArray::String32(_)) => gather_string!(String32, u32),

--- a/src/traits/print.rs
+++ b/src/traits/print.rs
@@ -70,6 +70,12 @@ pub(crate) fn value_to_string(arr: &Array, idx: usize) -> String {
             NumericArray::UInt16(a) => a.data[idx].to_string(),
             NumericArray::Float32(a) => format_float(a.data[idx] as f64),
             NumericArray::Float64(a) => format_float(a.data[idx]),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => format!("{}", a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => format!("{}", a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => format!("{}", a),
             NumericArray::Null => "null".into(),
         },
         // ------------------------- boolean ------------------------------


### PR DESCRIPTION
## Summary
- Adds `Decimal32`, `Decimal64`, `Decimal128` variants to `NumericArray` with match arms across all 12 dispatch methods
- Adds `dec32()/try_dec32()`, `dec64()/try_dec64()`, `dec128()/try_dec128()` accessors with cross-width widening
- Adds `Scalar::Decimal32/64/128` variants with scale-aware Display
- Implements `arrow_type()` on DecimalArray (deferred from TSK375)
- Adds From impls: owned and Arc for each width into NumericArray and Array, plus widening conversions between decimal widths
- Cascades decimal arms across Array, FieldArray, Arena, XArray, views, broadcast, print, consolidate, byte_size, value, and macros
- 39 new tests across numeric_array, array, scalar, and decimal modules

## Test plan
- [x] `cargo test --features decimal` passes (775 tests)
- [x] `cargo test` without decimal passes (680 tests, no regression)
- [x] `cargo test --all-features` passes (1,672 tests)
- [x] `cargo check --all-features` clean