### PR TITLE
Integrate DecimalArray into Value, Views, SuperArray, and Consolidate

### DIFF
--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -46,6 +46,8 @@
 
 #[cfg(feature = "datetime")]
 use crate::DatetimeArray;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 #[cfg(all(feature = "cube", feature = "views"))]
 use crate::TableV;
 use crate::{
@@ -244,6 +246,10 @@ pub type IntegerAVT<'a, T> = (&'a IntegerArray<T>, Offset, Length);
 
 /// Logical windowed ***A**rray **V**iew **T**uple* over a primitive float array.
 pub type FloatAVT<'a, T> = (&'a FloatArray<T>, Offset, Length);
+
+/// Logical windowed ***A**rray **V**iew **T**uple* over a decimal array.
+#[cfg(feature = "decimal")]
+pub type DecimalAVT<'a, T> = (&'a DecimalArray<T>, Offset, Length);
 
 /// Logical windowed ***A**rray **V**iew **T**uple* over an `Array` and its `Field`: *((array, offset, len), field)*.
 ///

--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -41,6 +41,8 @@ use crate::ArrayV;
 use crate::ArrayVT;
 #[cfg(feature = "datetime")]
 use crate::DatetimeArray;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 #[cfg(feature = "chunked")]
 use crate::SuperArray;
 #[cfg(feature = "datetime")]
@@ -1472,6 +1474,12 @@ impl Array {
         match_arm!(NumericArray, UInt64, IntegerArray<u64>);
         match_arm!(NumericArray, Float32, FloatArray<f32>);
         match_arm!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal128, DecimalArray<i128>);
 
         // TextArray
         match_arm!(TextArray, String32, StringArray<u32>);
@@ -1546,6 +1554,12 @@ impl Array {
         match_arm!(NumericArray, UInt64, IntegerArray<u64>);
         match_arm!(NumericArray, Float32, FloatArray<f32>);
         match_arm!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal128, DecimalArray<i128>);
 
         // TextArray
         match_arm!(TextArray, String32, StringArray<u32>);
@@ -1619,6 +1633,12 @@ impl Array {
         match_inner_type!(NumericArray, UInt64, IntegerArray<u64>);
         match_inner_type!(NumericArray, Float32, FloatArray<f32>);
         match_inner_type!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_inner_type!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type!(NumericArray, Decimal128, DecimalArray<i128>);
 
         match_inner_type!(TextArray, String32, StringArray<u32>);
         #[cfg(feature = "large_string")]
@@ -1686,6 +1706,12 @@ impl Array {
         match_inner_type_mut!(NumericArray, UInt64, IntegerArray<u64>);
         match_inner_type_mut!(NumericArray, Float32, FloatArray<f32>);
         match_inner_type_mut!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type_mut!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_inner_type_mut!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type_mut!(NumericArray, Decimal128, DecimalArray<i128>);
 
         match_inner_type_mut!(TextArray, String32, StringArray<u32>);
         #[cfg(feature = "large_string")]

--- a/src/enums/value/mod.rs
+++ b/src/enums/value/mod.rs
@@ -562,4 +562,55 @@ mod tests {
             assert_eq!(table.n_cols(), 2);
         }
     }
+
+    /// Decimal arrays flow through Value::Array and Value::ArrayView
+    /// correctly. The Value enum wraps Arc<Array>, so decimal support is
+    /// inherited from the Array and NumericArray enums.
+    #[cfg(feature = "decimal")]
+    mod decimal_value_tests {
+        use super::*;
+
+        fn decimal_array(n: usize) -> Array {
+            let vals: Vec<i32> = (0..n as i32).map(|i| i * 100).collect();
+            Array::from_decimal32(crate::DecimalArray::from_slice(&vals, 10, 2))
+        }
+
+        #[test]
+        fn decimal_len_counts_correctly() {
+            let value = Value::Array(Arc::new(decimal_array(5)));
+            assert_eq!(value.len(), 5);
+        }
+
+        #[cfg(feature = "views")]
+        #[test]
+        fn decimal_slice_returns_array_view() {
+            let value = Value::Array(Arc::new(decimal_array(10)));
+            let sliced = value.slice(3, 4);
+
+            if let Value::ArrayView(av) = &sliced {
+                assert_eq!(av.len(), 4);
+                assert_eq!(av.offset, 3);
+            } else {
+                panic!("Expected Value::ArrayView");
+            }
+            assert_eq!(sliced.len(), 4);
+        }
+
+        #[cfg(feature = "views")]
+        #[test]
+        fn decimal_view_re_slices() {
+            let value = Value::Array(Arc::new(decimal_array(10)));
+            let view = value.slice(2, 6);
+            let sub = view.slice(1, 3);
+            assert_eq!(sub.len(), 3);
+        }
+
+        #[test]
+        fn decimal_round_trips_through_value() {
+            let arr = decimal_array(3);
+            let value = Value::Array(Arc::new(arr.clone()));
+            let extracted = Array::try_from(value).unwrap();
+            assert_eq!(extracted, arr);
+        }
+    }
 }

