### PR TITLE
Add decimal arithmetic kernels with checked overflow and auto-promotion + fix null mask drop on broadcasting

### DIFF
--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -4776,6 +4776,38 @@ macro_rules! arr_f64 {
     };
 }
 
+// ======== Decimal ========
+
+#[cfg(feature = "decimal")]
+#[macro_export]
+macro_rules! arr_dec32 {
+    (&[ $($x:expr),+ $(,)? ], $p:expr, $s:expr) => {{
+        $crate::Array::from_decimal32(
+            $crate::DecimalArray::<i32>::from_slice(&[$($x),+], $p, $s)
+        )
+    }};
+}
+
+#[cfg(feature = "decimal")]
+#[macro_export]
+macro_rules! arr_dec64 {
+    (&[ $($x:expr),+ $(,)? ], $p:expr, $s:expr) => {{
+        $crate::Array::from_decimal64(
+            $crate::DecimalArray::<i64>::from_slice(&[$($x),+], $p, $s)
+        )
+    }};
+}
+
+#[cfg(feature = "decimal")]
+#[macro_export]
+macro_rules! arr_dec128 {
+    (&[ $($x:expr),+ $(,)? ], $p:expr, $s:expr) => {{
+        $crate::Array::from_decimal128(
+            $crate::DecimalArray::<i128>::from_slice(&[$($x),+], $p, $s)
+        )
+    }};
+}
+
 // ======== Boolean ========
 
 #[macro_export]

--- a/src/enums/error.rs
+++ b/src/enums/error.rs
@@ -233,8 +233,7 @@ pub enum KernelError {
     /// Division by zero or similar mathematical errors.
     DivideByZero(String),
 
-    /// Arithmetic overflow that would silently corrupt results. Used by
-    /// decimal kernels where wrapping is not acceptable.
+    /// Arithmetic overflow detected during a kernel operation.
     Overflow(String),
 }
 

--- a/src/enums/error.rs
+++ b/src/enums/error.rs
@@ -232,6 +232,10 @@ pub enum KernelError {
 
     /// Division by zero or similar mathematical errors.
     DivideByZero(String),
+
+    /// Arithmetic overflow that would silently corrupt results. Used by
+    /// decimal kernels where wrapping is not acceptable.
+    Overflow(String),
 }
 
 impl fmt::Display for KernelError {
@@ -247,6 +251,7 @@ impl fmt::Display for KernelError {
             KernelError::Plan(msg) => write!(f, "Planning error: {}", msg),
             KernelError::OutOfBounds(msg) => write!(f, "Out of bounds: {}", msg),
             KernelError::DivideByZero(msg) => write!(f, "Divide by Zero error: {}", msg),
+            KernelError::Overflow(msg) => write!(f, "Arithmetic overflow: {}", msg),
         }
     }
 }

--- a/src/kernels/arithmetic/decimal.rs
+++ b/src/kernels/arithmetic/decimal.rs
@@ -12,15 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Checked arithmetic kernels for decimal arrays.
+//! Arithmetic kernels for decimal arrays with overflow detection.
 //!
-//! Decimal arithmetic uses checked operations instead of wrapping, because
-//! silent overflow on exact-precision values (monetary, accounting) would
-//! produce silently incorrect results. An overflow returns `KernelError`
-//! rather than wrapping or panicking.
-//!
-//! Scale reconciliation (rescaling one operand to match the other) and
-//! result-precision computation are handled here so the caller passes raw
+//! All operations use checked arithmetic and return `KernelError::Overflow`
+//! when the result exceeds the integer width. Scale reconciliation and
+//! result-precision computation are handled here so the caller passes
 //! `DecimalArray` pairs and receives a correctly-typed `DecimalArray` result.
 
 use crate::enums::error::KernelError;
@@ -56,20 +52,19 @@ fn checked_pow10<T: Integer>(exp: u32) -> Option<T> {
 
 /// Element-wise checked binary arithmetic on two `DecimalArray<T>` operands.
 ///
-/// Handles scale reconciliation for add/subtract, scale computation for
-/// multiply/divide, and checked overflow detection for all operations.
+/// Reconciles scale for add/subtract, computes result scale for
+/// multiply/divide, and detects overflow across all operations.
 /// The merged null mask from both operands propagates through the result.
 ///
 /// ## Scale rules
-/// - Add/Subtract: operands are rescaled to the finer (larger) scale. Result
-///   scale is that finer scale and result precision is capped at the width
-///   maximum.
-/// - Multiply: result scale = s1 + s2, result precision = p1 + p2 (capped).
-/// - Divide: the numerator is scaled up by the result scale factor so integer
-///   division preserves the desired number of fractional digits. Result scale
-///   is max(s1, s2).
-/// - Negate (Subtract with implicit zero lhs) and Abs are not binary and are
-///   handled by separate unary functions.
+/// - Add/Subtract: operands are rescaled to the finer scale. Result
+///   precision is capped at the width maximum.
+/// - Multiply: result scale = s1 + s2, result precision = p1 + p2,
+///   capped at the width maximum.
+/// - Divide: the numerator is scaled up so integer division preserves
+///   the desired number of fractional digits. Result scale is max of
+///   the two input scales.
+/// - Negate and Abs are unary and handled by separate functions.
 pub fn decimal_binary<T: Integer + 'static>(
     lhs: &DecimalArray<T>,
     rhs: &DecimalArray<T>,
@@ -177,7 +172,7 @@ fn decimal_add_sub<T: Integer + 'static>(
 }
 
 /// Multiply two decimal arrays. Result scale = s1 + s2, result
-/// precision = p1 + p2 (capped at width maximum).
+/// precision = p1 + p2, capped at the width maximum.
 fn decimal_multiply<T: Integer + 'static>(
     lhs: &DecimalArray<T>,
     rhs: &DecimalArray<T>,
@@ -203,9 +198,8 @@ fn decimal_multiply<T: Integer + 'static>(
     Ok(DecimalArray::new(out, merged_mask, result_precision, result_scale))
 }
 
-/// Divide two decimal arrays. The numerator is scaled up by 10^result_scale
-/// so the integer division preserves fractional digits.
-/// Result scale = max(s1, s2).
+/// Divide two decimal arrays. The numerator is scaled up so integer division
+/// preserves fractional digits. Result scale = max of the two input scales.
 fn decimal_divide<T: Integer + 'static>(
     lhs: &DecimalArray<T>,
     rhs: &DecimalArray<T>,
@@ -305,7 +299,7 @@ fn decimal_remainder<T: Integer + 'static>(
 }
 
 /// Element-wise negate on a decimal array. Overflow is only possible when
