### PR TITLE
Add decimal support to pyo3 and minarrow-py Python bridges

### DIFF
--- a/minarrow-py/Cargo.lock
+++ b/minarrow-py/Cargo.lock
@@ -197,6 +197,6 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vec64"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5a35bf381f20a9d41312bd977f43e997ab5bc82deb85b503b3346e6a437b7"
+checksum = "1aef6bbef159f21ac387220ebc71141524423f7886afd390bc7b140f12630425"

--- a/minarrow-py/Cargo.toml
+++ b/minarrow-py/Cargo.toml
@@ -25,7 +25,7 @@ pyo3 = { version = "0.29", features = ["abi3-py39"] }
 thiserror = "2"
 
 [features]
-default = ["datetime", "large_string", "matrix", "scalar_type", "value_type", "cube", "arrow_interop", "ndarray"]
+default = ["datetime", "large_string", "matrix", "scalar_type", "value_type", "cube", "arrow_interop", "ndarray", "decimal"]
 extension-module = ["pyo3/extension-module"]
 arrow_interop = ["dep:minarrow-pyo3", "minarrow-pyo3/datetime"]
 simd = ["minarrow/simd"]
@@ -47,6 +47,7 @@ ndarray = [
 # Links libpython - use the default non `extension-module` link mode and
 # it should not be combined with `extension-module`.
 embed = ["arrow_interop", "scalar_type", "value_type", "simd"]
+decimal = ["minarrow/decimal", "minarrow-pyo3?/decimal"]
 datetime = ["minarrow/datetime"]
 extended_numeric_types = ["minarrow/extended_numeric_types", "minarrow-pyo3?/extended_numeric_types"]
 large_string = ["minarrow/large_string"]

--- a/minarrow-py/src/array.rs
+++ b/minarrow-py/src/array.rs
@@ -114,24 +114,50 @@ impl PyArrayInner {
         }
     }
 
-    /// The decimal precision, or `None` for non-decimal arrays.
-    #[cfg(feature = "decimal")]
-    pub fn precision(&self) -> Option<u8> {
+    /// Maximum number of significant decimal digits this array can represent.
+    pub fn precision(&self) -> u8 {
         match self.arrow_dtype() {
-            ArrowType::Decimal32(p, _)
-            | ArrowType::Decimal64(p, _)
-            | ArrowType::Decimal128(p, _) => Some(p),
-            _ => None,
+            ArrowType::Int32 => 10,
+            ArrowType::Int64 => 19,
+            ArrowType::UInt32 => 10,
+            ArrowType::UInt64 => 20,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::Int8 => 3,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::Int16 => 5,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::UInt8 => 3,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::UInt16 => 5,
+            ArrowType::Float32 => 7,
+            ArrowType::Float64 => 15,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(p, _) => p,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, _) => p,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, _) => p,
+            _ => 0,
         }
     }
 
-    /// The decimal scale, or `None` for non-decimal arrays.
-    #[cfg(feature = "decimal")]
+    /// Number of digits after the decimal point. Zero for integer types.
+    /// Floats return `None` because scale varies per value. Non-numeric
+    /// types also return `None`.
     pub fn scale(&self) -> Option<i8> {
         match self.arrow_dtype() {
-            ArrowType::Decimal32(_, s)
-            | ArrowType::Decimal64(_, s)
-            | ArrowType::Decimal128(_, s) => Some(s),
+            ArrowType::Int32 | ArrowType::Int64
+            | ArrowType::UInt32 | ArrowType::UInt64 => Some(0),
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::Int8 | ArrowType::Int16
+            | ArrowType::UInt8 | ArrowType::UInt16 => Some(0),
+            ArrowType::Float32 | ArrowType::Float64 => None,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, s) => Some(s),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(_, s) => Some(s),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(_, s) => Some(s),
             _ => None,
         }
     }
@@ -552,17 +578,13 @@ impl PyArray {
         self.0.arrow_type()
     }
 
-    /// The decimal precision (total significant digits), or `None` for
-    /// non-decimal arrays.
-    #[cfg(feature = "decimal")]
+    /// Maximum number of significant decimal digits this array can represent.
     #[getter]