--- a/src/structs/chunked/super_array.rs
+++ b/src/structs/chunked/super_array.rs
@@ -1838,4 +1838,92 @@ mod tests {
             _ => panic!("expected U32 dispatch"),
         }
     }
+
+    #[cfg(feature = "decimal")]
+    mod decimal_super_array_tests {
+        use super::*;
+        use crate::ffi::arrow_dtype::ArrowType;
+
+        fn decimal_array(vals: &[i32], precision: u8, scale: i8) -> Array {
+            Array::from_decimal32(crate::DecimalArray::from_slice(vals, precision, scale))
+        }
+
+        fn decimal_fa(name: &str, vals: &[i32], precision: u8, scale: i8) -> FieldArray {
+            let arr = decimal_array(vals, precision, scale);
+            let field = Field::new(name, ArrowType::Decimal32(precision, scale), false, None);
+            FieldArray::new(field, arr)
+        }
+
+        #[test]
+        fn push_and_type_validation() {
+            let mut sa = SuperArray::new();
+            sa.push(decimal_array(&[10, 20, 30], 10, 2));
+            assert_eq!(sa.n_chunks(), 1);
+            assert_eq!(sa.len(), 3);
+            sa.push(decimal_array(&[40, 50], 10, 2));
+            assert_eq!(sa.n_chunks(), 2);
+            assert_eq!(sa.len(), 5);
+        }
+
+        #[test]
+        #[should_panic(expected = "Chunk ArrowType mismatch")]
+        fn push_mismatched_scale_panics() {
+            let mut sa = SuperArray::new();
+            sa.push(decimal_array(&[10], 10, 2));
+            sa.push(decimal_array(&[20], 10, 3)); // different scale
+        }
+
+        #[test]
+        fn consolidate_decimal_chunks() {
+            let fa1 = decimal_fa("d", &[10, 20], 10, 2);
+            let fa2 = decimal_fa("d", &[30, 40, 50], 10, 2);
+            let sa = SuperArray::from_chunks(vec![fa1, fa2]);
+
+            let result = sa.consolidate();
+            assert_eq!(result.len(), 5);
+            if let Array::NumericArray(NumericArray::Decimal32(dec)) = result {
+                assert_eq!(dec.data.as_slice(), &[10, 20, 30, 40, 50]);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+            } else {
+                panic!("Expected Decimal32 Array");
+            }
+        }
+
+        #[cfg(feature = "views")]
+        #[test]
+        fn slice_and_consolidate() {
+            let fa1 = decimal_fa("d", &[10, 20, 30], 10, 2);
+            let fa2 = decimal_fa("d", &[40, 50], 10, 2);
+            let sa = SuperArray::from_chunks(vec![fa1, fa2]);
+            let view = sa.slice(2, 3); // [30, 40, 50]
+            let result = view.consolidate();
+
+            assert_eq!(result.len(), 3);
+            if let Array::NumericArray(NumericArray::Decimal32(dec)) = result {
+                assert_eq!(dec.data.as_slice(), &[30, 40, 50]);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+            } else {
+                panic!("Expected Decimal32 Array");
+            }
+        }
+
+        #[test]
+        fn concat_super_arrays() {
+            let sa1 = SuperArray::from_arrays(vec![decimal_array(&[10, 20], 10, 2)]);
+            let sa2 = SuperArray::from_arrays(vec![decimal_array(&[30], 10, 2)]);
+            let result = sa1.concat(sa2).unwrap();
+            assert_eq!(result.n_chunks(), 2);
+            assert_eq!(result.len(), 3);
+        }
+
+        #[test]
+        fn concat_mismatched_type_errors() {
+            let sa1 = SuperArray::from_arrays(vec![decimal_array(&[10], 10, 2)]);
+            let sa2 = SuperArray::from_arrays(vec![int_array(&[20])]);
+            let result = sa1.concat(sa2);
+            assert!(result.is_err());
+        }
+    }
 }