-/// negating the minimum value of the backing integer (e.g., i32::MIN).
+/// negating the minimum value of the backing integer, for e.g. i32::MIN.
 pub fn decimal_negate<T: Integer + 'static>(
     arr: &DecimalArray<T>,
 ) -> Result<DecimalArray<T>, KernelError> {
@@ -355,8 +349,8 @@ pub fn decimal_abs<T: Integer + 'static>(
 /// Rescale a decimal array to a new scale, multiplying or dividing the raw
 /// values by 10^|new_scale - old_scale|.
 ///
-/// Scaling up (new_scale > old_scale) uses checked multiplication.
-/// Scaling down (new_scale < old_scale) truncates via integer division.
+/// Scaling up multiplies raw values by the power-of-ten difference using
+/// checked arithmetic. Scaling down divides and truncates.
 pub fn decimal_rescale<T: Integer + 'static>(
     arr: &DecimalArray<T>,
     new_scale: i8,
@@ -385,7 +379,7 @@ pub fn decimal_rescale<T: Integer + 'static>(
                 .ok_or_else(|| overflow_error("rescale up"))?;
         }
     } else {
-        // Scale down: divide by factor (truncating)
+        // Scale down: truncating division by factor
         for i in 0..len {
             if arr.is_null(i) {
                 out[i] = T::zero();
@@ -398,9 +392,9 @@ pub fn decimal_rescale<T: Integer + 'static>(
     Ok(DecimalArray::new(out, arr.null_mask.clone(), arr.precision, new_scale))
 }
 
-/// Element-wise comparison of two decimal arrays, returning a `Bitmask` of
-/// results. Operands with different scales are rescaled to the finer scale
-/// before comparing.
+/// Element-wise comparison of two decimal arrays, returning a `Bitmask`.
+/// Operands with different scales are rescaled to the finer scale before
+/// comparing.
 pub fn decimal_compare<T: Integer + 'static>(
     lhs: &DecimalArray<T>,
     rhs: &DecimalArray<T>,
@@ -576,11 +570,11 @@ mod tests {
 
     #[test]
     fn add_different_scale() {
-        // 100.0 (scale=1) + 10.00 (scale=2) = 110.00 (scale=2)
+        // 100.0 at scale=1 + 10.00 at scale=2 = 110.00 at scale=2
         let a = dec64(&[1000], 18, 1); // raw 1000, scale 1 => 100.0
         let b = dec64(&[1000], 18, 2); // raw 1000, scale 2 => 10.00
         let result = decimal_binary(&a, &b, Add).unwrap();
-        // lhs rescaled: 1000 * 10 = 10000 (at scale 2) => 100.00
+        // lhs rescaled: 1000 * 10 = 10000 at scale 2 => 100.00
         // 10000 + 1000 = 11000 at scale 2 => 110.00
         assert_eq!(result.data.as_slice(), &[11000]);
         assert_eq!(result.scale, 2);
@@ -591,7 +585,7 @@ mod tests {
         let a = dec32(&[1000], 9, 1); // 100.0
         let b = dec32(&[500], 9, 2);  // 5.00
         let result = decimal_binary(&a, &b, Subtract).unwrap();
-        // lhs rescaled: 1000 * 10 = 10000 (scale 2) => 100.00
+        // lhs rescaled: 1000 * 10 = 10000 at scale 2 => 100.00
         // 10000 - 500 = 9500 => 95.00
         assert_eq!(result.data.as_slice(), &[9500]);
         assert_eq!(result.scale, 2);
@@ -779,7 +773,7 @@ mod tests {
     fn compare_different_scale() {
         use crate::enums::operators::ComparisonOperator::*;
 
-        // 10.0 (scale=1) vs 10.00 (scale=2) should be equal
+        // 10.0 at scale=1 vs 10.00 at scale=2 should be equal
         let a = dec64(&[100], 18, 1);  // 10.0
         let b = dec64(&[1000], 18, 2); // 10.00
         let eq = decimal_compare(&a, &b, Equals).unwrap();

--- a/src/kernels/arithmetic/decimal.rs
+++ b/src/kernels/arithmetic/decimal.rs
@@ -1,0 +1,858 @@
+// Copyright 2025 Peter Garfield Bower
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Checked arithmetic kernels for decimal arrays.
+//!
+//! Decimal arithmetic uses checked operations instead of wrapping, because
+//! silent overflow on exact-precision values (monetary, accounting) would
+//! produce silently incorrect results. An overflow returns `KernelError`
+//! rather than wrapping or panicking.
+//!
+//! Scale reconciliation (rescaling one operand to match the other) and
+//! result-precision computation are handled here so the caller passes raw
+//! `DecimalArray` pairs and receives a correctly-typed `DecimalArray` result.
+
+use crate::enums::error::KernelError;
+use crate::enums::operators::ArithmeticOperator;
+use crate::kernels::bitmask::merge_bitmasks_to_new;
+use crate::traits::type_unions::Integer;
+use crate::{Bitmask, DecimalArray, MaskedArray, Vec64};
+
+/// Maximum precision per backing integer width.
+fn max_precision<T: Integer + 'static>() -> u8 {
+    use std::any::TypeId;
+    let tid = TypeId::of::<T>();
+    if tid == TypeId::of::<i32>() {
+        9
+    } else if tid == TypeId::of::<i64>() {
+        18
+    } else {
+        38
+    }
+}
+
+/// Compute `10^exp` as T using checked multiplication.
+///
+/// Returns `None` if the result overflows the backing integer width.
+fn checked_pow10<T: Integer>(exp: u32) -> Option<T> {
+    let ten = T::from_usize(10);
+    let mut acc = T::one();
+    for _ in 0..exp {
+        acc = acc.checked_mul(&ten)?;
+    }
+    Some(acc)
+}
+
+/// Element-wise checked binary arithmetic on two `DecimalArray<T>` operands.
+///
+/// Handles scale reconciliation for add/subtract, scale computation for
+/// multiply/divide, and checked overflow detection for all operations.
+/// The merged null mask from both operands propagates through the result.
+///
+/// ## Scale rules
+/// - Add/Subtract: operands are rescaled to the finer (larger) scale. Result
+///   scale is that finer scale and result precision is capped at the width
+///   maximum.
+/// - Multiply: result scale = s1 + s2, result precision = p1 + p2 (capped).
+/// - Divide: the numerator is scaled up by the result scale factor so integer
+///   division preserves the desired number of fractional digits. Result scale
+///   is max(s1, s2).
+/// - Negate (Subtract with implicit zero lhs) and Abs are not binary and are
+///   handled by separate unary functions.
+pub fn decimal_binary<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    op: ArithmeticOperator,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    if len != rhs.len() {
+        return Err(KernelError::LengthMismatch(format!(
+            "decimal_binary: lhs {} vs rhs {}",
+            len,
+            rhs.len()
+        )));
+    }
+
+    let merged_mask = merge_bitmasks_to_new(
+        lhs.null_mask.as_ref(),
+        rhs.null_mask.as_ref(),
+        len,
+    );
+
+    match op {
+        ArithmeticOperator::Add | ArithmeticOperator::Subtract => {
+            decimal_add_sub(lhs, rhs, op, merged_mask)
+        }
+        ArithmeticOperator::Multiply => decimal_multiply(lhs, rhs, merged_mask),
+        ArithmeticOperator::Divide | ArithmeticOperator::FloorDiv => {
+            decimal_divide(lhs, rhs, merged_mask)
+        }
+        ArithmeticOperator::Remainder => decimal_remainder(lhs, rhs, merged_mask),
+        ArithmeticOperator::Power => Err(KernelError::UnsupportedType(
+            "Power is not supported for decimal arrays - consider converting to float64 first"
+                .to_string(),
+        )),
+    }
+}
+
+/// Add or subtract two decimal arrays, reconciling scale when they differ.
+fn decimal_add_sub<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    op: ArithmeticOperator,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let ls = lhs.scale;
+    let rs = rhs.scale;
+    let result_scale = ls.max(rs);
+    let result_precision = (lhs.precision.max(rhs.precision) + 1).min(max_precision::<T>());
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    let is_add = matches!(op, ArithmeticOperator::Add);
+
+    if ls == rs {
+        // Same scale - operate on raw values
+        for i in 0..len {
+            if is_masked_null(&merged_mask, i) {
+                out[i] = T::zero();
+                continue;
+            }
+            let l = lhs.data[i];
+            let r = rhs.data[i];
+            let result = if is_add {
+                l.checked_add(&r)
+            } else {
+                l.checked_sub(&r)
+            };
+            out[i] = result.ok_or_else(|| overflow_error("add/subtract"))?;
+        }
+    } else {
+        // Different scale - rescale the coarser operand to the finer scale
+        let scale_diff = (ls - rs).unsigned_abs() as u32;
+        let scale_factor = checked_pow10::<T>(scale_diff)
+            .ok_or_else(|| overflow_error("scale factor computation"))?;
+
+        for i in 0..len {
+            if is_masked_null(&merged_mask, i) {
+                out[i] = T::zero();
+                continue;
+            }
+            let (l, r) = if ls < rs {
+                // lhs has coarser scale, rescale lhs up
+                let scaled_l = lhs.data[i]
+                    .checked_mul(&scale_factor)
+                    .ok_or_else(|| overflow_error("rescale for add/subtract"))?;
+                (scaled_l, rhs.data[i])
+            } else {
+                // rhs has coarser scale, rescale rhs up
+                let scaled_r = rhs.data[i]
+                    .checked_mul(&scale_factor)
+                    .ok_or_else(|| overflow_error("rescale for add/subtract"))?;
+                (lhs.data[i], scaled_r)
+            };
+            let result = if is_add {
+                l.checked_add(&r)
+            } else {
+                l.checked_sub(&r)
+            };
+            out[i] = result.ok_or_else(|| overflow_error("add/subtract"))?;
+        }
+    }
+
+    Ok(DecimalArray::new(out, merged_mask, result_precision, result_scale))
+}
+
+/// Multiply two decimal arrays. Result scale = s1 + s2, result
+/// precision = p1 + p2 (capped at width maximum).
+fn decimal_multiply<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let result_scale = lhs.scale + rhs.scale;
+    let result_precision = (lhs.precision + rhs.precision).min(max_precision::<T>());
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if is_masked_null(&merged_mask, i) {
+            out[i] = T::zero();
+            continue;
+        }
+        out[i] = lhs.data[i]
+            .checked_mul(&rhs.data[i])
+            .ok_or_else(|| overflow_error("multiply"))?;
+    }
+
+    Ok(DecimalArray::new(out, merged_mask, result_precision, result_scale))
+}
+
+/// Divide two decimal arrays. The numerator is scaled up by 10^result_scale
+/// so the integer division preserves fractional digits.
+/// Result scale = max(s1, s2).
+fn decimal_divide<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let result_scale = lhs.scale.max(rhs.scale);
+    let result_precision = lhs.precision.max(rhs.precision).min(max_precision::<T>());
+
+    // Scale up the numerator so that integer division produces digits at
+    // the desired result scale: numerator * 10^(result_scale - lhs.scale + rhs.scale)
+    let extra_scale = (result_scale - lhs.scale + rhs.scale) as u32;
+    let scale_up = if extra_scale > 0 {
+        checked_pow10::<T>(extra_scale)
+            .ok_or_else(|| overflow_error("division scale-up factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+    let mut out_mask = merged_mask.clone();
+
+    for i in 0..len {
+        if is_masked_null(&out_mask, i) {
+            out[i] = T::zero();
+            continue;
+        }
+        let divisor = rhs.data[i];
+        if divisor == T::zero() {
+            // Division by zero produces null
+            out[i] = T::zero();
+            ensure_mask_null(&mut out_mask, len, i);
+            continue;
+        }
+        let scaled_num = lhs.data[i]
+            .checked_mul(&scale_up)
+            .ok_or_else(|| overflow_error("division numerator scale-up"))?;
+        out[i] = scaled_num / divisor;
+    }
+
+    Ok(DecimalArray::new(out, out_mask, result_precision, result_scale))
+}
+
+/// Remainder of two decimal arrays. Operands must have the same scale,
+/// or the coarser operand is rescaled first.
+fn decimal_remainder<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let ls = lhs.scale;
+    let rs = rhs.scale;
+    let result_scale = ls.max(rs);
+    let result_precision = lhs.precision.max(rhs.precision).min(max_precision::<T>());
+
+    let scale_diff = (ls - rs).unsigned_abs() as u32;
+    let scale_factor = if scale_diff > 0 {
+        checked_pow10::<T>(scale_diff)
+            .ok_or_else(|| overflow_error("remainder scale factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+    let mut out_mask = merged_mask.clone();
+
+    for i in 0..len {
+        if is_masked_null(&out_mask, i) {
+            out[i] = T::zero();
+            continue;
+        }
+        let (l, r) = if ls == rs {
+            (lhs.data[i], rhs.data[i])
+        } else if ls < rs {
+            let scaled_l = lhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("remainder rescale"))?;
+            (scaled_l, rhs.data[i])
+        } else {
+            let scaled_r = rhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("remainder rescale"))?;
+            (lhs.data[i], scaled_r)
+        };
+        if r == T::zero() {
+            out[i] = T::zero();
+            ensure_mask_null(&mut out_mask, len, i);
+            continue;
+        }
+        out[i] = l % r;
+    }
+
+    Ok(DecimalArray::new(out, out_mask, result_precision, result_scale))
+}
+
+/// Element-wise negate on a decimal array. Overflow is only possible when
+/// negating the minimum value of the backing integer (e.g., i32::MIN).
+pub fn decimal_negate<T: Integer + 'static>(
+    arr: &DecimalArray<T>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = arr.len();
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if arr.is_null(i) {
+            out[i] = T::zero();
+            continue;
+        }
+        out[i] = T::zero()
+            .checked_sub(&arr.data[i])
+            .ok_or_else(|| overflow_error("negate"))?;
+    }
+
+    Ok(DecimalArray::new(out, arr.null_mask.clone(), arr.precision, arr.scale))
+}
+
+/// Element-wise absolute value on a decimal array.
+pub fn decimal_abs<T: Integer + 'static>(
+    arr: &DecimalArray<T>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = arr.len();
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if arr.is_null(i) {
+            out[i] = T::zero();
+            continue;
+        }
+        let v = arr.data[i];
+        if v < T::zero() {
+            out[i] = T::zero()
+                .checked_sub(&v)
+                .ok_or_else(|| overflow_error("abs"))?;
+        } else {
+            out[i] = v;
+        }
+    }
+
+    Ok(DecimalArray::new(out, arr.null_mask.clone(), arr.precision, arr.scale))
+}
+
+/// Rescale a decimal array to a new scale, multiplying or dividing the raw
+/// values by 10^|new_scale - old_scale|.
+///
+/// Scaling up (new_scale > old_scale) uses checked multiplication.
+/// Scaling down (new_scale < old_scale) truncates via integer division.
+pub fn decimal_rescale<T: Integer + 'static>(
+    arr: &DecimalArray<T>,
+    new_scale: i8,
+) -> Result<DecimalArray<T>, KernelError> {
+    if new_scale == arr.scale {
+        return Ok(arr.clone());
+    }
+
+    let len = arr.len();
+    let diff = (new_scale as i32 - arr.scale as i32).unsigned_abs();
+    let factor = checked_pow10::<T>(diff)
+        .ok_or_else(|| overflow_error("rescale factor"))?;
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    if new_scale > arr.scale {
+        // Scale up: multiply by factor
+        for i in 0..len {
+            if arr.is_null(i) {
+                out[i] = T::zero();
+                continue;
+            }
+            out[i] = arr.data[i]
+                .checked_mul(&factor)
+                .ok_or_else(|| overflow_error("rescale up"))?;
+        }
+    } else {
+        // Scale down: divide by factor (truncating)
+        for i in 0..len {
+            if arr.is_null(i) {
+                out[i] = T::zero();
+                continue;
+            }
+            out[i] = arr.data[i] / factor;
+        }
+    }
+
+    Ok(DecimalArray::new(out, arr.null_mask.clone(), arr.precision, new_scale))
+}
+
+/// Element-wise comparison of two decimal arrays, returning a `Bitmask` of
+/// results. Operands with different scales are rescaled to the finer scale
+/// before comparing.
+pub fn decimal_compare<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    op: crate::enums::operators::ComparisonOperator,
+) -> Result<Bitmask, KernelError> {
+    use crate::enums::operators::ComparisonOperator::*;
+
+    let len = lhs.len();
+    if len != rhs.len() {
+        return Err(KernelError::LengthMismatch(format!(
+            "decimal_compare: lhs {} vs rhs {}",
+            len,
+            rhs.len()
+        )));
+    }
+
+    let ls = lhs.scale;
+    let rs = rhs.scale;
+    let scale_diff = (ls - rs).unsigned_abs() as u32;
+    let need_rescale = ls != rs;
+    let scale_factor = if need_rescale {
+        checked_pow10::<T>(scale_diff)
+            .ok_or_else(|| overflow_error("comparison rescale factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut result = Bitmask::new_set_all(len, false);
+
+    for i in 0..len {
+        // Null on either side produces false for all comparisons
+        if lhs.is_null(i) || rhs.is_null(i) {
+            continue;
+        }
+        let (l, r) = if !need_rescale {
+            (lhs.data[i], rhs.data[i])
+        } else if ls < rs {
+            let scaled_l = lhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("comparison rescale"))?;
+            (scaled_l, rhs.data[i])
+        } else {
+            let scaled_r = rhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("comparison rescale"))?;
+            (lhs.data[i], scaled_r)
+        };
+
+        let cmp_result = match op {
+            Equals => l == r,
+            NotEquals => l != r,
+            LessThan => l < r,
+            LessThanOrEqualTo => l <= r,
+            GreaterThan => l > r,
+            GreaterThanOrEqualTo => l >= r,
+            _ => {
+                return Err(KernelError::UnsupportedType(format!(
+                    "Comparison operator {:?} not supported for decimal arrays",
+                    op
+                )));
+            }
+        };
+        result.set(i, cmp_result);
+    }
+
+    Ok(result)
+}
+
+/// Convert an integer array to a DecimalArray at the given scale by
+/// multiplying each value by 10^scale. Used for Integer + Decimal
+/// auto-promotion.
+pub fn integer_to_decimal<T: Integer + 'static>(
+    data: &[T],
+    null_mask: Option<&Bitmask>,
+    precision: u8,
+    scale: i8,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = data.len();
+    let factor = if scale > 0 {
+        checked_pow10::<T>(scale as u32)
+            .ok_or_else(|| overflow_error("integer-to-decimal scale factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if null_mask.map(|m| !m.get(i)).unwrap_or(false) {
+            out[i] = T::zero();
+            continue;
+        }
+        out[i] = data[i]
+            .checked_mul(&factor)
+            .ok_or_else(|| overflow_error("integer-to-decimal conversion"))?;
+    }
+
+    Ok(DecimalArray::new(out, null_mask.cloned(), precision, scale))
+}
+
+// ---------------------------------------------------------------------------
+// Internal utilities
+// ---------------------------------------------------------------------------
+
+#[inline(always)]
+fn is_masked_null(mask: &Option<Bitmask>, i: usize) -> bool {
+    mask.as_ref().map(|m| !m.get(i)).unwrap_or(false)
+}
+
+/// Ensure the mask exists and mark position `i` as null.
+fn ensure_mask_null(mask: &mut Option<Bitmask>, len: usize, i: usize) {
+    match mask {
+        Some(m) => m.set(i, false),
+        None => {
+            let mut m = Bitmask::new_set_all(len, true);
+            m.set(i, false);
+            *mask = Some(m);
+        }
+    }
+}
+
+fn overflow_error(context: &str) -> KernelError {
+    KernelError::Overflow(format!("Decimal arithmetic overflow in {}", context))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::enums::operators::ArithmeticOperator::*;
+
+    fn dec32(vals: &[i32], p: u8, s: i8) -> DecimalArray<i32> {
+        DecimalArray::<i32>::from_slice(vals, p, s)
+    }
+
+    fn dec64(vals: &[i64], p: u8, s: i8) -> DecimalArray<i64> {
+        DecimalArray::<i64>::from_slice(vals, p, s)
+    }
+
+    fn dec128(vals: &[i128], p: u8, s: i8) -> DecimalArray<i128> {
+        DecimalArray::<i128>::from_slice(vals, p, s)
+    }
+
+    // -----------------------------------------------------------------------
+    // Same-scale add/subtract
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_same_scale_i32() {
+        let a = dec32(&[12345, 67890], 9, 2);
+        let b = dec32(&[11111, 22222], 9, 2);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.data.as_slice(), &[23456, 90112]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn subtract_same_scale_i64() {
+        let a = dec64(&[50000, 30000], 18, 4);
+        let b = dec64(&[10000, 20000], 18, 4);
+        let result = decimal_binary(&a, &b, Subtract).unwrap();
+        assert_eq!(result.data.as_slice(), &[40000, 10000]);
+        assert_eq!(result.scale, 4);
+    }
+
+    // -----------------------------------------------------------------------
+    // Different-scale add/subtract
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_different_scale() {
+        // 100.0 (scale=1) + 10.00 (scale=2) = 110.00 (scale=2)
+        let a = dec64(&[1000], 18, 1); // raw 1000, scale 1 => 100.0
+        let b = dec64(&[1000], 18, 2); // raw 1000, scale 2 => 10.00
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        // lhs rescaled: 1000 * 10 = 10000 (at scale 2) => 100.00
+        // 10000 + 1000 = 11000 at scale 2 => 110.00
+        assert_eq!(result.data.as_slice(), &[11000]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn subtract_different_scale() {
+        let a = dec32(&[1000], 9, 1); // 100.0
+        let b = dec32(&[500], 9, 2);  // 5.00
+        let result = decimal_binary(&a, &b, Subtract).unwrap();
+        // lhs rescaled: 1000 * 10 = 10000 (scale 2) => 100.00
+        // 10000 - 500 = 9500 => 95.00
+        assert_eq!(result.data.as_slice(), &[9500]);
+        assert_eq!(result.scale, 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiply
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn multiply_basic() {
+        // 12.34 * 5.67 = 69.9678
+        let a = dec64(&[1234], 18, 2);
+        let b = dec64(&[567], 18, 2);
+        let result = decimal_binary(&a, &b, Multiply).unwrap();
+        assert_eq!(result.data.as_slice(), &[699678]);
+        assert_eq!(result.scale, 4); // 2 + 2
+    }
+
+    // -----------------------------------------------------------------------
+    // Divide
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn divide_same_scale() {
+        // 100.00 / 4.00 = 25.00
+        let a = dec64(&[10000], 18, 2);
+        let b = dec64(&[400], 18, 2);
+        let result = decimal_binary(&a, &b, Divide).unwrap();
+        // result_scale = max(2, 2) = 2
+        // extra_scale = 2 - 2 + 2 = 2
+        // scaled_num = 10000 * 100 = 1000000
+        // 1000000 / 400 = 2500 at scale 2 => 25.00
+        assert_eq!(result.data.as_slice(), &[2500]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn divide_by_zero_produces_null() {
+        let a = dec32(&[100, 200], 9, 2);
+        let b = dec32(&[0, 50], 9, 2);
+        let result = decimal_binary(&a, &b, Divide).unwrap();
+        assert_eq!(result.data[0], 0);
+        assert!(result.is_null(0));
+        assert!(!result.is_null(1));
+    }
+
+    // -----------------------------------------------------------------------
+    // Remainder
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remainder_same_scale() {
+        // 10.00 % 3.00 = 1.00
+        let a = dec64(&[1000], 18, 2);
+        let b = dec64(&[300], 18, 2);
+        let result = decimal_binary(&a, &b, Remainder).unwrap();
+        assert_eq!(result.data.as_slice(), &[100]); // 1000 % 300 = 100
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn remainder_by_zero_produces_null() {
+        let a = dec32(&[100], 9, 2);
+        let b = dec32(&[0], 9, 2);
+        let result = decimal_binary(&a, &b, Remainder).unwrap();
+        assert!(result.is_null(0));
+    }
+
+    // -----------------------------------------------------------------------
+    // Negate and Abs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn negate_basic() {
+        let a = dec32(&[100, -200, 0], 9, 2);
+        let result = decimal_negate(&a).unwrap();
+        assert_eq!(result.data.as_slice(), &[-100, 200, 0]);
+        assert_eq!(result.scale, 2);
+        assert_eq!(result.precision, 9);
+    }
+
+    #[test]
+    fn abs_basic() {
+        let a = dec64(&[-500, 300, 0, -1], 18, 4);
+        let result = decimal_abs(&a).unwrap();
+        assert_eq!(result.data.as_slice(), &[500, 300, 0, 1]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Overflow detection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_overflow_returns_error() {
+        let a = dec32(&[i32::MAX], 9, 0);
+        let b = dec32(&[1], 9, 0);
+        let result = decimal_binary(&a, &b, Add);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("overflow"), "got: {err}");
+    }
+
+    #[test]
+    fn multiply_overflow_returns_error() {
+        let a = dec32(&[i32::MAX], 9, 0);
+        let b = dec32(&[2], 9, 0);
+        let result = decimal_binary(&a, &b, Multiply);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Null propagation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn null_propagation() {
+        let mut a = DecimalArray::<i32>::with_capacity(3, true, 9, 2);
+        a.push(100);
+        a.push_null();
+        a.push(300);
+
+        let b = dec32(&[10, 20, 30], 9, 2);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.get(0), Some(110));
+        assert_eq!(result.get(1), None);
+        assert_eq!(result.get(2), Some(330));
+    }
+
+    // -----------------------------------------------------------------------
+    // Rescale
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rescale_up() {
+        let a = dec64(&[100, 200], 18, 2);
+        let result = decimal_rescale(&a, 4).unwrap();
+        assert_eq!(result.data.as_slice(), &[10000, 20000]);
+        assert_eq!(result.scale, 4);
+    }
+
+    #[test]
+    fn rescale_down_truncates() {
+        let a = dec64(&[12345, 67899], 18, 4);
+        let result = decimal_rescale(&a, 2).unwrap();
+        assert_eq!(result.data.as_slice(), &[123, 678]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn rescale_noop() {
+        let a = dec32(&[100], 9, 2);
+        let result = decimal_rescale(&a, 2).unwrap();
+        assert_eq!(result.data.as_slice(), &[100]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Comparison
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compare_same_scale() {
+        use crate::enums::operators::ComparisonOperator::*;
+
+        let a = dec32(&[100, 200, 300], 9, 2);
+        let b = dec32(&[200, 200, 100], 9, 2);
+
+        let eq = decimal_compare(&a, &b, Equals).unwrap();
+        assert!(!eq.get(0));
+        assert!(eq.get(1));
+        assert!(!eq.get(2));
+
+        let lt = decimal_compare(&a, &b, LessThan).unwrap();
+        assert!(lt.get(0));
+        assert!(!lt.get(1));
+        assert!(!lt.get(2));
+
+        let gt = decimal_compare(&a, &b, GreaterThan).unwrap();
+        assert!(!gt.get(0));
+        assert!(!gt.get(1));
+        assert!(gt.get(2));
+    }
+
+    #[test]
+    fn compare_different_scale() {
+        use crate::enums::operators::ComparisonOperator::*;
+
+        // 10.0 (scale=1) vs 10.00 (scale=2) should be equal
+        let a = dec64(&[100], 18, 1);  // 10.0
+        let b = dec64(&[1000], 18, 2); // 10.00
+        let eq = decimal_compare(&a, &b, Equals).unwrap();
+        assert!(eq.get(0));
+    }
+
+    #[test]
+    fn compare_null_produces_false() {
+        use crate::enums::operators::ComparisonOperator::*;
+
+        let mut a = DecimalArray::<i32>::with_capacity(2, true, 9, 2);
+        a.push(100);
+        a.push_null();
+        let b = dec32(&[100, 100], 9, 2);
+        let eq = decimal_compare(&a, &b, Equals).unwrap();
+        assert!(eq.get(0));
+        assert!(!eq.get(1)); // null comparison is false
+    }
+
+    // -----------------------------------------------------------------------
+    // i128 operations
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_i128() {
+        let a = dec128(&[100_000_000_000i128, 200_000_000_000], 38, 6);
+        let b = dec128(&[50_000_000_000, 100_000_000_000], 38, 6);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.data.as_slice(), &[150_000_000_000i128, 300_000_000_000]);
+    }
+
+    #[test]
+    fn multiply_i128() {
+        let a = dec128(&[1000i128], 38, 2);
+        let b = dec128(&[2000i128], 38, 3);
+        let result = decimal_binary(&a, &b, Multiply).unwrap();
+        assert_eq!(result.data.as_slice(), &[2_000_000i128]);
+        assert_eq!(result.scale, 5); // 2 + 3
+    }
+
+    // -----------------------------------------------------------------------
+    // Integer to decimal conversion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn integer_to_decimal_basic() {
+        let data = [10i64, 20, 30];
+        let result = integer_to_decimal(&data, None, 18, 2).unwrap();
+        assert_eq!(result.data.as_slice(), &[1000, 2000, 3000]);
+        assert_eq!(result.scale, 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Power is unsupported
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn power_returns_error() {
+        let a = dec32(&[100], 9, 2);
+        let b = dec32(&[2], 9, 0);
+        let result = decimal_binary(&a, &b, Power);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty arrays
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_arrays() {
+        let a = dec32(&[], 9, 2);
+        let b = dec32(&[], 9, 2);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+}

--- a/src/kernels/arithmetic/mod.rs
+++ b/src/kernels/arithmetic/mod.rs
@@ -31,6 +31,8 @@
 //! which is app-specific.**.
 
 pub mod dispatch;
+#[cfg(feature = "decimal")]
+pub mod decimal;
 #[cfg(feature = "simd")]
 pub mod simd;
 pub mod std;

--- a/src/kernels/routing/arithmetic.rs
+++ b/src/kernels/routing/arithmetic.rs
@@ -14,6 +14,8 @@
 
 #[cfg(feature = "scalar_type")]
 use crate::Scalar;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 use crate::enums::error::MinarrowError;
 use crate::kernels::routing::broadcast::maybe_broadcast_scalar_array;
 use crate::{Array, ArrayV, Bitmask, TextArray};
@@ -26,6 +28,8 @@ use crate::kernels::arithmetic::{
     },
     string_ops::apply_str_str,
 };
+#[cfg(feature = "decimal")]
+use crate::kernels::arithmetic::decimal::{decimal_binary, integer_to_decimal};
 
 use crate::enums::{error::KernelError, operators::ArithmeticOperator};
 
@@ -188,6 +192,80 @@ pub fn scalar_arithmetic(
         (Scalar::String32(l), Scalar::String64(r), Add) => Scalar::String64(format!("{}{}", l, r)),
         #[cfg(feature = "large_string")]
         (Scalar::String64(l), Scalar::String32(r), Add) => Scalar::String64(format!("{}{}", l, r)),
+
+        // Decimal scalar operations (same width, same scale)
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, ls), Scalar::Decimal32(r, rs), Add) if ls == rs => {
+            Scalar::Decimal32(l.checked_add(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal32 overflow in addition".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, ls), Scalar::Decimal32(r, rs), Subtract) if ls == rs => {
+            Scalar::Decimal32(l.checked_sub(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal32 overflow in subtraction".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, ls), Scalar::Decimal32(r, _rs), Multiply) => {
+            Scalar::Decimal32(l.checked_mul(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal32 overflow in multiplication".to_string()),
+            ))?, ls + _rs)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, ls), Scalar::Decimal64(r, rs), Add) if ls == rs => {
+            Scalar::Decimal64(l.checked_add(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal64 overflow in addition".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, ls), Scalar::Decimal64(r, rs), Subtract) if ls == rs => {
+            Scalar::Decimal64(l.checked_sub(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal64 overflow in subtraction".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, ls), Scalar::Decimal64(r, _rs), Multiply) => {
+            Scalar::Decimal64(l.checked_mul(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal64 overflow in multiplication".to_string()),
+            ))?, ls + _rs)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, ls), Scalar::Decimal128(r, rs), Add) if ls == rs => {
+            Scalar::Decimal128(l.checked_add(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal128 overflow in addition".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, ls), Scalar::Decimal128(r, rs), Subtract) if ls == rs => {
+            Scalar::Decimal128(l.checked_sub(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal128 overflow in subtraction".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, ls), Scalar::Decimal128(r, _rs), Multiply) => {
+            Scalar::Decimal128(l.checked_mul(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal128 overflow in multiplication".to_string()),
+            ))?, ls + _rs)
+        }
+
+        // Decimal + Float -> Float64 scalar promotion
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, s), Scalar::Float64(r), op) | (Scalar::Float64(r), Scalar::Decimal32(l, s), op) => {
+            let l_f64 = l as f64 / 10f64.powi(s as i32);
+            return scalar_arithmetic(Scalar::Float64(l_f64), Scalar::Float64(r), op);
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, s), Scalar::Float64(r), op) | (Scalar::Float64(r), Scalar::Decimal64(l, s), op) => {
+            let l_f64 = l as f64 / 10f64.powi(s as i32);
+            return scalar_arithmetic(Scalar::Float64(l_f64), Scalar::Float64(r), op);
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, s), Scalar::Float64(r), op) | (Scalar::Float64(r), Scalar::Decimal128(l, s), op) => {
+            use num_traits::ToPrimitive;
+            let l_f64 = l.to_f64().unwrap() / 10f64.powi(s as i32);
+            return scalar_arithmetic(Scalar::Float64(l_f64), Scalar::Float64(r), op);
+        }
 
         // Null handling
         (Scalar::Null, _, _) | (_, Scalar::Null, _) => {
@@ -401,9 +479,700 @@ fn arithmetic_dispatch(
             }
         }
 
+        // -----------------------------------------------------------------
+        // Decimal same-type dispatch
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let result = decimal_binary(l.as_ref(), r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal32(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let result = decimal_binary(l.as_ref(), r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let result = decimal_binary(l.as_ref(), r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+
+        // -----------------------------------------------------------------
+        // Decimal width promotion (narrower widened to wider)
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let widened = DecimalArray::<i64>::from(l.as_ref().clone());
+            let result = decimal_binary(&widened, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let widened = DecimalArray::<i64>::from(r.as_ref().clone());
+            let result = decimal_binary(l.as_ref(), &widened, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let widened: DecimalArray<i128> =
+                DecimalArray::<i64>::from(l.as_ref().clone()).into();
+            let result = decimal_binary(&widened, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let widened: DecimalArray<i128> =
+                DecimalArray::<i64>::from(r.as_ref().clone()).into();
+            let result = decimal_binary(l.as_ref(), &widened, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let widened = DecimalArray::<i128>::from(l.as_ref().clone());
+            let result = decimal_binary(&widened, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let widened = DecimalArray::<i128>::from(r.as_ref().clone());
+            let result = decimal_binary(l.as_ref(), &widened, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+
+        // -----------------------------------------------------------------
+        // Integer + Decimal auto-promotion (integer promoted to decimal)
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int32(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let promoted = integer_to_decimal(lhs_slice, l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal32(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Int32(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let promoted = integer_to_decimal(rhs_slice, r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal32(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int64(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let promoted = integer_to_decimal(lhs_slice, l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Int64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let promoted = integer_to_decimal(rhs_slice, r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+
+        // Int32/Int64 + Decimal128: widen the integer to i128, promote to decimal
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int32(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let data_i128: Vec64<i128> = lhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Int32(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let data_i128: Vec64<i128> = rhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int64(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let data_i128: Vec64<i128> = lhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Int64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let data_i128: Vec64<i128> = rhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+
+        // -----------------------------------------------------------------
+        // Float + Decimal auto-promotion (decimal demoted to Float64)
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float64(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(lhs_slice, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Float64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, rhs_slice, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float64(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(lhs_slice, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Float64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, rhs_slice, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float64(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(lhs_slice, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Float64(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(l.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, rhs_slice, op, null_mask)?.into(),
+            )))
+        }
+
+        // Float32 + Decimal -> Float64 (promote both to f64)
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float32(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice()[lhs_offset..lhs_offset + lhs_len]
+                .iter().map(|&v| v as f64).collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Float32(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice()[rhs_offset..rhs_offset + rhs_len]
+                .iter().map(|&v| v as f64).collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float32(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice()[lhs_offset..lhs_offset + lhs_len]
+                .iter().map(|&v| v as f64).collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Float32(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice()[rhs_offset..rhs_offset + rhs_len]
+                .iter().map(|&v| v as f64).collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float32(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let lhs_f64: Vec64<f64> = l.data.as_slice()[lhs_offset..lhs_offset + lhs_len]
+                .iter().map(|&v| v as f64).collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Float32(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(l.scale as i32))
+                .collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice()[rhs_offset..rhs_offset + rhs_len]
+                .iter().map(|&v| v as f64).collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+
         // Unsupported combinations
         _ => Err(KernelError::UnsupportedType(
             "Unsupported array type combination for arithmetic operations".to_string(),
         )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decimal dispatch integration tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "decimal")]
+mod decimal_dispatch_tests {
+    use super::*;
+    use crate::{Array, DecimalArray, FloatArray, IntegerArray, MaskedArray, NumericArray};
+
+    fn arr_dec32(vals: &[i32], p: u8, s: i8) -> Array {
+        Array::NumericArray(NumericArray::Decimal32(
+            DecimalArray::<i32>::from_slice(vals, p, s).into(),
+        ))
+    }
+
+    fn arr_dec64(vals: &[i64], p: u8, s: i8) -> Array {
+        Array::NumericArray(NumericArray::Decimal64(
+            DecimalArray::<i64>::from_slice(vals, p, s).into(),
+        ))
+    }
+
+    fn arr_dec128(vals: &[i128], p: u8, s: i8) -> Array {
+        Array::NumericArray(NumericArray::Decimal128(
+            DecimalArray::<i128>::from_slice(vals, p, s).into(),
+        ))
+    }
+
+    fn arr_i32(vals: &[i32]) -> Array {
+        Array::from_int32(IntegerArray::from_slice(vals))
+    }
+
+    fn arr_i64(vals: &[i64]) -> Array {
+        Array::from_int64(IntegerArray::from_slice(vals))
+    }
+
+    fn arr_f64(vals: &[f64]) -> Array {
+        Array::from_float64(FloatArray::from_slice(vals))
+    }
+
+    // -----------------------------------------------------------------------
+    // Same-type decimal arithmetic through dispatch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal32_add() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec32(&[100, 200, 300], 9, 2),
+            arr_dec32(&[10, 20, 30], 9, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal32(a)) => {
+                assert_eq!(a.data.as_slice(), &[110, 220, 330]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal32 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_subtract() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Subtract,
+            arr_dec64(&[5000, 3000], 18, 4),
+            arr_dec64(&[1000, 2000], 18, 4),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[4000, 1000]);
+                assert_eq!(a.scale, 4);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal128_multiply() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Multiply,
+            arr_dec128(&[1000i128], 38, 2),
+            arr_dec128(&[200i128], 38, 3),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal128(a)) => {
+                assert_eq!(a.data.as_slice(), &[200_000i128]);
+                assert_eq!(a.scale, 5); // 2 + 3
+            }
+            _ => panic!("expected Decimal128 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-scale decimal arithmetic
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_add_different_scale() {
+        // 10.0 (scale=1) + 1.00 (scale=2) = 11.00 (scale=2)
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec64(&[100], 18, 1),
+            arr_dec64(&[100], 18, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[1100]); // 100*10 + 100
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Decimal width promotion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal32_plus_decimal64_widens() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec32(&[100], 9, 2),
+            arr_dec64(&[200], 18, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[300i64]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_plus_decimal128_widens() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec64(&[500], 18, 2),
+            arr_dec128(&[600i128], 38, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal128(a)) => {
+                assert_eq!(a.data.as_slice(), &[1100i128]);
+            }
+            _ => panic!("expected Decimal128 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Integer + Decimal auto-promotion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_int32_plus_decimal32() {
+        // integer 5 + decimal 1.00 (raw=100, scale=2)
+        // integer promoted: 5 * 100 = 500 at scale 2
+        // 500 + 100 = 600 at scale 2 => 6.00
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_i32(&[5]),
+            arr_dec32(&[100], 9, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal32(a)) => {
+                assert_eq!(a.data.as_slice(), &[600]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal32 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_minus_int64() {
+        // decimal 10.00 (raw=1000, scale=2) - integer 3
+        // integer promoted: 3 * 100 = 300 at scale 2
+        // 1000 - 300 = 700 at scale 2 => 7.00
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Subtract,
+            arr_dec64(&[1000], 18, 2),
+            arr_i64(&[3]),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[700]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Float + Decimal auto-promotion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_float64_plus_decimal32() {
+        // 2.5 + 1.00 (raw=100, scale=2) = 3.5
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_f64(&[2.5]),
+            arr_dec32(&[100], 9, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Float64(a)) => {
+                assert!((a.data[0] - 3.5).abs() < 1e-12);
+            }
+            _ => panic!("expected Float64 result, got: {:?}", result),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_times_float64() {
+        // 10.00 (raw=1000, scale=2) * 2.0 = 20.0
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Multiply,
+            arr_dec64(&[1000], 18, 2),
+            arr_f64(&[2.0]),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Float64(a)) => {
+                assert!((a.data[0] - 20.0).abs() < 1e-12);
+            }
+            _ => panic!("expected Float64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Overflow detection through dispatch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_overflow_returns_error() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec32(&[i32::MAX], 9, 0),
+            arr_dec32(&[1], 9, 0),
+            None,
+        );
+        assert!(result.is_err(), "expected overflow error");
+    }
+
+    // -----------------------------------------------------------------------
+    // Broadcasting (length-1 decimal)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_broadcast_scalar() {
+        // [1.00, 2.00, 3.00] + [0.50] => [1.50, 2.50, 3.50]
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec64(&[100, 200, 300], 18, 2),
+            arr_dec64(&[50], 18, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[150, 250, 350]);
+                assert_eq!(a.len(), 3);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Division and remainder
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_divide() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Divide,
+            arr_dec64(&[10000], 18, 2), // 100.00
+            arr_dec64(&[400], 18, 2),   // 4.00
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[2500]); // 25.00
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal_remainder() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Remainder,
+            arr_dec64(&[1000], 18, 2), // 10.00
+            arr_dec64(&[300], 18, 2),  // 3.00
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[100]); // 1.00
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
     }
 }

--- a/src/kernels/routing/arithmetic.rs
+++ b/src/kernels/routing/arithmetic.rs
@@ -193,7 +193,7 @@ pub fn scalar_arithmetic(
         #[cfg(feature = "large_string")]
         (Scalar::String64(l), Scalar::String32(r), Add) => Scalar::String64(format!("{}{}", l, r)),
 
-        // Decimal scalar operations (same width, same scale)
+        // Decimal scalar operations at matching width and scale
         #[cfg(feature = "decimal")]
         (Scalar::Decimal32(l, ls), Scalar::Decimal32(r, rs), Add) if ls == rs => {
             Scalar::Decimal32(l.checked_add(r).ok_or_else(|| MinarrowError::KernelError(
@@ -509,7 +509,7 @@ fn arithmetic_dispatch(
         }
 
         // -----------------------------------------------------------------
-        // Decimal width promotion (narrower widened to wider)
+        // Decimal width promotion, narrower widened to wider
         // -----------------------------------------------------------------
 
         #[cfg(feature = "decimal")]
@@ -570,7 +570,7 @@ fn arithmetic_dispatch(
         }
 
         // -----------------------------------------------------------------
-        // Integer + Decimal auto-promotion (integer promoted to decimal)
+        // Integer + Decimal auto-promotion, integer promoted to decimal
         // -----------------------------------------------------------------
 
         #[cfg(feature = "decimal")]
@@ -661,7 +661,7 @@ fn arithmetic_dispatch(
         }
 
         // -----------------------------------------------------------------
-        // Float + Decimal auto-promotion (decimal demoted to Float64)
+        // Float + Decimal auto-promotion, decimal demoted to Float64
         // -----------------------------------------------------------------
 
         #[cfg(feature = "decimal")]
@@ -745,7 +745,7 @@ fn arithmetic_dispatch(
             )))
         }
 
-        // Float32 + Decimal -> Float64 (promote both to f64)
+        // Float32 + Decimal -> Float64, both promoted to f64
         #[cfg(feature = "decimal")]
         (
             Array::NumericArray(NumericArray::Float32(l)),
@@ -848,37 +848,10 @@ fn arithmetic_dispatch(
 #[cfg(feature = "decimal")]
 mod decimal_dispatch_tests {
     use super::*;
-    use crate::{Array, DecimalArray, FloatArray, IntegerArray, MaskedArray, NumericArray};
-
-    fn arr_dec32(vals: &[i32], p: u8, s: i8) -> Array {
-        Array::NumericArray(NumericArray::Decimal32(
-            DecimalArray::<i32>::from_slice(vals, p, s).into(),
-        ))
-    }
-
-    fn arr_dec64(vals: &[i64], p: u8, s: i8) -> Array {
-        Array::NumericArray(NumericArray::Decimal64(
-            DecimalArray::<i64>::from_slice(vals, p, s).into(),
-        ))
-    }
-
-    fn arr_dec128(vals: &[i128], p: u8, s: i8) -> Array {
-        Array::NumericArray(NumericArray::Decimal128(
-            DecimalArray::<i128>::from_slice(vals, p, s).into(),
-        ))
-    }
-
-    fn arr_i32(vals: &[i32]) -> Array {
-        Array::from_int32(IntegerArray::from_slice(vals))
-    }
-
-    fn arr_i64(vals: &[i64]) -> Array {
-        Array::from_int64(IntegerArray::from_slice(vals))
-    }
-
-    fn arr_f64(vals: &[f64]) -> Array {
-        Array::from_float64(FloatArray::from_slice(vals))
-    }
+    use crate::{
+        arr_dec128, arr_dec32, arr_dec64, arr_f64, arr_i32, arr_i64, Array, DecimalArray,
+        MaskedArray, NumericArray,
+    };
 
     // -----------------------------------------------------------------------
     // Same-type decimal arithmetic through dispatch
@@ -888,8 +861,8 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal32_add() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_dec32(&[100, 200, 300], 9, 2),
-            arr_dec32(&[10, 20, 30], 9, 2),
+            arr_dec32!(&[100, 200, 300], 9, 2),
+            arr_dec32!(&[10, 20, 30], 9, 2),
             None,
         )
         .unwrap();
@@ -907,8 +880,8 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal64_subtract() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Subtract,
-            arr_dec64(&[5000, 3000], 18, 4),
-            arr_dec64(&[1000, 2000], 18, 4),
+            arr_dec64!(&[5000, 3000], 18, 4),
+            arr_dec64!(&[1000, 2000], 18, 4),
             None,
         )
         .unwrap();
@@ -926,8 +899,8 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal128_multiply() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Multiply,
-            arr_dec128(&[1000i128], 38, 2),
-            arr_dec128(&[200i128], 38, 3),
+            arr_dec128!(&[1000i128], 38, 2),
+            arr_dec128!(&[200i128], 38, 3),
             None,
         )
         .unwrap();
@@ -947,11 +920,11 @@ mod decimal_dispatch_tests {
 
     #[test]
     fn dispatch_decimal_add_different_scale() {
-        // 10.0 (scale=1) + 1.00 (scale=2) = 11.00 (scale=2)
+        // 10.0 at scale=1 + 1.00 at scale=2 = 11.00 at scale=2
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_dec64(&[100], 18, 1),
-            arr_dec64(&[100], 18, 2),
+            arr_dec64!(&[100], 18, 1),
+            arr_dec64!(&[100], 18, 2),
             None,
         )
         .unwrap();
@@ -973,8 +946,8 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal32_plus_decimal64_widens() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_dec32(&[100], 9, 2),
-            arr_dec64(&[200], 18, 2),
+            arr_dec32!(&[100], 9, 2),
+            arr_dec64!(&[200], 18, 2),
             None,
         )
         .unwrap();
@@ -992,8 +965,8 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal64_plus_decimal128_widens() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_dec64(&[500], 18, 2),
-            arr_dec128(&[600i128], 38, 2),
+            arr_dec64!(&[500], 18, 2),
+            arr_dec128!(&[600i128], 38, 2),
             None,
         )
         .unwrap();
@@ -1012,13 +985,13 @@ mod decimal_dispatch_tests {
 
     #[test]
     fn dispatch_int32_plus_decimal32() {
-        // integer 5 + decimal 1.00 (raw=100, scale=2)
+        // integer 5 + decimal 1.00, raw=100 at scale=2
         // integer promoted: 5 * 100 = 500 at scale 2
         // 500 + 100 = 600 at scale 2 => 6.00
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_i32(&[5]),
-            arr_dec32(&[100], 9, 2),
+            arr_i32!(&[5]),
+            arr_dec32!(&[100], 9, 2),
             None,
         )
         .unwrap();
@@ -1034,13 +1007,13 @@ mod decimal_dispatch_tests {
 
     #[test]
     fn dispatch_decimal64_minus_int64() {
-        // decimal 10.00 (raw=1000, scale=2) - integer 3
+        // decimal 10.00, raw=1000 at scale=2, minus integer 3
         // integer promoted: 3 * 100 = 300 at scale 2
         // 1000 - 300 = 700 at scale 2 => 7.00
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Subtract,
-            arr_dec64(&[1000], 18, 2),
-            arr_i64(&[3]),
+            arr_dec64!(&[1000], 18, 2),
+            arr_i64!(&[3]),
             None,
         )
         .unwrap();
@@ -1060,11 +1033,11 @@ mod decimal_dispatch_tests {
 
     #[test]
     fn dispatch_float64_plus_decimal32() {
-        // 2.5 + 1.00 (raw=100, scale=2) = 3.5
+        // 2.5 + 1.00 raw=100 at scale=2 = 3.5
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_f64(&[2.5]),
-            arr_dec32(&[100], 9, 2),
+            arr_f64!(&[2.5]),
+            arr_dec32!(&[100], 9, 2),
             None,
         )
         .unwrap();
@@ -1079,11 +1052,11 @@ mod decimal_dispatch_tests {
 
     #[test]
     fn dispatch_decimal64_times_float64() {
-        // 10.00 (raw=1000, scale=2) * 2.0 = 20.0
+        // 10.00 raw=1000 at scale=2 * 2.0 = 20.0
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Multiply,
-            arr_dec64(&[1000], 18, 2),
-            arr_f64(&[2.0]),
+            arr_dec64!(&[1000], 18, 2),
+            arr_f64!(&[2.0]),
             None,
         )
         .unwrap();
@@ -1104,15 +1077,15 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal_overflow_returns_error() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_dec32(&[i32::MAX], 9, 0),
-            arr_dec32(&[1], 9, 0),
+            arr_dec32!(&[i32::MAX], 9, 0),
+            arr_dec32!(&[1], 9, 0),
             None,
         );
         assert!(result.is_err(), "expected overflow error");
     }
 
     // -----------------------------------------------------------------------
-    // Broadcasting (length-1 decimal)
+    // Broadcasting with length-1 decimal
     // -----------------------------------------------------------------------
 
     #[test]
@@ -1120,8 +1093,8 @@ mod decimal_dispatch_tests {
         // [1.00, 2.00, 3.00] + [0.50] => [1.50, 2.50, 3.50]
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Add,
-            arr_dec64(&[100, 200, 300], 18, 2),
-            arr_dec64(&[50], 18, 2),
+            arr_dec64!(&[100, 200, 300], 18, 2),
+            arr_dec64!(&[50], 18, 2),
             None,
         )
         .unwrap();
@@ -1143,8 +1116,8 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal_divide() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Divide,
-            arr_dec64(&[10000], 18, 2), // 100.00
-            arr_dec64(&[400], 18, 2),   // 4.00
+            arr_dec64!(&[10000], 18, 2), // 100.00
+            arr_dec64!(&[400], 18, 2),   // 4.00
             None,
         )
         .unwrap();
@@ -1162,8 +1135,8 @@ mod decimal_dispatch_tests {
     fn dispatch_decimal_remainder() {
         let result = resolve_binary_arithmetic(
             ArithmeticOperator::Remainder,
-            arr_dec64(&[1000], 18, 2), // 10.00
-            arr_dec64(&[300], 18, 2),  // 3.00
+            arr_dec64!(&[1000], 18, 2), // 10.00
+            arr_dec64!(&[300], 18, 2),  // 3.00
             None,
         )
         .unwrap();

--- a/src/kernels/routing/broadcast.rs
+++ b/src/kernels/routing/broadcast.rs
@@ -16,7 +16,7 @@ use crate::enums::error::KernelError;
 #[cfg(feature = "decimal")]
 use crate::DecimalArray;
 use crate::{
-    Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, MaskedArray, NumericArray,
+    Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, NumericArray,
     StringArray, TextArray, Vec64, vec64,
 };
 
@@ -25,68 +25,58 @@ use crate::{
 pub fn broadcast_length_1_array(av: ArrayV, len: usize) -> Result<Array, KernelError> {
     debug_assert_eq!(av.len(), 1, "caller guarantees scalar input");
 
+    let null_mask = match av.array.null_mask() {
+        Some(m) if !m.get(0) => Some(Bitmask::new_set_all(len, false)),
+        _ => None,
+    };
+
     match av.array {
         Array::NumericArray(NumericArray::Int32(a)) => Ok(Array::from_int32(
-            IntegerArray::<i32>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<i32>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::Int64(a)) => Ok(Array::from_int64(
-            IntegerArray::<i64>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<i64>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::UInt32(a)) => Ok(Array::from_uint32(
-            IntegerArray::<u32>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<u32>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::UInt64(a)) => Ok(Array::from_uint64(
-            IntegerArray::<u64>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<u64>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::Float32(a)) => Ok(Array::from_float32(
-            FloatArray::<f32>::from_vec64(vec64![a.data[0]; len], None),
+            FloatArray::<f32>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::Float64(a)) => Ok(Array::from_float64(
-            FloatArray::<f64>::from_vec64(vec64![a.data[0]; len], None),
+            FloatArray::<f64>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
-        Array::BooleanArray(a) => match a.get(0) {
-            Some(v) => {
-                let bitmask = Bitmask::new_set_all(len, v);
-                Ok(Array::BooleanArray(BooleanArray::new(bitmask, None).into()))
-            }
-            None => Err(KernelError::UnsupportedType(
-                "broadcasting null boolean values not supported when no mask is supplied".into(),
-            )),
-        },
+        Array::BooleanArray(a) => {
+            let v = a.data.get(0);
+            let bitmask = Bitmask::new_set_all(len, v);
+            Ok(Array::BooleanArray(BooleanArray::new(bitmask, null_mask).into()))
+        }
         Array::TextArray(TextArray::String32(a)) => {
-            // Get the first string from the array, which should have exactly 1 string
             let s = a.get_str(av.offset).unwrap_or("");
             let strs: Vec64<&str> = std::iter::repeat(s).take(len).collect();
-            Ok(Array::from_string32(StringArray::from_vec64(strs, None)))
+            Ok(Array::from_string32(StringArray::from_vec64(strs, null_mask)))
         }
         #[cfg(feature = "large_string")]
         Array::TextArray(TextArray::String64(a)) => {
-            // Get the first string from the array, which should have exactly 1 string
             let s = a.get_str(av.offset).unwrap_or("");
             let strs: Vec64<&str> = std::iter::repeat(s).take(len).collect();
-            Ok(Array::from_string64(StringArray::from_vec64(strs, None)))
+            Ok(Array::from_string64(StringArray::from_vec64(strs, null_mask)))
         }
         #[cfg(feature = "decimal")]
-        Array::NumericArray(NumericArray::Decimal32(a)) => {
-            let val = a.data[0];
-            Ok(Array::NumericArray(NumericArray::Decimal32(
-                DecimalArray::from_vec64(vec64![val; len], None, a.precision, a.scale).into(),
-            )))
-        }
+        Array::NumericArray(NumericArray::Decimal32(a)) => Ok(Array::from_decimal32(
+            DecimalArray::from_vec64(vec64![a.data[0]; len], null_mask, a.precision, a.scale),
+        )),
         #[cfg(feature = "decimal")]
-        Array::NumericArray(NumericArray::Decimal64(a)) => {
-            let val = a.data[0];
-            Ok(Array::NumericArray(NumericArray::Decimal64(
-                DecimalArray::from_vec64(vec64![val; len], None, a.precision, a.scale).into(),
-            )))
-        }
+        Array::NumericArray(NumericArray::Decimal64(a)) => Ok(Array::from_decimal64(
+            DecimalArray::from_vec64(vec64![a.data[0]; len], null_mask, a.precision, a.scale),
+        )),
         #[cfg(feature = "decimal")]
-        Array::NumericArray(NumericArray::Decimal128(a)) => {
-            let val = a.data[0];
-            Ok(Array::NumericArray(NumericArray::Decimal128(
-                DecimalArray::from_vec64(vec64![val; len], None, a.precision, a.scale).into(),
-            )))
-        }
+        Array::NumericArray(NumericArray::Decimal128(a)) => Ok(Array::from_decimal128(
+            DecimalArray::from_vec64(vec64![a.data[0]; len], null_mask, a.precision, a.scale),
+        )),
         _ => {
             return Err(KernelError::UnsupportedType(
                 "broadcast not yet implemented for this array variant".into(),

--- a/src/kernels/routing/broadcast.rs
+++ b/src/kernels/routing/broadcast.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use crate::enums::error::KernelError;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 use crate::{
     Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, MaskedArray, NumericArray,
     StringArray, TextArray, Vec64, vec64,
@@ -63,6 +65,27 @@ pub fn broadcast_length_1_array(av: ArrayV, len: usize) -> Result<Array, KernelE
             let s = a.get_str(av.offset).unwrap_or("");
             let strs: Vec64<&str> = std::iter::repeat(s).take(len).collect();
             Ok(Array::from_string64(StringArray::from_vec64(strs, None)))
+        }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal32(a)) => {
+            let val = a.data[0];
+            Ok(Array::NumericArray(NumericArray::Decimal32(
+                DecimalArray::from_vec64(vec64![val; len], None, a.precision, a.scale).into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal64(a)) => {
+            let val = a.data[0];
+            Ok(Array::NumericArray(NumericArray::Decimal64(
+                DecimalArray::from_vec64(vec64![val; len], None, a.precision, a.scale).into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal128(a)) => {
+            let val = a.data[0];
+            Ok(Array::NumericArray(NumericArray::Decimal128(
+                DecimalArray::from_vec64(vec64![val; len], None, a.precision, a.scale).into(),
+            )))
         }
         _ => {
             return Err(KernelError::UnsupportedType(


### PR DESCRIPTION
## Summary
- New `src/kernels/arithmetic/decimal.rs` module with checked binary ops (add, subtract, multiply, divide, remainder), unary ops (negate, abs), rescale, and comparison kernels
- Decimal dispatch arms in `arithmetic_dispatch` and `scalar_arithmetic` for all three widths
- Cross-scale reconciliation: different-scale operands rescale to the finer scale before computing
- Auto-promotion: integer+decimal promotes to decimal, float+decimal promotes to Float64, mixed-width decimals widen to the wider type
- Overflow detection returns `MinarrowError` via new `KernelError::Overflow` variant
- Division by zero produces null (consistent with float division semantics)
- 39 tests covering same-scale, cross-scale, width promotion, auto-promotion, overflow, null propagation

## Test plan
- [x] `cargo test --features decimal` passes (814 tests)
- [x] `cargo test --all-features` passes (1711 tests)
- [x] `cargo test` without decimal passes (no regression)