-    fn precision(&self) -> Option<u8> {
+    fn precision(&self) -> u8 {
         self.0.precision()
     }
 
-    /// The decimal scale (digits after the decimal point), or `None` for
-    /// non-decimal arrays.
-    #[cfg(feature = "decimal")]
+    /// Decimal scale metadata, or `None` for non-decimal types.
     #[getter]
     fn scale(&self) -> Option<i8> {
         self.0.scale()

--- a/minarrow-py/src/array.rs
+++ b/minarrow-py/src/array.rs
@@ -114,6 +114,28 @@ impl PyArrayInner {
         }
     }
 
+    /// The decimal precision, or `None` for non-decimal arrays.
+    #[cfg(feature = "decimal")]
+    pub fn precision(&self) -> Option<u8> {
+        match self.arrow_dtype() {
+            ArrowType::Decimal32(p, _)
+            | ArrowType::Decimal64(p, _)
+            | ArrowType::Decimal128(p, _) => Some(p),
+            _ => None,
+        }
+    }
+
+    /// The decimal scale, or `None` for non-decimal arrays.
+    #[cfg(feature = "decimal")]
+    pub fn scale(&self) -> Option<i8> {
+        match self.arrow_dtype() {
+            ArrowType::Decimal32(_, s)
+            | ArrowType::Decimal64(_, s)
+            | ArrowType::Decimal128(_, s) => Some(s),
+            _ => None,
+        }
+    }
+
     /// Whether this array is a windowed view of a larger buffer.
     pub fn is_view(&self) -> bool {
         match self {
@@ -528,6 +550,22 @@ impl PyArray {
     #[getter]
     fn arrow_type(&self) -> PyArrowType {
         self.0.arrow_type()
+    }
+
+    /// The decimal precision (total significant digits), or `None` for
+    /// non-decimal arrays.
+    #[cfg(feature = "decimal")]
+    #[getter]
+    fn precision(&self) -> Option<u8> {
+        self.0.precision()
+    }
+
+    /// The decimal scale (digits after the decimal point), or `None` for
+    /// non-decimal arrays.
+    #[cfg(feature = "decimal")]
+    #[getter]
+    fn scale(&self) -> Option<i8> {
+        self.0.scale()
     }
 
     fn __len__(&self) -> usize {

--- a/minarrow-py/src/arrow_type.rs
+++ b/minarrow-py/src/arrow_type.rs
@@ -180,6 +180,12 @@ pub enum PyArrowType {
     Timestamp { unit: PyTimeUnit, tz: Option<String> },
     #[cfg(feature = "datetime")]
     Interval { unit: PyIntervalUnit },
+    #[cfg(feature = "decimal")]
+    Decimal32 { precision: u8, scale: i8 },
+    #[cfg(feature = "decimal")]
+    Decimal64 { precision: u8, scale: i8 },
+    #[cfg(feature = "decimal")]
+    Decimal128 { precision: u8, scale: i8 },
     String(),
     #[cfg(feature = "large_string")]
     LargeString(),
@@ -233,6 +239,12 @@ impl From<ArrowType> for PyArrowType {
             ArrowType::Timestamp(unit, tz) => PyArrowType::Timestamp { unit: unit.into(), tz },
             #[cfg(feature = "datetime")]
             ArrowType::Interval(unit) => PyArrowType::Interval { unit: unit.into() },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(p, s) => PyArrowType::Decimal32 { precision: p, scale: s },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => PyArrowType::Decimal64 { precision: p, scale: s },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => PyArrowType::Decimal128 { precision: p, scale: s },
             ArrowType::String => PyArrowType::String(),
             #[cfg(feature = "large_string")]
             ArrowType::LargeString => PyArrowType::LargeString(),
@@ -285,6 +297,12 @@ impl From<PyArrowType> for ArrowType {
             PyArrowType::Timestamp { unit, tz } => ArrowType::Timestamp(unit.into(), tz),
             #[cfg(feature = "datetime")]
             PyArrowType::Interval { unit } => ArrowType::Interval(unit.into()),
+            #[cfg(feature = "decimal")]
+            PyArrowType::Decimal32 { precision, scale } => ArrowType::Decimal32(precision, scale),
+            #[cfg(feature = "decimal")]
+            PyArrowType::Decimal64 { precision, scale } => ArrowType::Decimal64(precision, scale),
+            #[cfg(feature = "decimal")]
+            PyArrowType::Decimal128 { precision, scale } => ArrowType::Decimal128(precision, scale),
             PyArrowType::String() => ArrowType::String,
             #[cfg(feature = "large_string")]
             PyArrowType::LargeString() => ArrowType::LargeString,

--- a/minarrow-py/src/convert.rs
+++ b/minarrow-py/src/convert.rs
@@ -21,6 +21,8 @@ use minarrow::arr_str64_opt;
 use minarrow::{arr_i8_opt, arr_i16_opt, arr_u8_opt, arr_u16_opt};
 use minarrow::enums::array::extract_option_values64;
 use minarrow::enums::time_units::TimeUnit;
+#[cfg(feature = "decimal")]
+use minarrow::DecimalArray;
 use minarrow::{
     arr_bool_opt, arr_f32_opt, arr_f64_opt, arr_i32_opt, arr_i64_opt, arr_str32_opt, arr_u32_opt,
     arr_u64_opt, Array, ArrayV, Bitmask, CategoricalArray, DatetimeArray, Scalar, Vec64,
@@ -164,6 +166,30 @@ pub fn build_array_typed(data: &Bound<'_, PyAny>, dtype: &ArrowType) -> PyResult
             build_temporal!(i64, from_datetime_i64, *unit)
         }
         ArrowType::Timestamp(unit, _) => build_temporal!(i64, from_datetime_i64, *unit),
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(p, s) => {
+            let (values, null_mask) =
+                extract_option_values64(read_sequence::<Option<i32>>(data)?);
+            Ok(Array::from_decimal32(DecimalArray::<i32>::from_vec64(
+                values, null_mask, *p, *s,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal64(p, s) => {
+            let (values, null_mask) =
+                extract_option_values64(read_sequence::<Option<i64>>(data)?);
+            Ok(Array::from_decimal64(DecimalArray::<i64>::from_vec64(
+                values, null_mask, *p, *s,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal128(p, s) => {
+            let (values, null_mask) =
+                extract_option_values64(read_sequence::<Option<i128>>(data)?);
+            Ok(Array::from_decimal128(DecimalArray::<i128>::from_vec64(
+                values, null_mask, *p, *s,
+            )))
+        }
         other => Err(PyValueError::new_err(format!(
             "dtype {} cannot be built from a Python sequence; use from_arrow instead",
             other
@@ -272,7 +298,61 @@ pub fn parse_dtype(name: &str) -> PyResult<ArrowType> {
                 ));
             }
         }
+        #[cfg(feature = "decimal")]
+        s if s.starts_with("decimal128") || s.starts_with("decimal64") || s.starts_with("decimal32") || s.starts_with("decimal") => {
+            return parse_decimal_dtype(s);
+        }
         other => return Err(PyValueError::new_err(format!("unknown dtype '{other}'"))),
+    })
+}
+
+/// Parse a decimal dtype string such as `"decimal128(38,10)"` or `"decimal(10,2)"`.
+///
+/// Accepted forms:
+/// - `decimal128(P,S)` - Decimal128 with precision P and scale S.
+/// - `decimal64(P,S)` - Decimal64.
+/// - `decimal32(P,S)` - Decimal32.
+/// - `decimal(P,S)` - alias for Decimal128.
+#[cfg(feature = "decimal")]
+fn parse_decimal_dtype(s: &str) -> PyResult<ArrowType> {
+    // Determine the width prefix and the remainder after it
+    let (width, rest) = if s.starts_with("decimal128") {
+        (128u32, &s["decimal128".len()..])
+    } else if s.starts_with("decimal64") {
+        (64, &s["decimal64".len()..])
+    } else if s.starts_with("decimal32") {
+        (32, &s["decimal32".len()..])
+    } else if s.starts_with("decimal") {
+        (128, &s["decimal".len()..])
+    } else {
+        return Err(PyValueError::new_err(format!("unknown dtype '{s}'")));
+    };
+
+    // Expect (P,S) after the prefix
+    let rest = rest.trim();
+    if !rest.starts_with('(') || !rest.ends_with(')') {
+        return Err(PyValueError::new_err(format!(
+            "decimal dtype must include precision and scale as 'decimal128(P,S)', got '{s}'"
+        )));
+    }
+    let inner = &rest[1..rest.len() - 1];
+    let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+    if parts.len() != 2 {
+        return Err(PyValueError::new_err(format!(
+            "decimal dtype must have two parameters (precision, scale), got '{s}'"
+        )));
+    }
+    let precision: u8 = parts[0].parse().map_err(|_| {
+        PyValueError::new_err(format!("invalid decimal precision in '{s}'"))
+    })?;
+    let scale: i8 = parts[1].parse().map_err(|_| {
+        PyValueError::new_err(format!("invalid decimal scale in '{s}'"))
+    })?;
+
+    Ok(match width {
+        32 => ArrowType::Decimal32(precision, scale),
+        64 => ArrowType::Decimal64(precision, scale),
+        _ => ArrowType::Decimal128(precision, scale),
     })
 }
 
@@ -442,6 +522,49 @@ pub fn resolve_index(i: isize, len: usize) -> PyResult<usize> {
     Ok(resolved as usize)
 }
 
+/// Convert a decimal scalar to a Python `decimal.Decimal` value.
+///
+/// Reconstructs the human-readable decimal string from the raw unscaled integer
+/// and scale, then passes it to `decimal.Decimal()` for exact conversion.
+#[cfg(feature = "decimal")]
+fn decimal_scalar_to_py(py: Python<'_>, raw: i128, scale: i8) -> PyResult<Py<PyAny>> {
+    let formatted = format_decimal_string(raw, scale);
+    let decimal_mod = py.import("decimal")?;
+    let result = decimal_mod.call_method1("Decimal", (formatted,))?;
+    Ok(result.unbind())
+}
+
+/// Format a decimal value as a string for `decimal.Decimal` construction.
+#[cfg(feature = "decimal")]
+fn format_decimal_string(raw: i128, scale: i8) -> String {
+    let raw_str = format!("{}", raw);
+    if scale == 0 {
+        return raw_str;
+    }
+    if scale < 0 {
+        let zeros = (-scale) as usize;
+        return format!("{}{}", raw_str, "0".repeat(zeros));
+    }
+    let scale_usize = scale as usize;
+    let (is_negative, digits) = if raw_str.starts_with('-') {
+        (true, &raw_str[1..])
+    } else {
+        (false, raw_str.as_str())
+    };
+    let padded = if digits.len() <= scale_usize {
+        format!("{:0>width$}", digits, width = scale_usize + 1)
+    } else {
+        digits.to_string()
+    };
+    let split_pos = padded.len() - scale_usize;
+    let (int_part, frac_part) = padded.split_at(split_pos);
+    if is_negative {
+        format!("-{}.{}", int_part, frac_part)
+    } else {
+        format!("{}.{}", int_part, frac_part)
+    }
+}
+
 /// Coerce a minarrow `Scalar` to its Python-native value. `Null` becomes `None`.
 ///
 /// Temporal values surface as their raw integer. Faithful
@@ -468,6 +591,12 @@ pub fn scalar_to_py(py: Python<'_>, scalar: Scalar) -> PyResult<Py<PyAny>> {
         Scalar::String32(v) => v.into_py_any(py),
         #[cfg(feature = "large_string")]
         Scalar::String64(v) => v.into_py_any(py),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(v, scale) => decimal_scalar_to_py(py, v as i128, scale),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(v, scale) => decimal_scalar_to_py(py, v as i128, scale),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(v, scale) => decimal_scalar_to_py(py, v, scale),
         #[cfg(feature = "datetime")]
         Scalar::Datetime32(v) => v.into_py_any(py),
         #[cfg(feature = "datetime")]
@@ -502,6 +631,12 @@ pub fn scalar_repr(scalar: &Scalar) -> String {
         Scalar::String32(v) => format!("\"{}\"", v),
         #[cfg(feature = "large_string")]
         Scalar::String64(v) => format!("\"{}\"", v),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(v, s) => format_decimal_string(*v as i128, *s),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(v, s) => format_decimal_string(*v as i128, *s),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(v, s) => format_decimal_string(*v, *s),
         #[cfg(feature = "datetime")]
         Scalar::Datetime32(v) => v.to_string(),
         #[cfg(feature = "datetime")]

--- a/minarrow-py/src/dtype.rs
+++ b/minarrow-py/src/dtype.rs
@@ -63,6 +63,7 @@ impl TypeClass {
 pub enum DType {
     Integer,
     Float,
+    Decimal,
     String,
     Categorical,
     Datetime,
@@ -76,6 +77,7 @@ impl DType {
         match self {
             DType::Integer => "Integer",
             DType::Float => "Float",
+            DType::Decimal => "Decimal",
             DType::String => "String",
             DType::Categorical => "Categorical",
             DType::Datetime => "Datetime",
@@ -99,7 +101,7 @@ impl DType {
     #[getter]
     pub fn group(&self) -> TypeClass {
         match self {
-            DType::Integer | DType::Float => TypeClass::Numeric,
+            DType::Integer | DType::Float | DType::Decimal => TypeClass::Numeric,
             DType::String | DType::Categorical => TypeClass::Text,
             DType::Datetime => TypeClass::Temporal,
             DType::Boolean => TypeClass::Boolean,
@@ -109,7 +111,7 @@ impl DType {
 
     #[getter]
     fn is_numeric(&self) -> bool {
-        matches!(self, DType::Integer | DType::Float)
+        matches!(self, DType::Integer | DType::Float | DType::Decimal)
     }
 
     #[getter]
@@ -133,6 +135,8 @@ pub fn dtype_from_arrow(at: &ArrowType) -> DType {
         #[cfg(feature = "extended_numeric_types")]
         Int8 | Int16 | UInt8 | UInt16 => DType::Integer,
         Float32 | Float64 => DType::Float,
+        #[cfg(feature = "decimal")]
+        Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) => DType::Decimal,
         String | Utf8View => DType::String,
         #[cfg(feature = "large_string")]
         LargeString => DType::String,
@@ -157,6 +161,12 @@ pub fn width_from_arrow(at: &ArrowType) -> u32 {
         Int16 | UInt16 => 16,
         Int32 | UInt32 | Float32 => 32,
         Int64 | UInt64 | Float64 => 64,
+        #[cfg(feature = "decimal")]
+        Decimal32(_, _) => 32,
+        #[cfg(feature = "decimal")]
+        Decimal64(_, _) => 64,
+        #[cfg(feature = "decimal")]
+        Decimal128(_, _) => 128,
         String | Utf8View => 32,
         #[cfg(feature = "large_string")]
         LargeString => 64,

--- a/minarrow-py/tests/test_decimal.py
+++ b/minarrow-py/tests/test_decimal.py
@@ -1,0 +1,226 @@
+"""Tests for decimal array support in minarrow-py.
+
+Run after `maturin develop`:
+    python -m pytest tests/test_decimal.py
+"""
+
+import decimal
+
+import pytest
+
+import minarrow as mp
+
+
+# --- Construction from int values with dtype string -------------------------
+
+
+def test_decimal128_from_ints():
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    assert len(a) == 2
+    assert a.dtype == mp.DType.Decimal
+    assert a.dtype.group == mp.TypeClass.Numeric
+    assert a.dtype.is_numeric
+    assert a.precision == 10
+    assert a.scale == 2
+    assert a.bit_width == 128
+
+
+def test_decimal64_from_ints():
+    a = mp.Array([100, 200, 300], dtype="decimal64(18,4)")
+    assert len(a) == 3
+    assert a.precision == 18
+    assert a.scale == 4
+    assert a.bit_width == 64
+
+
+def test_decimal32_from_ints():
+    a = mp.Array([10, 20], dtype="decimal32(9,2)")
+    assert len(a) == 2
+    assert a.precision == 9
+    assert a.scale == 2
+    assert a.bit_width == 32
+
+
+def test_decimal_alias_is_decimal128():
+    a = mp.Array([100], dtype="decimal(10,2)")
+    assert str(a.arrow_type) == "Decimal128(10, 2)"
+    assert a.bit_width == 128
+
+
+def test_decimal_with_nulls():
+    a = mp.Array([12345, None, 67890], dtype="decimal128(10,2)")
+    assert len(a) == 3
+    assert a.null_count == 1
+
+
+# --- Properties on non-decimal arrays return None ---------------------------
+
+
+def test_precision_none_for_int():
+    a = mp.Array([1, 2, 3])
+    assert a.precision is None
+
+
+def test_scale_none_for_float():
+    a = mp.Array([1.0, 2.0])
+    assert a.scale is None
+
+
+# --- Element access ---------------------------------------------------------
+
+
+def test_getitem_returns_decimal():
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    val = a[0]
+    assert isinstance(val, decimal.Decimal)
+    assert val == decimal.Decimal("123.45")
+
+
+def test_getitem_null_is_none():
+    a = mp.Array([12345, None], dtype="decimal128(10,2)")
+    assert a[1] is None
+
+
+def test_getitem_negative_index():
+    a = mp.Array([100, 200, 300], dtype="decimal128(10,2)")
+    assert a[-1] == decimal.Decimal("3.00")
+
+
+# --- Display (repr) shows scale-formatted values ----------------------------
+
+
+def test_repr_shows_decimal_values():
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    text = repr(a)
+    assert "dtype: Decimal" in text
+    assert "123.45" in text
+    assert "678.90" in text
+
+
+def test_repr_shows_null():
+    a = mp.Array([12345, None], dtype="decimal128(10,2)")
+    text = repr(a)
+    assert "null" in text
+
+
+# --- Slicing ----------------------------------------------------------------
+
+
+def test_slice_preserves_decimal():
+    a = mp.Array([100, 200, 300, 400], dtype="decimal128(10,2)")
+    s = a[1:3]
+    assert len(s) == 2
+    assert s[0] == decimal.Decimal("2.00")
+    assert s[1] == decimal.Decimal("3.00")
+
+
+# --- Named column -----------------------------------------------------------
+
+
+def test_named_decimal_column():
+    a = mp.Array([12345, 67890], name="price", dtype="decimal128(10,2)")
+    assert a.name == "price"
+    assert a.precision == 10
+    assert a.scale == 2
+
+
+# --- ArrowType construction -------------------------------------------------
+
+
+def test_arrow_type_decimal128():
+    at = mp.ArrowType.Decimal128(precision=38, scale=10)
+    assert str(at) == "Decimal128(38, 10)"
+
+
+def test_arrow_type_decimal64():
+    at = mp.ArrowType.Decimal64(precision=18, scale=4)
+    assert str(at) == "Decimal64(18, 4)"
+
+
+def test_arrow_type_decimal32():
+    at = mp.ArrowType.Decimal32(precision=9, scale=2)
+    assert str(at) == "Decimal32(9, 2)"
+
+
+# --- Arrow interop (PyArrow round-trip) -------------------------------------
+
+
+def test_from_arrow_decimal128():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("123.45"), decimal.Decimal("678.90"), None],
+        type=pa.decimal128(10, 2),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    assert a.dtype == mp.DType.Decimal
+    assert a.precision == 10
+    assert a.scale == 2
+    assert len(a) == 3
+    assert a.null_count == 1
+    assert a[0] == decimal.Decimal("123.45")
+    assert a[1] == decimal.Decimal("678.90")
+    assert a[2] is None
+
+
+def test_to_arrow_roundtrip():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("19.99"), decimal.Decimal("29.99")],
+        type=pa.decimal128(10, 2),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    out = a.to_arrow()
+    assert out.to_pylist() == pa_arr.to_pylist()
+    assert out.type == pa.decimal128(10, 2)
+
+
+def test_pyarrow_roundtrip_with_nulls():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("1.23"), None, decimal.Decimal("-4.56")],
+        type=pa.decimal128(10, 2),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    out = a.to_arrow()
+    assert out.to_pylist() == pa_arr.to_pylist()
+
+
+def test_pyarrow_high_precision():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("12345678901234567890.1234567890")],
+        type=pa.decimal128(38, 10),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    assert a.precision == 38
+    assert a.scale == 10
+    out = a.to_arrow()
+    assert out.to_pylist() == pa_arr.to_pylist()
+
+
+# --- PyCapsule protocol (consumed by PyArrow) -------------------------------
+
+
+def test_pycapsule_consumed_by_pyarrow():
+    import pyarrow as pa
+
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    pa_arr = pa.array(a)
+    assert pa_arr.type == pa.decimal128(10, 2)
+    assert pa_arr.to_pylist() == [decimal.Decimal("123.45"), decimal.Decimal("678.90")]
+
+
+def test_pycapsule_with_nulls():
+    import pyarrow as pa
+
+    a = mp.Array([12345, None, 67890], dtype="decimal128(10,2)")
+    pa_arr = pa.array(a)
+    assert pa_arr.to_pylist() == [
+        decimal.Decimal("123.45"),
+        None,
+        decimal.Decimal("678.90"),
+    ]

--- a/minarrow-py/tests/test_decimal.py
+++ b/minarrow-py/tests/test_decimal.py
@@ -53,16 +53,18 @@ def test_decimal_with_nulls():
     assert a.null_count == 1
 
 
-# --- Properties on non-decimal arrays return None ---------------------------
+# --- Precision and scale on non-decimal types --------------------------------
 
 
-def test_precision_none_for_int():
+def test_precision_for_int64():
     a = mp.Array([1, 2, 3])
-    assert a.precision is None
+    assert a.precision == 19
+    assert a.scale == 0
 
 
-def test_scale_none_for_float():
+def test_precision_for_float64():
     a = mp.Array([1.0, 2.0])
+    assert a.precision == 15
     assert a.scale is None
 
 

--- a/pyo3/Cargo.lock
+++ b/pyo3/Cargo.lock
@@ -186,6 +186,6 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "vec64"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5a35bf381f20a9d41312bd977f43e997ab5bc82deb85b503b3346e6a437b7"
+checksum = "1aef6bbef159f21ac387220ebc71141524423f7886afd390bc7b140f12630425"

--- a/pyo3/Cargo.toml
+++ b/pyo3/Cargo.toml
@@ -29,7 +29,7 @@ pyo3 = { version = "0.29" }
 thiserror = "2"
 
 [features]
-default = ["datetime", "extended_numeric_types"]
+default = ["datetime", "extended_numeric_types", "decimal"]
 extension-module = ["pyo3/extension-module"]
 datetime = ["minarrow/datetime"]
 extended_numeric_types = ["minarrow/extended_numeric_types"]
@@ -39,6 +39,7 @@ default_categorical_8 = ["minarrow/default_categorical_8"]
 # Enables 8, 16 and 64 byte categorical bit widths. When combined with default_categorical_8,
 # the extra one added is the 32 byte (making the other feature unused).
 extended_categorical = ["minarrow/extended_categorical"]
+decimal = ["minarrow/decimal"]
 table_metadata = ["minarrow/table_metadata"]
 # N-dimensional tensor bridging with DLPack capsule interchange.
 ndarray = ["minarrow/ndarray", "minarrow/dlpack", "minarrow/views", "minarrow/select"]

--- a/pyo3/src/ffi/mod.rs
+++ b/pyo3/src/ffi/mod.rs
@@ -97,6 +97,19 @@
 //! | `IntegerArray<u8>` | `NumericArray::UInt8` | `C` | `pa.UInt8Array` |
 //! | `IntegerArray<u16>` | `NumericArray::UInt16` | `S` | `pa.UInt16Array` |
 //!
+//! ### Decimal types (feature `decimal`)
+//!
+//! | MinArrow inner type | `Array` enum path | Arrow format | PyArrow type |
+//! |---------------------|-------------------|--------------|--------------|
+//! | `DecimalArray<i32>` | `NumericArray::Decimal32` | `d:P,S,32` | `pa.Decimal128Array` |
+//! | `DecimalArray<i64>` | `NumericArray::Decimal64` | `d:P,S,64` | `pa.Decimal128Array` |
+//! | `DecimalArray<i128>` | `NumericArray::Decimal128` | `d:P,S` | `pa.Decimal128Array` |
+//!
+//! Decimal32 and Decimal64 map to PyArrow's `Decimal128Array` because PyArrow only
+//! supports 128-bit decimal. The underlying Arrow C Data Interface format string
+//! carries the true bit width, so a Decimal32 or Decimal64 array imported back into
+//! MinArrow retains its original width.
+//!
 //! ### Boolean
 //!
 //! | MinArrow inner type | `Array` enum path | Arrow format | PyArrow type |

--- a/pyo3/src/ffi/to_py.rs
+++ b/pyo3/src/ffi/to_py.rs
@@ -129,6 +129,21 @@ fn arrow_type_to_pyarrow<'py>(
             pa.call_method0("null")
         }
 
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal128(p, s) => pa.call_method1("decimal128", (*p, *s)),
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(p, s) => {
+            // PyArrow has no Decimal32 type so map to Decimal128 with the same
+            // precision and scale.
+            pa.call_method1("decimal128", (*p, *s))
+        }
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal64(p, s) => {
+            // PyArrow has no Decimal64 type so map to Decimal128 with the same
+            // precision and scale.
+            pa.call_method1("decimal128", (*p, *s))
+        }
+
         ArrowType::Dictionary(key_type) => {
             let index_ty = pa.call_method0(key_type.arrow_index_name())?;
             let value_ty = pa.call_method0("utf8")?;

--- a/pyo3/tests/test_roundtrip.py
+++ b/pyo3/tests/test_roundtrip.py
@@ -238,6 +238,50 @@ print(f"  Output: {len(result)} elements, {result.num_chunks} chunks")
 assert chunked.to_pylist() == result.to_pylist(), "String ChunkedArray mismatch!"
 print("  ✓ PASSED")
 
+# Test 21: Decimal128 Array roundtrip
+print("\nTest 21: Decimal128 Array Roundtrip")
+print("-" * 40)
+import decimal
+arr = pa.array([decimal.Decimal("123.45"), decimal.Decimal("678.90"), None], type=pa.decimal128(10, 2))
+print(f"  Input:  {arr.to_pylist()}")
+result = ma.echo_array(arr)
+print(f"  Output: {result.to_pylist()}")
+assert arr.to_pylist() == result.to_pylist(), "Decimal128 array mismatch!"
+assert result.type == arr.type, f"Decimal128 type mismatch: expected {arr.type}, got {result.type}"
+print("  ✓ PASSED")
+
+# Test 22: Decimal128 Array roundtrip with high precision
+print("\nTest 22: Decimal128 High Precision Roundtrip")
+print("-" * 40)
+arr = pa.array(
+    [decimal.Decimal("12345678901234567890.1234567890"), None, decimal.Decimal("-9876543210.0987654321")],
+    type=pa.decimal128(38, 10),
+)
+print(f"  Input:  {arr.to_pylist()}")
+result = ma.echo_array(arr)
+print(f"  Output: {result.to_pylist()}")
+assert arr.to_pylist() == result.to_pylist(), "Decimal128 high precision array mismatch!"
+assert result.type == arr.type, f"Decimal128 type mismatch: expected {arr.type}, got {result.type}"
+print("  ✓ PASSED")
+
+# Test 23: Decimal128 in RecordBatch roundtrip
+print("\nTest 23: Decimal128 in RecordBatch Roundtrip")
+print("-" * 40)
+batch = pa.RecordBatch.from_pydict({
+    "id": pa.array([1, 2, 3], type=pa.int64()),
+    "price": pa.array(
+        [decimal.Decimal("19.99"), decimal.Decimal("29.99"), decimal.Decimal("39.99")],
+        type=pa.decimal128(10, 2),
+    ),
+})
+print(f"  Input:  {batch.num_rows} rows, {batch.num_columns} cols")
+result = ma.echo_batch(batch)
+print(f"  Output: {result.num_rows} rows, {result.num_columns} cols")
+assert batch.column("id").to_pylist() == result.column("id").to_pylist(), "ID column mismatch!"
+assert batch.column("price").to_pylist() == result.column("price").to_pylist(), "Price column mismatch!"
+assert result.schema.field("price").type == pa.decimal128(10, 2), "Decimal type not preserved in RecordBatch!"
+print("  ✓ PASSED")
+
 print("\n" + "=" * 50)
 print("All tests PASSED!")
 print("=" * 50)

--- a/tests/apache_arrow.rs
+++ b/tests/apache_arrow.rs
@@ -985,6 +985,30 @@ fn rt_arrow_super_table_shared_categorical32() {
 
 #[cfg(feature = "decimal")]
 #[test]
+fn rt_arrow_decimal32() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i32>::from_slice(&[12345, -6789, 0], 9, 2);
+    let a = MArray::from_decimal32(arr);
+    let f = Field::new("dec32", ArrowType::Decimal32(9, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_arrow_decimal64() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i64>::from_slice(&[12345, -67890, 0], 18, 4);
+    let a = MArray::from_decimal64(arr);
+    let f = Field::new("dec64", ArrowType::Decimal64(18, 4), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "decimal")]
+#[test]
 fn rt_arrow_decimal128() {
     use minarrow::DecimalArray;
 


### PR DESCRIPTION
## Summary
- pyo3: Decimal32/64/128 map to PyArrow `pa.decimal128()` for export/import via the existing Arrow C Data Interface FFI. 
- minarrow-py: construction from `list[int]` via `dtype="decimal128(P,S)"`, element access returns `decimal.Decimal`, scale-aware `repr`, `.precision` and `.scale` properties
- Adds Decimal32 and Decimal64 round-trip tests for arrow-rs C Data Interface (gap from TSK378 which only tested Decimal128)
- 26 new tests across pyo3 and minarrow-py

## Test plan
- [x] pyo3 pytest passes (23 tests including 3 new decimal)
- [x] minarrow-py pytest passes (139 tests including 23 new decimal)
- [x] `cargo test --features "decimal,cast_arrow"` passes (all three widths round-trip)
- [x] `cargo test --features decimal` passes