--- a/src/structs/variants/decimal.rs
+++ b/src/structs/variants/decimal.rs
@@ -775,6 +775,69 @@ impl<T: Integer> Concatenate for DecimalArray<T> {
 }
 
 // ---------------------------------------------------------------------------
+// Consolidate - merges view windows into a contiguous DecimalArray
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "chunked")]
+impl<'a, T: Integer> crate::traits::consolidate::Consolidate
+    for Vec<crate::aliases::DecimalAVT<'a, T>>
+{
+    type Output = DecimalArray<T>;
+
+    /// Consolidate a vector of `(DecimalArray<T>, offset, len)` view tuples
+    /// into one contiguous `DecimalArray<T>`. Reads each window from the
+    /// source buffer with no intermediate copy. Precision and scale are
+    /// taken from the first chunk and validated against all subsequent chunks.
+    fn consolidate(self) -> DecimalArray<T> {
+        use crate::traits::masked_array::MaskedArray;
+
+        assert!(
+            !self.is_empty(),
+            "consolidate() called on empty Vec<DecimalAVT>"
+        );
+
+        let (first, _, _) = &self[0];
+        let precision = first.precision;
+        let scale = first.scale;
+
+        let total_len: usize = self.iter().map(|(_, _, len)| *len).sum();
+        let has_nulls = self.iter().any(|(arr, _, _)| arr.null_mask.is_some());
+
+        let mut result = DecimalArray::<T>::with_capacity(total_len, false, precision, scale);
+        let mut result_mask: Option<Bitmask> = if has_nulls {
+            Some(Bitmask::new_set_all(0, false))
+        } else {
+            None
+        };
+
+        for (arr, offset, len) in &self {
+            debug_assert_eq!(
+                arr.precision, precision,
+                "DecimalArray consolidate: precision mismatch across chunks"
+            );
+            debug_assert_eq!(
+                arr.scale, scale,
+                "DecimalArray consolidate: scale mismatch across chunks"
+            );
+            let data: &[T] = &arr.data[*offset..*offset + *len];
+            result.data.extend_from_slice(data);
+
+            if let Some(ref mut mask) = result_mask {
+                match arr.null_mask() {
+                    Some(src) => mask.extend_from_bitmask_range(src, *offset, *len),
+                    None => mask.push_bits(true, *len),
+                }
+            }
+        }
+
+        if let Some(mask) = result_mask {
+            result.set_null_mask(Some(mask));
+        }
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Widening conversions (lossless)
 // ---------------------------------------------------------------------------
 
@@ -1616,5 +1679,106 @@ mod tests {
         arc_arr.push(40);
         assert_eq!(arc_arr.len(), 4);
         assert_eq!(arc_arr.get(3), Some(40));
+    }
+
+    // -----------------------------------------------------------------------
+    // Consolidate view tuples
+    // -----------------------------------------------------------------------
+
+    #[cfg(feature = "chunked")]
+    mod consolidate_tests {
+        use super::*;
+        use crate::traits::consolidate::Consolidate;
+
+        #[test]
+        fn consolidate_single_full_window() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30], 10, 2);
+            let views = vec![(&arr, 0, 3)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 3);
+            assert_eq!(result.precision, 10);
+            assert_eq!(result.scale, 2);
+            assert_eq!(result.get(0), Some(10));
+            assert_eq!(result.get(1), Some(20));
+            assert_eq!(result.get(2), Some(30));
+        }
+
+        #[test]
+        fn consolidate_windowed_offset() {
+            let arr = DecimalArray::<i64>::from_slice(&[100, 200, 300, 400, 500], 18, 4);
+            let views = vec![(&arr, 1, 3)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 3);
+            assert_eq!(result.precision, 18);
+            assert_eq!(result.scale, 4);
+            assert_eq!(result.get(0), Some(200));
+            assert_eq!(result.get(1), Some(300));
+            assert_eq!(result.get(2), Some(400));
+        }
+
+        #[test]
+        fn consolidate_multiple_windows() {
+            let arr1 = DecimalArray::<i32>::from_slice(&[10, 20, 30], 10, 2);
+            let arr2 = DecimalArray::<i32>::from_slice(&[40, 50], 10, 2);
+            let views = vec![(&arr1, 0, 3), (&arr2, 0, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 5);
+            assert_eq!(result.precision, 10);
+            assert_eq!(result.scale, 2);
+            assert_eq!(result.get(0), Some(10));
+            assert_eq!(result.get(4), Some(50));
+        }
+
+        #[test]
+        fn consolidate_with_null_mask_propagation() {
+            let mut arr1 = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+            arr1.push(10);
+            arr1.push_null();
+            arr1.push(30);
+
+            let arr2 = DecimalArray::<i32>::from_slice(&[40, 50], 10, 2);
+
+            let views = vec![(&arr1, 0, 3), (&arr2, 0, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 5);
+            assert_eq!(result.get(0), Some(10));
+            assert_eq!(result.get(1), None);
+            assert_eq!(result.get(2), Some(30));
+            assert_eq!(result.get(3), Some(40));
+            assert_eq!(result.get(4), Some(50));
+            assert_eq!(result.null_count(), 1);
+        }
+
+        #[test]
+        fn consolidate_decimal128() {
+            let arr = DecimalArray::<i128>::from_slice(&[100, 200, 300], 38, 10);
+            let views = vec![(&arr, 1, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 2);
+            assert_eq!(result.precision, 38);
+            assert_eq!(result.scale, 10);
+            assert_eq!(result.get(0), Some(200i128));
+            assert_eq!(result.get(1), Some(300i128));
+        }
+
+        #[test]
+        fn consolidate_cross_chunk_with_nulls_in_both() {
+            let mut arr1 = DecimalArray::<i64>::with_capacity(2, true, 18, 6);
+            arr1.push(100);
+            arr1.push_null();
+
+            let mut arr2 = DecimalArray::<i64>::with_capacity(2, true, 18, 6);
+            arr2.push_null();
+            arr2.push(400);
+
+            let views = vec![(&arr1, 0, 2), (&arr2, 0, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 4);
+            assert_eq!(result.get(0), Some(100));
+            assert_eq!(result.get(1), None);
+            assert_eq!(result.get(2), None);
+            assert_eq!(result.get(3), Some(400));
+            assert_eq!(result.null_count(), 2);
+        }
     }
 }

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -1715,4 +1715,123 @@ mod tests {
         let empty = view.gather_mask(&Bitmask::new_set_all(4, false));
         assert_eq!(empty.len(), 0);
     }
+
+    // Decimal ArrayV Tests
+
+    #[cfg(feature = "decimal")]
+    mod decimal_view_tests {
+        use super::*;
+        use crate::{DecimalArray, MaskedArray, NumericArray};
+
+        #[test]
+        fn decimal32_view_windowing_and_slice() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 2);
+            let array = Array::from_decimal32(arr);
+            let view = ArrayV::new(array, 1, 3);
+
+            assert_eq!(view.len(), 3);
+            assert_eq!(view.offset, 1);
+            assert_eq!(view.get::<DecimalArray<i32>>(0), Some(20));
+            assert_eq!(view.get::<DecimalArray<i32>>(1), Some(30));
+            assert_eq!(view.get::<DecimalArray<i32>>(2), Some(40));
+            assert_eq!(view.get::<DecimalArray<i32>>(3), None);
+
+            let sub = view.slice(1, 1);
+            assert_eq!(sub.len(), 1);
+            assert_eq!(sub.get::<DecimalArray<i32>>(0), Some(30));
+        }
+
+        #[test]
+        fn decimal64_view_null_count() {
+            let mut arr = DecimalArray::<i64>::with_capacity(4, true, 18, 4);
+            arr.push(100);
+            arr.push_null();
+            arr.push(300);
+            arr.push(400);
+
+            let array = Array::from_decimal64(arr);
+            let view = ArrayV::new(array, 0, 4);
+            assert_eq!(view.null_count(), 1);
+
+            let sub = view.slice(0, 1);
+            assert_eq!(sub.null_count(), 0);
+
+            let sub_with_null = view.slice(1, 1);
+            assert_eq!(sub_with_null.null_count(), 1);
+        }
+
+        #[test]
+        fn decimal128_view_to_array_preserves_metadata() {
+            let arr = DecimalArray::<i128>::from_slice(&[100, 200, 300], 38, 10);
+            let array = Array::from_decimal128(arr);
+            let view = ArrayV::new(array, 1, 2);
+            let materialised = view.to_array();
+
+            if let Array::NumericArray(NumericArray::Decimal128(dec)) = materialised {
+                assert_eq!(dec.len(), 2);
+                assert_eq!(dec.precision, 38);
+                assert_eq!(dec.scale, 10);
+                assert_eq!(dec.get(0), Some(200i128));
+                assert_eq!(dec.get(1), Some(300i128));
+            } else {
+                panic!("Expected Decimal128 Array");
+            }
+        }
+
+        #[test]
+        fn decimal_view_from_array_spans_backing() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20], 10, 2);
+            let array = Array::from_decimal32(arr);
+            let view = ArrayV::from(array);
+            assert!(view.spans_backing());
+            assert_eq!(view.len(), 2);
+        }
+
+        #[cfg(feature = "select")]
+        #[test]
+        fn decimal_gather_indices() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 2);
+            let array = Array::from_decimal32(arr);
+            let view = ArrayV::new(array, 0, 5);
+
+            let gathered = view.gather_indices(&[4, 2, 0]);
+            if let Array::NumericArray(NumericArray::Decimal32(dec)) = gathered {
+                assert_eq!(dec.data.as_slice(), &[50, 30, 10]);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+            } else {
+                panic!("Expected Decimal32 Array");
+            }
+        }
+
+        #[cfg(feature = "select")]
+        #[test]
+        fn decimal_gather_mask_with_nulls() {
+            let mut arr = DecimalArray::<i64>::with_capacity(4, true, 18, 4);
+            arr.push(10);
+            arr.push_null();
+            arr.push(30);
+            arr.push(40);
+
+            let array = Array::from_decimal64(arr);
+            let view = ArrayV::new(array, 0, 4);
+
+            let mut mask = Bitmask::new_set_all(4, false);
+            mask.set(0, true);
+            mask.set(1, true);
+            mask.set(3, true);
+
+            let result = view.gather_mask(&mask);
+            if let Array::NumericArray(NumericArray::Decimal64(dec)) = result {
+                assert_eq!(dec.len(), 3);
+                assert_eq!(dec.get(0), Some(10));
+                assert_eq!(dec.get(1), None);
+                assert_eq!(dec.get(2), Some(40));
+                assert_eq!(dec.precision, 18);
+                assert_eq!(dec.scale, 4);
+            } else {
+                panic!("Expected Decimal64 Array");
+            }
+        }
+    }
 }

