### PR TITLE
Add decimal broadcast dispatch and scale-aware print formatting

### DIFF
--- a/src/kernels/routing/broadcast.rs
+++ b/src/kernels/routing/broadcast.rs
@@ -17,6 +17,8 @@ use crate::{
     Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, MaskedArray, NumericArray,
     StringArray, TextArray, Vec64, vec64,
 };
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 
 /// Repeat a length-1 `Array` to `len`.  
 /// Errors if the input length is *not* 1, or the variant is unsupported.  
@@ -64,6 +66,48 @@ pub fn broadcast_length_1_array(av: ArrayV, len: usize) -> Result<Array, KernelE
             let strs: Vec64<&str> = std::iter::repeat(s).take(len).collect();
             Ok(Array::from_string64(StringArray::from_vec64(strs, None)))
         }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal32(a)) => {
+            let null_mask = if a.is_null(0) {
+                Some(Bitmask::new_set_all(len, false))
+            } else {
+                None
+            };
+            Ok(Array::from_decimal32(DecimalArray::from_vec64(
+                vec64![a.data[0]; len],
+                null_mask,
+                a.precision,
+                a.scale,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal64(a)) => {
+            let null_mask = if a.is_null(0) {
+                Some(Bitmask::new_set_all(len, false))
+            } else {
+                None
+            };
+            Ok(Array::from_decimal64(DecimalArray::from_vec64(
+                vec64![a.data[0]; len],
+                null_mask,
+                a.precision,
+                a.scale,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal128(a)) => {
+            let null_mask = if a.is_null(0) {
+                Some(Bitmask::new_set_all(len, false))
+            } else {
+                None
+            };
+            Ok(Array::from_decimal128(DecimalArray::from_vec64(
+                vec64![a.data[0]; len],
+                null_mask,
+                a.precision,
+                a.scale,
+            )))
+        }
         _ => {
             return Err(KernelError::UnsupportedType(
                 "broadcast not yet implemented for this array variant".into(),
@@ -99,4 +143,94 @@ pub fn maybe_broadcast_scalar_array<'a>(
     Err(KernelError::LengthMismatch(format!(
         "cannot broadcast arrays of length {l} and {r}"
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal32() {
+        let arr = Array::from_decimal32(DecimalArray::from_slice(&[12345i32], 10, 2));
+        let av = ArrayV::new(arr, 0, 1);
+        let result = broadcast_length_1_array(av, 4).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal32(a)) = result {
+            assert_eq!(a.data.as_slice(), &[12345, 12345, 12345, 12345]);
+            assert_eq!(a.precision, 10);
+            assert_eq!(a.scale, 2);
+            assert!(a.null_mask.is_none());
+        } else {
+            panic!("Expected Decimal32 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal64() {
+        let arr = Array::from_decimal64(DecimalArray::from_slice(&[99999i64], 18, 4));
+        let av = ArrayV::new(arr, 0, 1);
+        let result = broadcast_length_1_array(av, 3).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal64(a)) = result {
+            assert_eq!(a.data.as_slice(), &[99999, 99999, 99999]);
+            assert_eq!(a.precision, 18);
+            assert_eq!(a.scale, 4);
+        } else {
+            panic!("Expected Decimal64 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal128() {
+        let arr = Array::from_decimal128(DecimalArray::from_slice(&[500i128], 38, 0));
+        let av = ArrayV::new(arr, 0, 1);
+        let result = broadcast_length_1_array(av, 2).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal128(a)) = result {
+            assert_eq!(a.data.as_slice(), &[500, 500]);
+            assert_eq!(a.precision, 38);
+            assert_eq!(a.scale, 0);
+        } else {
+            panic!("Expected Decimal128 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal_null_propagation() {
+        let mut arr = DecimalArray::from_slice(&[0i64], 10, 2);
+        arr.null_mask = Some(Bitmask::new_set_all(1, false));
+        let av = ArrayV::new(Array::from_decimal64(arr), 0, 1);
+        let result = broadcast_length_1_array(av, 3).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal64(a)) = result {
+            assert_eq!(a.data.len(), 3);
+            let mask = a.null_mask.as_ref().unwrap();
+            for i in 0..3 {
+                assert!(!mask.get(i), "element {i} should be null");
+            }
+        } else {
+            panic!("Expected Decimal64 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_maybe_broadcast_decimal_scalar_array() {
+        let scalar = Array::from_decimal32(DecimalArray::from_slice(&[100i32], 5, 1));
+        let target = Array::from_decimal32(DecimalArray::from_slice(&[1, 2, 3], 5, 1));
+        let (lhs, rhs) = maybe_broadcast_scalar_array(
+            ArrayV::new(scalar, 0, 1),
+            ArrayV::new(target, 0, 3),
+        )
+        .unwrap();
+        assert_eq!(lhs.len(), 3);
+        assert_eq!(rhs.len(), 3);
+        if let Array::NumericArray(NumericArray::Decimal32(a)) = &lhs.array {
+            assert_eq!(a.data.as_slice(), &[100, 100, 100]);
+            assert_eq!(a.precision, 5);
+            assert_eq!(a.scale, 1);
+        } else {
+            panic!("Expected broadcast Decimal32 array");
+        }
+    }
 }

--- a/src/traits/print.rs
+++ b/src/traits/print.rs
@@ -22,6 +22,8 @@ use std::fmt::{self, Display, Formatter};
 use crate::{Array, Buffer, Float, NumericArray, TextArray};
 #[cfg(feature = "datetime")]
 use crate::{DatetimeArray, Integer, TemporalArray};
+#[cfg(feature = "decimal")]
+use crate::structs::variants::decimal::format_decimal_value;
 
 pub(crate) const MAX_PREVIEW: usize = 50;
 
@@ -71,11 +73,11 @@ pub(crate) fn value_to_string(arr: &Array, idx: usize) -> String {
             NumericArray::Float32(a) => format_float(a.data[idx] as f64),
             NumericArray::Float64(a) => format_float(a.data[idx]),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(a) => format!("{}", a),
+            NumericArray::Decimal32(a) => format_decimal_value(a.data[idx], a.scale),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal64(a) => format!("{}", a),
+            NumericArray::Decimal64(a) => format_decimal_value(a.data[idx], a.scale),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal128(a) => format!("{}", a),
+            NumericArray::Decimal128(a) => format_decimal_value(a.data[idx], a.scale),
             NumericArray::Null => "null".into(),
         },
         // ------------------------- boolean ------------------------------
@@ -435,4 +437,80 @@ fn parse_timezone_offset(tz: &str) -> Option<time::UtcOffset> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_positive_scale() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal64(DecimalArray::from_slice(&[12345i64, -67890], 10, 2));
+        assert_eq!(value_to_string(&arr, 0), "123.45");
+        assert_eq!(value_to_string(&arr, 1), "-678.90");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_zero_scale() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal32(DecimalArray::from_slice(&[42i32, 100], 5, 0));
+        assert_eq!(value_to_string(&arr, 0), "42");
+        assert_eq!(value_to_string(&arr, 1), "100");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_negative_scale() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal32(DecimalArray::from_slice(&[123i32], 10, -2));
+        assert_eq!(value_to_string(&arr, 0), "12300");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_null() {
+        use crate::{Bitmask, DecimalArray};
+        let mut da = DecimalArray::from_slice(&[0i64, 100], 10, 2);
+        da.null_mask = Some(Bitmask::from_bools(&[false, true]));
+        let arr = Array::from_decimal64(da);
+        assert_eq!(value_to_string(&arr, 0), "null");
+        assert_eq!(value_to_string(&arr, 1), "1.00");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal128() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal128(DecimalArray::from_slice(&[999_999i128], 38, 4));
+        assert_eq!(value_to_string(&arr, 0), "99.9999");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_table_display_with_decimal_column() {
+        use crate::{DecimalArray, FieldArray, Table};
+        use crate::ffi::arrow_dtype::ArrowType;
+        use crate::Field;
+
+        let decimal_arr = DecimalArray::<i64>::from_slice(&[12345, 67890, 100], 10, 2);
+        let arr = Array::from_decimal64(decimal_arr);
+        let field = Field::new(
+            "amount".to_string(),
+            ArrowType::Decimal128(10, 2),
+            false,
+            None,
+        );
+        let table = Table::build(
+            vec![FieldArray::new(field, arr)],
+            3,
+            "test".to_string(),
+        );
+        let display = format!("{}", table);
+        assert!(display.contains("123.45"), "display should contain 123.45, got: {}", display);
+        assert!(display.contains("678.90"), "display should contain 678.90, got: {}", display);
+        assert!(display.contains("1.00"), "display should contain 1.00, got: {}", display);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds Decimal32/64/128 arms to `broadcast_length_1_array` for repeating length-1 decimal arrays to target length, preserving precision/scale and null mask
- Fixes Print trait `value_to_string` for decimal variants to use per-element scale-aware formatting instead of formatting the entire array
- 11 new tests covering broadcast for all widths, null propagation, and table display integration

## Test plan
- [x] `cargo test --features "decimal,chunked,views"` passes (786 tests)
- [x] `cargo test` without decimal passes (no regression)