--- a/src/structs/views/chunked/super_array_view.rs
+++ b/src/structs/views/chunked/super_array_view.rs
@@ -960,6 +960,192 @@ mod tests {
             panic!("Expected Categorical32 Array");
         }
     }
+
+    // Decimal Array Consolidation Tests
+
+    #[cfg(feature = "decimal")]
+    fn fa_decimal32(name: &str, vals: &[i32], precision: u8, scale: i8) -> FieldArray {
+        let arr = Array::from_decimal32(crate::DecimalArray::from_slice(vals, precision, scale));
+        let field = Field::new(
+            name,
+            ArrowType::Decimal32(precision, scale),
+            false,
+            None,
+        );
+        FieldArray::new(field, arr)
+    }
+
+    #[cfg(feature = "decimal")]
+    fn fa_decimal64(name: &str, vals: &[i64], precision: u8, scale: i8) -> FieldArray {
+        let arr = Array::from_decimal64(crate::DecimalArray::from_slice(vals, precision, scale));
+        let field = Field::new(
+            name,
+            ArrowType::Decimal64(precision, scale),
+            false,
+            None,
+        );
+        FieldArray::new(field, arr)
+    }
+
+    #[cfg(feature = "decimal")]
+    fn fa_decimal128(name: &str, vals: &[i128], precision: u8, scale: i8) -> FieldArray {
+        let arr = Array::from_decimal128(crate::DecimalArray::from_slice(vals, precision, scale));
+        let field = Field::new(
+            name,
+            ArrowType::Decimal128(precision, scale),
+            false,
+            None,
+        );
+        FieldArray::new(field, arr)
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_single_chunk() {
+        let fa1 = fa_decimal32("d", &[10, 20, 30, 40], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1]);
+        let slice = ca.slice(0, 4);
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 4);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[10, 20, 30, 40]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_multiple_chunks() {
+        let fa1 = fa_decimal32("d", &[10, 20], 10, 2);
+        let fa2 = fa_decimal32("d", &[30, 40, 50], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(0, 5);
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 5);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[10, 20, 30, 40, 50]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_with_offset() {
+        let fa1 = fa_decimal32("d", &[100, 200, 300, 400, 500], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1]);
+        let slice = ca.slice(1, 3); // [200, 300, 400]
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 3);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[200, 300, 400]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_cross_chunk_slice() {
+        let fa1 = fa_decimal32("d", &[10, 20], 10, 2);
+        let fa2 = fa_decimal32("d", &[30, 40], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(1, 2); // [20, 30] spanning chunks
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 2);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[20, 30]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal64_multiple_chunks() {
+        let fa1 = fa_decimal64("d", &[1000i64, 2000], 18, 4);
+        let fa2 = fa_decimal64("d", &[3000i64], 18, 4);
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(0, 3);
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 3);
+        if let Array::NumericArray(NumericArray::Decimal64(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[1000i64, 2000, 3000]);
+            assert_eq!(dec.precision, 18);
+            assert_eq!(dec.scale, 4);
+        } else {
+            panic!("Expected Decimal64 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal128_with_offset() {
+        let fa1 = fa_decimal128("d", &[10i128, 20, 30, 40, 50], 38, 10);
+        let ca = SuperArray::from_chunks(vec![fa1]);
+        let slice = ca.slice(2, 2); // [30, 40]
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 2);
+        if let Array::NumericArray(NumericArray::Decimal128(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[30i128, 40]);
+            assert_eq!(dec.precision, 38);
+            assert_eq!(dec.scale, 10);
+        } else {
+            panic!("Expected Decimal128 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal_with_nulls() {
+        use crate::MaskedArray;
+
+        let mut dec_arr = crate::DecimalArray::<i32>::with_capacity(4, true, 10, 2);
+        dec_arr.push(10);
+        dec_arr.push_null();
+        dec_arr.push(30);
+        dec_arr.push(40);
+        let arr1 = Array::from_decimal32(dec_arr);
+        let field = Field::new("d", ArrowType::Decimal32(10, 2), true, None);
+        let fa1 = FieldArray::new(field.clone(), arr1);
+
+        let arr2 = Array::from_decimal32(
+            crate::DecimalArray::<i32>::from_slice(&[50, 60], 10, 2),
+        );
+        let fa2 = FieldArray::new(field.clone(), arr2);
+
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(0, 6);
+        let result = slice.consolidate();
+
+        assert_eq!(result.len(), 6);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = result {
+            assert_eq!(dec.get(0), Some(10));
+            assert_eq!(dec.get(1), None);
+            assert_eq!(dec.get(2), Some(30));
+            assert_eq!(dec.get(3), Some(40));
+            assert_eq!(dec.get(4), Some(50));
+            assert_eq!(dec.get(5), Some(60));
+            assert_eq!(dec.null_count(), 1);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
 }
 
 /// SuperArray -> SuperArrayV conversion

--- a/src/structs/views/collections/numeric_array_view.rs
+++ b/src/structs/views/collections/numeric_array_view.rs
@@ -713,4 +713,113 @@ mod tests {
             _ => panic!("expected Int32 variant"),
         }
     }
+
+    // Decimal NumericArrayV Tests
+
+    #[cfg(feature = "decimal")]
+    mod decimal_view_tests {
+        use super::*;
+        use crate::DecimalArray;
+
+        #[test]
+        fn decimal32_view_get_f64() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 2);
+            let numeric = NumericArray::Decimal32(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 1, 3);
+
+            assert_eq!(view.len(), 3);
+            assert_eq!(view.get_f64(0), Some(20.0));
+            assert_eq!(view.get_f64(1), Some(30.0));
+            assert_eq!(view.get_f64(2), Some(40.0));
+            assert_eq!(view.get_f64(3), None);
+        }
+
+        #[test]
+        fn decimal64_view_slice() {
+            let arr = DecimalArray::<i64>::from_slice(&[100, 200, 300, 400], 18, 4);
+            let numeric = NumericArray::Decimal64(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 0, 4);
+            let sub = view.slice(1, 2);
+
+            assert_eq!(sub.len(), 2);
+            assert_eq!(sub.get_f64(0), Some(200.0));
+            assert_eq!(sub.get_f64(1), Some(300.0));
+        }
+
+        #[test]
+        fn decimal128_view_null_count() {
+            let mut arr = DecimalArray::<i128>::with_capacity(4, true, 38, 10);
+            arr.push(10);
+            arr.push_null();
+            arr.push(30);
+            arr.push(40);
+
+            let numeric = NumericArray::Decimal128(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 0, 4);
+            assert_eq!(view.null_count(), 1);
+            assert!(view.has_nulls());
+
+            let no_null_view = view.slice(2, 2);
+            assert_eq!(no_null_view.null_count(), 0);
+            assert!(!no_null_view.has_nulls());
+        }
+
+        #[test]
+        fn decimal_view_to_numeric_array_preserves_metadata() {
+            let arr = DecimalArray::<i32>::from_slice(&[100, 200, 300, 400], 10, 2);
+            let numeric = NumericArray::Decimal32(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 1, 2);
+            let materialised = view.to_numeric_array();
+
+            if let NumericArray::Decimal32(dec) = materialised {
+                assert_eq!(dec.len(), 2);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+                assert_eq!(dec.get(0), Some(200));
+                assert_eq!(dec.get(1), Some(300));
+            } else {
+                panic!("Expected Decimal32 variant");
+            }
+        }
+
+        #[test]
+        fn decimal_view_from_numeric_array() {
+            let arr = DecimalArray::<i64>::from_slice(&[10, 20], 18, 6);
+            let numeric = NumericArray::Decimal64(Arc::new(arr));
+            let view = NumericArrayV::from(numeric);
+            assert_eq!(view.len(), 2);
+            assert_eq!(view.offset, 0);
+            assert_eq!(view.get_f64(0), Some(10.0));
+            assert_eq!(view.get_f64(1), Some(20.0));
+        }
+
+        #[test]
+        fn decimal_view_from_array_v() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40], 10, 2);
+            let array = crate::Array::from_decimal32(arr);
+            let array_v = crate::ArrayV::new(array, 1, 2);
+            let numeric_v = NumericArrayV::from(array_v);
+
+            assert_eq!(numeric_v.len(), 2);
+            assert_eq!(numeric_v.offset, 1);
+            assert_eq!(numeric_v.get_f64(0), Some(20.0));
+            assert_eq!(numeric_v.get_f64(1), Some(30.0));
+        }
+
+        #[test]
+        fn decimal_view_null_mask_view() {
+            let mut arr = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+            arr.push(10);
+            arr.push_null();
+            arr.push(30);
+
+            let numeric = NumericArray::Decimal32(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 0, 3);
+            let mask = view.null_mask_view().expect("should have null mask");
+            assert_eq!(mask.len(), 3);
+            assert!(mask.get(0));
+            assert!(!mask.get(1));
+            assert!(mask.get(2));
+        }
+    }
 }

--- a/src/traits/consolidate.rs
+++ b/src/traits/consolidate.rs
@@ -200,6 +200,20 @@ impl<'a> Consolidate for Vec<crate::aliases::ArrayVT<'a>> {
             }};
         }
 
+        #[cfg(feature = "decimal")]
+        macro_rules! gather_decimal {
+            ($variant:ident, $T:ty) => {{
+                let views: Vec<crate::aliases::DecimalAVT<'a, $T>> = self
+                    .iter()
+                    .map(|(arr, off, len)| match arr {
+                        Array::NumericArray(NumericArray::$variant(a)) => (a.as_ref(), *off, *len),
+                        _ => panic!("inconsistent NumericArray variants in chunk vector"),
+                    })
+                    .collect();
+                Array::NumericArray(NumericArray::$variant(Arc::new(views.consolidate())))
+            }};
+        }
+
         match self[0].0 {
             Array::NumericArray(NumericArray::Int32(_)) => gather_numeric!(Int32, i32),
             Array::NumericArray(NumericArray::Int64(_)) => gather_numeric!(Int64, i64),
@@ -217,15 +231,15 @@ impl<'a> Consolidate for Vec<crate::aliases::ArrayVT<'a>> {
             Array::NumericArray(NumericArray::UInt16(_)) => gather_numeric!(UInt16, u16),
             #[cfg(feature = "decimal")]
             Array::NumericArray(NumericArray::Decimal32(_)) => {
-                panic!("Consolidate is not yet implemented for DecimalArray")
+                gather_decimal!(Decimal32, i32)
             }
             #[cfg(feature = "decimal")]
             Array::NumericArray(NumericArray::Decimal64(_)) => {
-                panic!("Consolidate is not yet implemented for DecimalArray")
+                gather_decimal!(Decimal64, i64)
             }
             #[cfg(feature = "decimal")]
             Array::NumericArray(NumericArray::Decimal128(_)) => {
-                panic!("Consolidate is not yet implemented for DecimalArray")
+                gather_decimal!(Decimal128, i128)
             }
             Array::NumericArray(NumericArray::Null) => Array::Null,
 


### PR DESCRIPTION
## Summary
- Adds `DecimalAVT` type alias for decimal view tuples
- Adds `Array::inner` typed access arms for decimal variants
- Implements `Consolidate` for `Vec<DecimalAVT>` with precision/scale validation and null mask propagation
- Replaces Consolidate panic placeholders with working `gather_decimal!` macro dispatch
- Comprehensive tests across Value, ArrayV, NumericArrayV, SuperArray, and SuperArrayV (766 lines added)

## Adjacent finding
A pre-existing bug was identified in `Bitmask::extend` (double-increments `self.len`) - not introduced by this PR, documented on the ticket for separate consideration.

## Test plan
- [x] `cargo test --features "decimal,views,chunked,value_type,scalar_type"` passes (892 tests)
- [x] `cargo test` without decimal passes (no regression)