### PR TITLE
Add Arrow Decimal Array Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,14 @@ extended_categorical = ["default_categorical_8"]
 # For most analytical use cases, they get upcasted anyway.
 extended_numeric_types = []
 
+# Adds Decimal32, Decimal64, and Decimal128 array types for exact numeric
+# values (for e.g., monetary, accounting, high-precision columns). DecimalArray<T>
+# stores unscaled integers with precision and scale metadata for
+# scale-aware formatting and lossless round-trip through Arrow FFI.
+# Also gates `impl Integer for i128` and the associated Numeric/Primitive
+# impls that i128 requires.
+decimal = []
+
 # Adds a cube object for stacking tables on an extra axis
 # Useful for time series, and group analytics.
 cube = ["views", "select", "hash"]

--- a/minarrow-py/Cargo.lock
+++ b/minarrow-py/Cargo.lock
@@ -197,6 +197,6 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "vec64"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5a35bf381f20a9d41312bd977f43e997ab5bc82deb85b503b3346e6a437b7"
+checksum = "1aef6bbef159f21ac387220ebc71141524423f7886afd390bc7b140f12630425"

--- a/minarrow-py/Cargo.toml
+++ b/minarrow-py/Cargo.toml
@@ -25,7 +25,7 @@ pyo3 = { version = "0.29", features = ["abi3-py39"] }
 thiserror = "2"
 
 [features]
-default = ["datetime", "large_string", "matrix", "scalar_type", "value_type", "cube", "arrow_interop", "ndarray"]
+default = ["datetime", "large_string", "matrix", "scalar_type", "value_type", "cube", "arrow_interop", "ndarray", "decimal"]
 extension-module = ["pyo3/extension-module"]
 arrow_interop = ["dep:minarrow-pyo3", "minarrow-pyo3/datetime"]
 simd = ["minarrow/simd"]
@@ -47,6 +47,7 @@ ndarray = [
 # Links libpython - use the default non `extension-module` link mode and
 # it should not be combined with `extension-module`.
 embed = ["arrow_interop", "scalar_type", "value_type", "simd"]
+decimal = ["minarrow/decimal", "minarrow-pyo3?/decimal"]
 datetime = ["minarrow/datetime"]
 extended_numeric_types = ["minarrow/extended_numeric_types", "minarrow-pyo3?/extended_numeric_types"]
 large_string = ["minarrow/large_string"]

--- a/minarrow-py/src/array.rs
+++ b/minarrow-py/src/array.rs
@@ -114,6 +114,54 @@ impl PyArrayInner {
         }
     }
 
+    /// Maximum number of significant decimal digits this array can represent.
+    pub fn precision(&self) -> u8 {
+        match self.arrow_dtype() {
+            ArrowType::Int32 => 10,
+            ArrowType::Int64 => 19,
+            ArrowType::UInt32 => 10,
+            ArrowType::UInt64 => 20,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::Int8 => 3,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::Int16 => 5,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::UInt8 => 3,
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::UInt16 => 5,
+            ArrowType::Float32 => 7,
+            ArrowType::Float64 => 15,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(p, _) => p,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, _) => p,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, _) => p,
+            _ => 0,
+        }
+    }
+
+    /// Number of digits after the decimal point. Zero for integer types.
+    /// Floats return `None` because scale varies per value. Non-numeric
+    /// types also return `None`.
+    pub fn scale(&self) -> Option<i8> {
+        match self.arrow_dtype() {
+            ArrowType::Int32 | ArrowType::Int64
+            | ArrowType::UInt32 | ArrowType::UInt64 => Some(0),
+            #[cfg(feature = "extended_numeric_types")]
+            ArrowType::Int8 | ArrowType::Int16
+            | ArrowType::UInt8 | ArrowType::UInt16 => Some(0),
+            ArrowType::Float32 | ArrowType::Float64 => None,
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, s) => Some(s),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(_, s) => Some(s),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(_, s) => Some(s),
+            _ => None,
+        }
+    }
+
     /// Whether this array is a windowed view of a larger buffer.
     pub fn is_view(&self) -> bool {
         match self {
@@ -528,6 +576,18 @@ impl PyArray {
     #[getter]
     fn arrow_type(&self) -> PyArrowType {
         self.0.arrow_type()
+    }
+
+    /// Maximum number of significant decimal digits this array can represent.
+    #[getter]
+    fn precision(&self) -> u8 {
+        self.0.precision()
+    }
+
+    /// Decimal scale metadata, or `None` for non-decimal types.
+    #[getter]
+    fn scale(&self) -> Option<i8> {
+        self.0.scale()
     }
 
     fn __len__(&self) -> usize {

--- a/minarrow-py/src/array.rs
+++ b/minarrow-py/src/array.rs
@@ -141,9 +141,9 @@ impl PyArrayInner {
         }
     }
 
-    /// Number of digits after the decimal point. Zero for integer types.
-    /// Floats return `None` because scale varies per value. Non-numeric
-    /// types also return `None`.
+    /// Number of digits after the decimal point. Zero for integer types,
+    /// `None` for floats because scale varies per value, and `None` for
+    /// non-numeric types.
     pub fn scale(&self) -> Option<i8> {
         match self.arrow_dtype() {
             ArrowType::Int32 | ArrowType::Int64

--- a/minarrow-py/src/arrow_type.rs
+++ b/minarrow-py/src/arrow_type.rs
@@ -180,6 +180,12 @@ pub enum PyArrowType {
     Timestamp { unit: PyTimeUnit, tz: Option<String> },
     #[cfg(feature = "datetime")]
     Interval { unit: PyIntervalUnit },
+    #[cfg(feature = "decimal")]
+    Decimal32 { precision: u8, scale: i8 },
+    #[cfg(feature = "decimal")]
+    Decimal64 { precision: u8, scale: i8 },
+    #[cfg(feature = "decimal")]
+    Decimal128 { precision: u8, scale: i8 },
     String(),
     #[cfg(feature = "large_string")]
     LargeString(),
@@ -233,6 +239,12 @@ impl From<ArrowType> for PyArrowType {
             ArrowType::Timestamp(unit, tz) => PyArrowType::Timestamp { unit: unit.into(), tz },
             #[cfg(feature = "datetime")]
             ArrowType::Interval(unit) => PyArrowType::Interval { unit: unit.into() },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(p, s) => PyArrowType::Decimal32 { precision: p, scale: s },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => PyArrowType::Decimal64 { precision: p, scale: s },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => PyArrowType::Decimal128 { precision: p, scale: s },
             ArrowType::String => PyArrowType::String(),
             #[cfg(feature = "large_string")]
             ArrowType::LargeString => PyArrowType::LargeString(),
@@ -285,6 +297,12 @@ impl From<PyArrowType> for ArrowType {
             PyArrowType::Timestamp { unit, tz } => ArrowType::Timestamp(unit.into(), tz),
             #[cfg(feature = "datetime")]
             PyArrowType::Interval { unit } => ArrowType::Interval(unit.into()),
+            #[cfg(feature = "decimal")]
+            PyArrowType::Decimal32 { precision, scale } => ArrowType::Decimal32(precision, scale),
+            #[cfg(feature = "decimal")]
+            PyArrowType::Decimal64 { precision, scale } => ArrowType::Decimal64(precision, scale),
+            #[cfg(feature = "decimal")]
+            PyArrowType::Decimal128 { precision, scale } => ArrowType::Decimal128(precision, scale),
             PyArrowType::String() => ArrowType::String,
             #[cfg(feature = "large_string")]
             PyArrowType::LargeString() => ArrowType::LargeString,

--- a/minarrow-py/src/convert.rs
+++ b/minarrow-py/src/convert.rs
@@ -21,6 +21,8 @@ use minarrow::arr_str64_opt;
 use minarrow::{arr_i8_opt, arr_i16_opt, arr_u8_opt, arr_u16_opt};
 use minarrow::enums::array::extract_option_values64;
 use minarrow::enums::time_units::TimeUnit;
+#[cfg(feature = "decimal")]
+use minarrow::DecimalArray;
 use minarrow::{
     arr_bool_opt, arr_f32_opt, arr_f64_opt, arr_i32_opt, arr_i64_opt, arr_str32_opt, arr_u32_opt,
     arr_u64_opt, Array, ArrayV, Bitmask, CategoricalArray, DatetimeArray, Scalar, Vec64,
@@ -164,6 +166,30 @@ pub fn build_array_typed(data: &Bound<'_, PyAny>, dtype: &ArrowType) -> PyResult
             build_temporal!(i64, from_datetime_i64, *unit)
         }
         ArrowType::Timestamp(unit, _) => build_temporal!(i64, from_datetime_i64, *unit),
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(p, s) => {
+            let (values, null_mask) =
+                extract_option_values64(read_sequence::<Option<i32>>(data)?);
+            Ok(Array::from_decimal32(DecimalArray::<i32>::from_vec64(
+                values, null_mask, *p, *s,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal64(p, s) => {
+            let (values, null_mask) =
+                extract_option_values64(read_sequence::<Option<i64>>(data)?);
+            Ok(Array::from_decimal64(DecimalArray::<i64>::from_vec64(
+                values, null_mask, *p, *s,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal128(p, s) => {
+            let (values, null_mask) =
+                extract_option_values64(read_sequence::<Option<i128>>(data)?);
+            Ok(Array::from_decimal128(DecimalArray::<i128>::from_vec64(
+                values, null_mask, *p, *s,
+            )))
+        }
         other => Err(PyValueError::new_err(format!(
             "dtype {} cannot be built from a Python sequence; use from_arrow instead",
             other
@@ -272,7 +298,61 @@ pub fn parse_dtype(name: &str) -> PyResult<ArrowType> {
                 ));
             }
         }
+        #[cfg(feature = "decimal")]
+        s if s.starts_with("decimal128") || s.starts_with("decimal64") || s.starts_with("decimal32") || s.starts_with("decimal") => {
+            return parse_decimal_dtype(s);
+        }
         other => return Err(PyValueError::new_err(format!("unknown dtype '{other}'"))),
+    })
+}
+
+/// Parse a decimal dtype string such as `"decimal128(38,10)"` or `"decimal(10,2)"`.
+///
+/// Accepted forms:
+/// - `decimal128(P,S)` - Decimal128 with precision P and scale S.
+/// - `decimal64(P,S)` - Decimal64.
+/// - `decimal32(P,S)` - Decimal32.
+/// - `decimal(P,S)` - alias for Decimal128.
+#[cfg(feature = "decimal")]
+fn parse_decimal_dtype(s: &str) -> PyResult<ArrowType> {
+    // Determine the width prefix and the remainder after it
+    let (width, rest) = if s.starts_with("decimal128") {
+        (128u32, &s["decimal128".len()..])
+    } else if s.starts_with("decimal64") {
+        (64, &s["decimal64".len()..])
+    } else if s.starts_with("decimal32") {
+        (32, &s["decimal32".len()..])
+    } else if s.starts_with("decimal") {
+        (128, &s["decimal".len()..])
+    } else {
+        return Err(PyValueError::new_err(format!("unknown dtype '{s}'")));
+    };
+
+    // Expect (P,S) after the prefix
+    let rest = rest.trim();
+    if !rest.starts_with('(') || !rest.ends_with(')') {
+        return Err(PyValueError::new_err(format!(
+            "decimal dtype must include precision and scale as 'decimal128(P,S)', got '{s}'"
+        )));
+    }
+    let inner = &rest[1..rest.len() - 1];
+    let parts: Vec<&str> = inner.split(',').map(str::trim).collect();
+    if parts.len() != 2 {
+        return Err(PyValueError::new_err(format!(
+            "decimal dtype must have two parameters (precision, scale), got '{s}'"
+        )));
+    }
+    let precision: u8 = parts[0].parse().map_err(|_| {
+        PyValueError::new_err(format!("invalid decimal precision in '{s}'"))
+    })?;
+    let scale: i8 = parts[1].parse().map_err(|_| {
+        PyValueError::new_err(format!("invalid decimal scale in '{s}'"))
+    })?;
+
+    Ok(match width {
+        32 => ArrowType::Decimal32(precision, scale),
+        64 => ArrowType::Decimal64(precision, scale),
+        _ => ArrowType::Decimal128(precision, scale),
     })
 }
 
@@ -442,6 +522,49 @@ pub fn resolve_index(i: isize, len: usize) -> PyResult<usize> {
     Ok(resolved as usize)
 }
 
+/// Convert a decimal scalar to a Python `decimal.Decimal` value.
+///
+/// Reconstructs the human-readable decimal string from the raw unscaled integer
+/// and scale, then passes it to `decimal.Decimal()` for exact conversion.
+#[cfg(feature = "decimal")]
+fn decimal_scalar_to_py(py: Python<'_>, raw: i128, scale: i8) -> PyResult<Py<PyAny>> {
+    let formatted = format_decimal_string(raw, scale);
+    let decimal_mod = py.import("decimal")?;
+    let result = decimal_mod.call_method1("Decimal", (formatted,))?;
+    Ok(result.unbind())
+}
+
+/// Format a decimal value as a string for `decimal.Decimal` construction.
+#[cfg(feature = "decimal")]
+fn format_decimal_string(raw: i128, scale: i8) -> String {
+    let raw_str = format!("{}", raw);
+    if scale == 0 {
+        return raw_str;
+    }
+    if scale < 0 {
+        let zeros = (-scale) as usize;
+        return format!("{}{}", raw_str, "0".repeat(zeros));
+    }
+    let scale_usize = scale as usize;
+    let (is_negative, digits) = if raw_str.starts_with('-') {
+        (true, &raw_str[1..])
+    } else {
+        (false, raw_str.as_str())
+    };
+    let padded = if digits.len() <= scale_usize {
+        format!("{:0>width$}", digits, width = scale_usize + 1)
+    } else {
+        digits.to_string()
+    };
+    let split_pos = padded.len() - scale_usize;
+    let (int_part, frac_part) = padded.split_at(split_pos);
+    if is_negative {
+        format!("-{}.{}", int_part, frac_part)
+    } else {
+        format!("{}.{}", int_part, frac_part)
+    }
+}
+
 /// Coerce a minarrow `Scalar` to its Python-native value. `Null` becomes `None`.
 ///
 /// Temporal values surface as their raw integer. Faithful
@@ -468,6 +591,12 @@ pub fn scalar_to_py(py: Python<'_>, scalar: Scalar) -> PyResult<Py<PyAny>> {
         Scalar::String32(v) => v.into_py_any(py),
         #[cfg(feature = "large_string")]
         Scalar::String64(v) => v.into_py_any(py),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(v, scale) => decimal_scalar_to_py(py, v as i128, scale),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(v, scale) => decimal_scalar_to_py(py, v as i128, scale),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(v, scale) => decimal_scalar_to_py(py, v, scale),
         #[cfg(feature = "datetime")]
         Scalar::Datetime32(v) => v.into_py_any(py),
         #[cfg(feature = "datetime")]
@@ -502,6 +631,12 @@ pub fn scalar_repr(scalar: &Scalar) -> String {
         Scalar::String32(v) => format!("\"{}\"", v),
         #[cfg(feature = "large_string")]
         Scalar::String64(v) => format!("\"{}\"", v),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(v, s) => format_decimal_string(*v as i128, *s),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(v, s) => format_decimal_string(*v as i128, *s),
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(v, s) => format_decimal_string(*v, *s),
         #[cfg(feature = "datetime")]
         Scalar::Datetime32(v) => v.to_string(),
         #[cfg(feature = "datetime")]

--- a/minarrow-py/src/dtype.rs
+++ b/minarrow-py/src/dtype.rs
@@ -63,6 +63,7 @@ impl TypeClass {
 pub enum DType {
     Integer,
     Float,
+    Decimal,
     String,
     Categorical,
     Datetime,
@@ -76,6 +77,7 @@ impl DType {
         match self {
             DType::Integer => "Integer",
             DType::Float => "Float",
+            DType::Decimal => "Decimal",
             DType::String => "String",
             DType::Categorical => "Categorical",
             DType::Datetime => "Datetime",
@@ -99,7 +101,7 @@ impl DType {
     #[getter]
     pub fn group(&self) -> TypeClass {
         match self {
-            DType::Integer | DType::Float => TypeClass::Numeric,
+            DType::Integer | DType::Float | DType::Decimal => TypeClass::Numeric,
             DType::String | DType::Categorical => TypeClass::Text,
             DType::Datetime => TypeClass::Temporal,
             DType::Boolean => TypeClass::Boolean,
@@ -109,7 +111,7 @@ impl DType {
 
     #[getter]
     fn is_numeric(&self) -> bool {
-        matches!(self, DType::Integer | DType::Float)
+        matches!(self, DType::Integer | DType::Float | DType::Decimal)
     }
 
     #[getter]
@@ -133,6 +135,8 @@ pub fn dtype_from_arrow(at: &ArrowType) -> DType {
         #[cfg(feature = "extended_numeric_types")]
         Int8 | Int16 | UInt8 | UInt16 => DType::Integer,
         Float32 | Float64 => DType::Float,
+        #[cfg(feature = "decimal")]
+        Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) => DType::Decimal,
         String | Utf8View => DType::String,
         #[cfg(feature = "large_string")]
         LargeString => DType::String,
@@ -157,6 +161,12 @@ pub fn width_from_arrow(at: &ArrowType) -> u32 {
         Int16 | UInt16 => 16,
         Int32 | UInt32 | Float32 => 32,
         Int64 | UInt64 | Float64 => 64,
+        #[cfg(feature = "decimal")]
+        Decimal32(_, _) => 32,
+        #[cfg(feature = "decimal")]
+        Decimal64(_, _) => 64,
+        #[cfg(feature = "decimal")]
+        Decimal128(_, _) => 128,
         String | Utf8View => 32,
         #[cfg(feature = "large_string")]
         LargeString => 64,

--- a/minarrow-py/tests/test_decimal.py
+++ b/minarrow-py/tests/test_decimal.py
@@ -1,0 +1,228 @@
+"""Tests for decimal array support in minarrow-py.
+
+Run after `maturin develop`:
+    python -m pytest tests/test_decimal.py
+"""
+
+import decimal
+
+import pytest
+
+import minarrow as mp
+
+
+# --- Construction from int values with dtype string -------------------------
+
+
+def test_decimal128_from_ints():
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    assert len(a) == 2
+    assert a.dtype == mp.DType.Decimal
+    assert a.dtype.group == mp.TypeClass.Numeric
+    assert a.dtype.is_numeric
+    assert a.precision == 10
+    assert a.scale == 2
+    assert a.bit_width == 128
+
+
+def test_decimal64_from_ints():
+    a = mp.Array([100, 200, 300], dtype="decimal64(18,4)")
+    assert len(a) == 3
+    assert a.precision == 18
+    assert a.scale == 4
+    assert a.bit_width == 64
+
+
+def test_decimal32_from_ints():
+    a = mp.Array([10, 20], dtype="decimal32(9,2)")
+    assert len(a) == 2
+    assert a.precision == 9
+    assert a.scale == 2
+    assert a.bit_width == 32
+
+
+def test_decimal_alias_is_decimal128():
+    a = mp.Array([100], dtype="decimal(10,2)")
+    assert str(a.arrow_type) == "Decimal128(10, 2)"
+    assert a.bit_width == 128
+
+
+def test_decimal_with_nulls():
+    a = mp.Array([12345, None, 67890], dtype="decimal128(10,2)")
+    assert len(a) == 3
+    assert a.null_count == 1
+
+
+# --- Precision and scale on non-decimal types --------------------------------
+
+
+def test_precision_for_int64():
+    a = mp.Array([1, 2, 3])
+    assert a.precision == 19
+    assert a.scale == 0
+
+
+def test_precision_for_float64():
+    a = mp.Array([1.0, 2.0])
+    assert a.precision == 15
+    assert a.scale is None
+
+
+# --- Element access ---------------------------------------------------------
+
+
+def test_getitem_returns_decimal():
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    val = a[0]
+    assert isinstance(val, decimal.Decimal)
+    assert val == decimal.Decimal("123.45")
+
+
+def test_getitem_null_is_none():
+    a = mp.Array([12345, None], dtype="decimal128(10,2)")
+    assert a[1] is None
+
+
+def test_getitem_negative_index():
+    a = mp.Array([100, 200, 300], dtype="decimal128(10,2)")
+    assert a[-1] == decimal.Decimal("3.00")
+
+
+# --- Display (repr) shows scale-formatted values ----------------------------
+
+
+def test_repr_shows_decimal_values():
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    text = repr(a)
+    assert "dtype: Decimal" in text
+    assert "123.45" in text
+    assert "678.90" in text
+
+
+def test_repr_shows_null():
+    a = mp.Array([12345, None], dtype="decimal128(10,2)")
+    text = repr(a)
+    assert "null" in text
+
+
+# --- Slicing ----------------------------------------------------------------
+
+
+def test_slice_preserves_decimal():
+    a = mp.Array([100, 200, 300, 400], dtype="decimal128(10,2)")
+    s = a[1:3]
+    assert len(s) == 2
+    assert s[0] == decimal.Decimal("2.00")
+    assert s[1] == decimal.Decimal("3.00")
+
+
+# --- Named column -----------------------------------------------------------
+
+
+def test_named_decimal_column():
+    a = mp.Array([12345, 67890], name="price", dtype="decimal128(10,2)")
+    assert a.name == "price"
+    assert a.precision == 10
+    assert a.scale == 2
+
+
+# --- ArrowType construction -------------------------------------------------
+
+
+def test_arrow_type_decimal128():
+    at = mp.ArrowType.Decimal128(precision=38, scale=10)
+    assert str(at) == "Decimal128(38, 10)"
+
+
+def test_arrow_type_decimal64():
+    at = mp.ArrowType.Decimal64(precision=18, scale=4)
+    assert str(at) == "Decimal64(18, 4)"
+
+
+def test_arrow_type_decimal32():
+    at = mp.ArrowType.Decimal32(precision=9, scale=2)
+    assert str(at) == "Decimal32(9, 2)"
+
+
+# --- Arrow interop (PyArrow round-trip) -------------------------------------
+
+
+def test_from_arrow_decimal128():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("123.45"), decimal.Decimal("678.90"), None],
+        type=pa.decimal128(10, 2),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    assert a.dtype == mp.DType.Decimal
+    assert a.precision == 10
+    assert a.scale == 2
+    assert len(a) == 3
+    assert a.null_count == 1
+    assert a[0] == decimal.Decimal("123.45")
+    assert a[1] == decimal.Decimal("678.90")
+    assert a[2] is None
+
+
+def test_to_arrow_roundtrip():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("19.99"), decimal.Decimal("29.99")],
+        type=pa.decimal128(10, 2),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    out = a.to_arrow()
+    assert out.to_pylist() == pa_arr.to_pylist()
+    assert out.type == pa.decimal128(10, 2)
+
+
+def test_pyarrow_roundtrip_with_nulls():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("1.23"), None, decimal.Decimal("-4.56")],
+        type=pa.decimal128(10, 2),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    out = a.to_arrow()
+    assert out.to_pylist() == pa_arr.to_pylist()
+
+
+def test_pyarrow_high_precision():
+    import pyarrow as pa
+
+    pa_arr = pa.array(
+        [decimal.Decimal("12345678901234567890.1234567890")],
+        type=pa.decimal128(38, 10),
+    )
+    a = mp.Array.from_arrow(pa_arr)
+    assert a.precision == 38
+    assert a.scale == 10
+    out = a.to_arrow()
+    assert out.to_pylist() == pa_arr.to_pylist()
+
+
+# --- PyCapsule protocol (consumed by PyArrow) -------------------------------
+
+
+def test_pycapsule_consumed_by_pyarrow():
+    import pyarrow as pa
+
+    a = mp.Array([12345, 67890], dtype="decimal128(10,2)")
+    pa_arr = pa.array(a)
+    assert pa_arr.type == pa.decimal128(10, 2)
+    assert pa_arr.to_pylist() == [decimal.Decimal("123.45"), decimal.Decimal("678.90")]
+
+
+def test_pycapsule_with_nulls():
+    import pyarrow as pa
+
+    a = mp.Array([12345, None, 67890], dtype="decimal128(10,2)")
+    pa_arr = pa.array(a)
+    assert pa_arr.to_pylist() == [
+        decimal.Decimal("123.45"),
+        None,
+        decimal.Decimal("678.90"),
+    ]

--- a/pyo3/Cargo.lock
+++ b/pyo3/Cargo.lock
@@ -186,6 +186,6 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "vec64"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5a35bf381f20a9d41312bd977f43e997ab5bc82deb85b503b3346e6a437b7"
+checksum = "1aef6bbef159f21ac387220ebc71141524423f7886afd390bc7b140f12630425"

--- a/pyo3/Cargo.toml
+++ b/pyo3/Cargo.toml
@@ -29,7 +29,7 @@ pyo3 = { version = "0.29" }
 thiserror = "2"
 
 [features]
-default = ["datetime", "extended_numeric_types"]
+default = ["datetime", "extended_numeric_types", "decimal"]
 extension-module = ["pyo3/extension-module"]
 datetime = ["minarrow/datetime"]
 extended_numeric_types = ["minarrow/extended_numeric_types"]
@@ -39,6 +39,7 @@ default_categorical_8 = ["minarrow/default_categorical_8"]
 # Enables 8, 16 and 64 byte categorical bit widths. When combined with default_categorical_8,
 # the extra one added is the 32 byte (making the other feature unused).
 extended_categorical = ["minarrow/extended_categorical"]
+decimal = ["minarrow/decimal"]
 table_metadata = ["minarrow/table_metadata"]
 # N-dimensional tensor bridging with DLPack capsule interchange.
 ndarray = ["minarrow/ndarray", "minarrow/dlpack", "minarrow/views", "minarrow/select"]

--- a/pyo3/src/ffi/mod.rs
+++ b/pyo3/src/ffi/mod.rs
@@ -97,6 +97,19 @@
 //! | `IntegerArray<u8>` | `NumericArray::UInt8` | `C` | `pa.UInt8Array` |
 //! | `IntegerArray<u16>` | `NumericArray::UInt16` | `S` | `pa.UInt16Array` |
 //!
+//! ### Decimal types (feature `decimal`)
+//!
+//! | MinArrow inner type | `Array` enum path | Arrow format | PyArrow type |
+//! |---------------------|-------------------|--------------|--------------|
+//! | `DecimalArray<i32>` | `NumericArray::Decimal32` | `d:P,S,32` | `pa.Decimal128Array` |
+//! | `DecimalArray<i64>` | `NumericArray::Decimal64` | `d:P,S,64` | `pa.Decimal128Array` |
+//! | `DecimalArray<i128>` | `NumericArray::Decimal128` | `d:P,S` | `pa.Decimal128Array` |
+//!
+//! Decimal32 and Decimal64 map to PyArrow's `Decimal128Array` because PyArrow only
+//! supports 128-bit decimal. The underlying Arrow C Data Interface format string
+//! carries the true bit width, so a Decimal32 or Decimal64 array imported back into
+//! MinArrow retains its original width.
+//!
 //! ### Boolean
 //!
 //! | MinArrow inner type | `Array` enum path | Arrow format | PyArrow type |

--- a/pyo3/src/ffi/to_py.rs
+++ b/pyo3/src/ffi/to_py.rs
@@ -129,6 +129,21 @@ fn arrow_type_to_pyarrow<'py>(
             pa.call_method0("null")
         }
 
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal128(p, s) => pa.call_method1("decimal128", (*p, *s)),
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(p, s) => {
+            // PyArrow has no Decimal32 type so map to Decimal128 with the same
+            // precision and scale.
+            pa.call_method1("decimal128", (*p, *s))
+        }
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal64(p, s) => {
+            // PyArrow has no Decimal64 type so map to Decimal128 with the same
+            // precision and scale.
+            pa.call_method1("decimal128", (*p, *s))
+        }
+
         ArrowType::Dictionary(key_type) => {
             let index_ty = pa.call_method0(key_type.arrow_index_name())?;
             let value_ty = pa.call_method0("utf8")?;

--- a/pyo3/tests/test_roundtrip.py
+++ b/pyo3/tests/test_roundtrip.py
@@ -238,6 +238,50 @@ print(f"  Output: {len(result)} elements, {result.num_chunks} chunks")
 assert chunked.to_pylist() == result.to_pylist(), "String ChunkedArray mismatch!"
 print("  ✓ PASSED")
 
+# Test 21: Decimal128 Array roundtrip
+print("\nTest 21: Decimal128 Array Roundtrip")
+print("-" * 40)
+import decimal
+arr = pa.array([decimal.Decimal("123.45"), decimal.Decimal("678.90"), None], type=pa.decimal128(10, 2))
+print(f"  Input:  {arr.to_pylist()}")
+result = ma.echo_array(arr)
+print(f"  Output: {result.to_pylist()}")
+assert arr.to_pylist() == result.to_pylist(), "Decimal128 array mismatch!"
+assert result.type == arr.type, f"Decimal128 type mismatch: expected {arr.type}, got {result.type}"
+print("  ✓ PASSED")
+
+# Test 22: Decimal128 Array roundtrip with high precision
+print("\nTest 22: Decimal128 High Precision Roundtrip")
+print("-" * 40)
+arr = pa.array(
+    [decimal.Decimal("12345678901234567890.1234567890"), None, decimal.Decimal("-9876543210.0987654321")],
+    type=pa.decimal128(38, 10),
+)
+print(f"  Input:  {arr.to_pylist()}")
+result = ma.echo_array(arr)
+print(f"  Output: {result.to_pylist()}")
+assert arr.to_pylist() == result.to_pylist(), "Decimal128 high precision array mismatch!"
+assert result.type == arr.type, f"Decimal128 type mismatch: expected {arr.type}, got {result.type}"
+print("  ✓ PASSED")
+
+# Test 23: Decimal128 in RecordBatch roundtrip
+print("\nTest 23: Decimal128 in RecordBatch Roundtrip")
+print("-" * 40)
+batch = pa.RecordBatch.from_pydict({
+    "id": pa.array([1, 2, 3], type=pa.int64()),
+    "price": pa.array(
+        [decimal.Decimal("19.99"), decimal.Decimal("29.99"), decimal.Decimal("39.99")],
+        type=pa.decimal128(10, 2),
+    ),
+})
+print(f"  Input:  {batch.num_rows} rows, {batch.num_columns} cols")
+result = ma.echo_batch(batch)
+print(f"  Output: {result.num_rows} rows, {result.num_columns} cols")
+assert batch.column("id").to_pylist() == result.column("id").to_pylist(), "ID column mismatch!"
+assert batch.column("price").to_pylist() == result.column("price").to_pylist(), "Price column mismatch!"
+assert result.schema.field("price").type == pa.decimal128(10, 2), "Decimal type not preserved in RecordBatch!"
+print("  ✓ PASSED")
+
 print("\n" + "=" * 50)
 print("All tests PASSED!")
 print("=" * 50)

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -46,6 +46,8 @@
 
 #[cfg(feature = "datetime")]
 use crate::DatetimeArray;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 #[cfg(all(feature = "cube", feature = "views"))]
 use crate::TableV;
 use crate::{
@@ -244,6 +246,10 @@ pub type IntegerAVT<'a, T> = (&'a IntegerArray<T>, Offset, Length);
 
 /// Logical windowed ***A**rray **V**iew **T**uple* over a primitive float array.
 pub type FloatAVT<'a, T> = (&'a FloatArray<T>, Offset, Length);
+
+/// Logical windowed ***A**rray **V**iew **T**uple* over a decimal array.
+#[cfg(feature = "decimal")]
+pub type DecimalAVT<'a, T> = (&'a DecimalArray<T>, Offset, Length);
 
 /// Logical windowed ***A**rray **V**iew **T**uple* over an `Array` and its `Field`: *((array, offset, len), field)*.
 ///

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1167,6 +1167,50 @@ impl View for FloatArray<f64> {
     type BufferT = f64;
 }
 
+// --------- DecimalArray Variants ---------
+
+#[cfg(feature = "decimal")]
+impl From<crate::DecimalArray<i32>> for Array {
+    fn from(a: crate::DecimalArray<i32>) -> Self {
+        Array::NumericArray(NumericArray::Decimal32(Arc::new(a)))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<crate::DecimalArray<i64>> for Array {
+    fn from(a: crate::DecimalArray<i64>) -> Self {
+        Array::NumericArray(NumericArray::Decimal64(Arc::new(a)))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<crate::DecimalArray<i128>> for Array {
+    fn from(a: crate::DecimalArray<i128>) -> Self {
+        Array::NumericArray(NumericArray::Decimal128(Arc::new(a)))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<crate::DecimalArray<i32>>> for Array {
+    fn from(a: Arc<crate::DecimalArray<i32>>) -> Self {
+        Array::NumericArray(NumericArray::Decimal32(a))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<crate::DecimalArray<i64>>> for Array {
+    fn from(a: Arc<crate::DecimalArray<i64>>) -> Self {
+        Array::NumericArray(NumericArray::Decimal64(a))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<crate::DecimalArray<i128>>> for Array {
+    fn from(a: Arc<crate::DecimalArray<i128>>) -> Self {
+        Array::NumericArray(NumericArray::Decimal128(a))
+    }
+}
+
 // --------- TemporalArray Variants ---------
 
 #[cfg(feature = "datetime")]
@@ -1393,6 +1437,18 @@ impl From<Scalar> for Array {
             Datetime64(v) => Array::from_datetime_i64(DatetimeArray::from_slice(&[v], None)),
             #[cfg(feature = "datetime")]
             Interval => Array::from_int32(IntegerArray::from_slice(&[0i32])),
+            #[cfg(feature = "decimal")]
+            Decimal32(v, s) => Array::from_decimal32(
+                crate::DecimalArray::from_slice(&[v], 0, s),
+            ),
+            #[cfg(feature = "decimal")]
+            Decimal64(v, s) => Array::from_decimal64(
+                crate::DecimalArray::from_slice(&[v], 0, s),
+            ),
+            #[cfg(feature = "decimal")]
+            Decimal128(v, s) => Array::from_decimal128(
+                crate::DecimalArray::from_slice(&[v], 0, s),
+            ),
         }
     }
 }

--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -41,6 +41,8 @@ use crate::ArrayV;
 use crate::ArrayVT;
 #[cfg(feature = "datetime")]
 use crate::DatetimeArray;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 #[cfg(feature = "chunked")]
 use crate::SuperArray;
 #[cfg(feature = "datetime")]
@@ -1472,6 +1474,12 @@ impl Array {
         match_arm!(NumericArray, UInt64, IntegerArray<u64>);
         match_arm!(NumericArray, Float32, FloatArray<f32>);
         match_arm!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal128, DecimalArray<i128>);
 
         // TextArray
         match_arm!(TextArray, String32, StringArray<u32>);
@@ -1546,6 +1554,12 @@ impl Array {
         match_arm!(NumericArray, UInt64, IntegerArray<u64>);
         match_arm!(NumericArray, Float32, FloatArray<f32>);
         match_arm!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_arm!(NumericArray, Decimal128, DecimalArray<i128>);
 
         // TextArray
         match_arm!(TextArray, String32, StringArray<u32>);
@@ -1619,6 +1633,12 @@ impl Array {
         match_inner_type!(NumericArray, UInt64, IntegerArray<u64>);
         match_inner_type!(NumericArray, Float32, FloatArray<f32>);
         match_inner_type!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_inner_type!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type!(NumericArray, Decimal128, DecimalArray<i128>);
 
         match_inner_type!(TextArray, String32, StringArray<u32>);
         #[cfg(feature = "large_string")]
@@ -1686,6 +1706,12 @@ impl Array {
         match_inner_type_mut!(NumericArray, UInt64, IntegerArray<u64>);
         match_inner_type_mut!(NumericArray, Float32, FloatArray<f32>);
         match_inner_type_mut!(NumericArray, Float64, FloatArray<f64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type_mut!(NumericArray, Decimal32, DecimalArray<i32>);
+        #[cfg(feature = "decimal")]
+        match_inner_type_mut!(NumericArray, Decimal64, DecimalArray<i64>);
+        #[cfg(feature = "decimal")]
+        match_inner_type_mut!(NumericArray, Decimal128, DecimalArray<i128>);
 
         match_inner_type_mut!(TextArray, String32, StringArray<u32>);
         #[cfg(feature = "large_string")]

--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -4802,6 +4802,38 @@ macro_rules! arr_f64 {
     };
 }
 
+// ======== Decimal ========
+
+#[cfg(feature = "decimal")]
+#[macro_export]
+macro_rules! arr_dec32 {
+    (&[ $($x:expr),+ $(,)? ], $p:expr, $s:expr) => {{
+        $crate::Array::from_decimal32(
+            $crate::DecimalArray::<i32>::from_slice(&[$($x),+], $p, $s)
+        )
+    }};
+}
+
+#[cfg(feature = "decimal")]
+#[macro_export]
+macro_rules! arr_dec64 {
+    (&[ $($x:expr),+ $(,)? ], $p:expr, $s:expr) => {{
+        $crate::Array::from_decimal64(
+            $crate::DecimalArray::<i64>::from_slice(&[$($x),+], $p, $s)
+        )
+    }};
+}
+
+#[cfg(feature = "decimal")]
+#[macro_export]
+macro_rules! arr_dec128 {
+    (&[ $($x:expr),+ $(,)? ], $p:expr, $s:expr) => {{
+        $crate::Array::from_decimal128(
+            $crate::DecimalArray::<i128>::from_slice(&[$($x),+], $p, $s)
+        )
+    }};
+}
+
 // ======== Boolean ========
 
 #[macro_export]

--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -2525,6 +2525,10 @@ impl Array {
                 arr.null_mask = Some(mask);
                 Array::from_string32(arr)
             }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("null_array: DecimalArray is not yet available")
+            }
         }
     }
 
@@ -2608,6 +2612,10 @@ impl Array {
             ArrowType::Interval(_) => Array::TemporalArray(crate::TemporalArray::Datetime64(
                 Arc::new(crate::DatetimeArray::<i64>::default()),
             )),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("from_arrow_dtype: DecimalArray is not yet available")
+            }
         }
     }
 

--- a/src/enums/array.rs
+++ b/src/enums/array.rs
@@ -230,6 +230,24 @@ impl Array {
         Array::TemporalArray(TemporalArray::Datetime64(Arc::new(arr)))
     }
 
+    /// Creates an Array enum with a Decimal32 array.
+    #[cfg(feature = "decimal")]
+    pub fn from_decimal32(arr: crate::DecimalArray<i32>) -> Self {
+        Array::NumericArray(NumericArray::Decimal32(Arc::new(arr)))
+    }
+
+    /// Creates an Array enum with a Decimal64 array.
+    #[cfg(feature = "decimal")]
+    pub fn from_decimal64(arr: crate::DecimalArray<i64>) -> Self {
+        Array::NumericArray(NumericArray::Decimal64(Arc::new(arr)))
+    }
+
+    /// Creates an Array enum with a Decimal128 array.
+    #[cfg(feature = "decimal")]
+    pub fn from_decimal128(arr: crate::DecimalArray<i128>) -> Self {
+        Array::NumericArray(NumericArray::Decimal128(Arc::new(arr)))
+    }
+
     /// Creates an Array enum with a Boolean array.
     pub fn from_bool(arr: BooleanArray<()>) -> Self {
         Array::BooleanArray(Arc::new(arr))
@@ -870,6 +888,19 @@ impl Array {
                 NumericArray::Float64(a) => {
                     Arc::make_mut(a).push(value.try_f64().ok_or_else(unsupported)?)
                 }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    Arc::make_mut(a).push(value.try_i32().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    Arc::make_mut(a).push(value.try_i64().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)?;
+                    Arc::make_mut(a).push(v as i128)
+                }
                 NumericArray::Null => return Err(unsupported()),
             },
             Array::BooleanArray(a) => {
@@ -944,6 +975,12 @@ impl Array {
                 NumericArray::UInt64(a) => Arc::make_mut(a).push_null(),
                 NumericArray::Float32(a) => Arc::make_mut(a).push_null(),
                 NumericArray::Float64(a) => Arc::make_mut(a).push_null(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => Arc::make_mut(a).push_null(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => Arc::make_mut(a).push_null(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => Arc::make_mut(a).push_null(),
                 NumericArray::Null => return Err(unsupported()),
             },
             Array::BooleanArray(a) => Arc::make_mut(a).push_null(),
@@ -1036,6 +1073,19 @@ impl Array {
                 }
                 NumericArray::Float64(a) => {
                     Arc::make_mut(a).set(idx, value.try_f64().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    Arc::make_mut(a).set(idx, value.try_i32().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    Arc::make_mut(a).set(idx, value.try_i64().ok_or_else(unsupported)?)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)?;
+                    Arc::make_mut(a).set(idx, v as i128)
                 }
                 NumericArray::Null => return Err(unsupported()),
             },
@@ -1213,6 +1263,33 @@ impl Array {
                 }
                 NumericArray::Float64(a) => {
                     let v = value.try_f64().ok_or_else(unsupported)?;
+                    let arr = Arc::make_mut(a);
+                    arr.data.as_mut_slice()[range.clone()].fill(v);
+                    if let Some(mask) = &mut arr.null_mask {
+                        mask.set_range(range.start, range.end, true);
+                    }
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    let v = value.try_i32().ok_or_else(unsupported)?;
+                    let arr = Arc::make_mut(a);
+                    arr.data.as_mut_slice()[range.clone()].fill(v);
+                    if let Some(mask) = &mut arr.null_mask {
+                        mask.set_range(range.start, range.end, true);
+                    }
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)?;
+                    let arr = Arc::make_mut(a);
+                    arr.data.as_mut_slice()[range.clone()].fill(v);
+                    if let Some(mask) = &mut arr.null_mask {
+                        mask.set_range(range.start, range.end, true);
+                    }
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    let v = value.try_i64().ok_or_else(unsupported)? as i128;
                     let arr = Arc::make_mut(a);
                     arr.data.as_mut_slice()[range.clone()].fill(v);
                     if let Some(mask) = &mut arr.null_mask {
@@ -1687,6 +1764,21 @@ impl Array {
                     cast_slice::<f64, T>(arr.data(), offset, len).expect("cast failed")
                 }
 
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    cast_slice::<i32, T>(arr.data(), offset, len).expect("cast failed")
+                }
+
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    cast_slice::<i64, T>(arr.data(), offset, len).expect("cast failed")
+                }
+
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    cast_slice::<i128, T>(arr.data(), offset, len).expect("cast failed")
+                }
+
                 NumericArray::Null => panic!("Null array has no data payload"),
             },
 
@@ -1861,6 +1953,12 @@ impl Array {
                 NumericArray::UInt64(arr) => NumericArray::UInt64(arr.slice_clone(offset, len)),
                 NumericArray::Float32(arr) => NumericArray::Float32(arr.slice_clone(offset, len)),
                 NumericArray::Float64(arr) => NumericArray::Float64(arr.slice_clone(offset, len)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => NumericArray::Decimal32(arr.slice_clone(offset, len)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => NumericArray::Decimal64(arr.slice_clone(offset, len)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => NumericArray::Decimal128(arr.slice_clone(offset, len)),
                 NumericArray::Null => NumericArray::Null,
             }),
             Array::TextArray(inner) => Self::TextArray(match inner {
@@ -1921,6 +2019,12 @@ impl Array {
                 NumericArray::UInt64(_) => ArrowType::UInt64,
                 NumericArray::Float32(_) => ArrowType::Float32,
                 NumericArray::Float64(_) => ArrowType::Float64,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.arrow_type(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.arrow_type(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.arrow_type(),
                 NumericArray::Null => ArrowType::Null,
             },
             Array::TextArray(inner) => match inner {
@@ -2080,6 +2184,12 @@ impl Array {
                 NumericArray::UInt64(_) => true,
                 NumericArray::Float32(_) => false,
                 NumericArray::Float64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => false,
                 NumericArray::Null => false,
             },
             Array::TextArray(_) => false,
@@ -2109,6 +2219,12 @@ impl Array {
                 NumericArray::UInt16(_) => false,
                 NumericArray::UInt32(_) => false,
                 NumericArray::UInt64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => false,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => false,
                 NumericArray::Null => false,
             },
             Array::TextArray(_) => false,
@@ -2138,6 +2254,12 @@ impl Array {
                 NumericArray::UInt64(_) => true,
                 NumericArray::Float32(_) => true,
                 NumericArray::Float64(_) => true,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => true,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => true,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => true,
                 NumericArray::Null => false,
             },
             Array::TextArray(_) => false,
@@ -2183,6 +2305,12 @@ impl Array {
                 NumericArray::UInt64(arr) => arr.null_mask.as_ref(),
                 NumericArray::Float32(arr) => arr.null_mask.as_ref(),
                 NumericArray::Float64(arr) => arr.null_mask.as_ref(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => arr.null_mask.as_ref(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => arr.null_mask.as_ref(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => arr.null_mask.as_ref(),
                 NumericArray::Null => None,
             },
             Array::BooleanArray(arr) => arr.null_mask.as_ref(),
@@ -2380,6 +2508,12 @@ impl Array {
                 NumericArray::UInt64(a) => Some(Scalar::UInt64(a.data[idx])),
                 NumericArray::Float32(a) => Some(Scalar::Float32(a.data[idx])),
                 NumericArray::Float64(a) => Some(Scalar::Float64(a.data[idx])),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => Some(Scalar::Decimal32(a.data[idx], a.scale)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => Some(Scalar::Decimal64(a.data[idx], a.scale)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => Some(Scalar::Decimal128(a.data[idx], a.scale)),
                 NumericArray::Null => Some(Scalar::Null),
             },
             Array::TextArray(text) => match text {
@@ -2526,8 +2660,25 @@ impl Array {
                 Array::from_string32(arr)
             }
             #[cfg(feature = "decimal")]
-            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
-                panic!("null_array: DecimalArray is not yet available")
+            ArrowType::Decimal32(p, s) => {
+                let arr = crate::DecimalArray::<i32>::new(
+                    Vec64::from_slice(&vec![0i32; n_rows]), Some(mask), *p, *s,
+                );
+                Array::NumericArray(NumericArray::Decimal32(Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => {
+                let arr = crate::DecimalArray::<i64>::new(
+                    Vec64::from_slice(&vec![0i64; n_rows]), Some(mask), *p, *s,
+                );
+                Array::NumericArray(NumericArray::Decimal64(Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => {
+                let arr = crate::DecimalArray::<i128>::new(
+                    Vec64::from_slice(&vec![0i128; n_rows]), Some(mask), *p, *s,
+                );
+                Array::NumericArray(NumericArray::Decimal128(Arc::new(arr)))
             }
         }
     }
@@ -2613,8 +2764,22 @@ impl Array {
                 Arc::new(crate::DatetimeArray::<i64>::default()),
             )),
             #[cfg(feature = "decimal")]
-            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
-                panic!("from_arrow_dtype: DecimalArray is not yet available")
+            ArrowType::Decimal32(p, s) => {
+                Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                    crate::DecimalArray::<i32>::new(Vec64::new(), None, *p, *s),
+                )))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => {
+                Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                    crate::DecimalArray::<i64>::new(Vec64::new(), None, *p, *s),
+                )))
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => {
+                Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                    crate::DecimalArray::<i128>::new(Vec64::new(), None, *p, *s),
+                )))
             }
         }
     }
@@ -2947,6 +3112,75 @@ impl Array {
                     if has_nulls { Some(mask) } else { None },
                 ))
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, scale) => {
+                let scale = *scale;
+                let mut data = Vec64::<i32>::with_capacity(scalars.len());
+                let mut mask = Bitmask::new_set_all(scalars.len(), true);
+                for (i, s) in scalars.iter().enumerate() {
+                    match s {
+                        Scalar::Decimal32(v, _) => data.push(*v),
+                        Scalar::Null => {
+                            data.push(0);
+                            mask.set(i, false);
+                        }
+                        _ => data.push(s.i32()),
+                    }
+                }
+                let has_nulls = mask.count_zeros() > 0;
+                Array::from_decimal32(crate::DecimalArray::new(
+                    data,
+                    if has_nulls { Some(mask) } else { None },
+                    0,
+                    scale,
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(_, scale) => {
+                let scale = *scale;
+                let mut data = Vec64::<i64>::with_capacity(scalars.len());
+                let mut mask = Bitmask::new_set_all(scalars.len(), true);
+                for (i, s) in scalars.iter().enumerate() {
+                    match s {
+                        Scalar::Decimal64(v, _) => data.push(*v),
+                        Scalar::Null => {
+                            data.push(0);
+                            mask.set(i, false);
+                        }
+                        _ => data.push(s.i64()),
+                    }
+                }
+                let has_nulls = mask.count_zeros() > 0;
+                Array::from_decimal64(crate::DecimalArray::new(
+                    data,
+                    if has_nulls { Some(mask) } else { None },
+                    0,
+                    scale,
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(_, scale) => {
+                let scale = *scale;
+                let mut data = Vec64::<i128>::with_capacity(scalars.len());
+                let mut mask = Bitmask::new_set_all(scalars.len(), true);
+                for (i, s) in scalars.iter().enumerate() {
+                    match s {
+                        Scalar::Decimal128(v, _) => data.push(*v),
+                        Scalar::Null => {
+                            data.push(0);
+                            mask.set(i, false);
+                        }
+                        _ => data.push(s.i64() as i128),
+                    }
+                }
+                let has_nulls = mask.count_zeros() > 0;
+                Array::from_decimal128(crate::DecimalArray::new(
+                    data,
+                    if has_nulls { Some(mask) } else { None },
+                    0,
+                    scale,
+                ))
+            }
             Scalar::Null => Array::Null,
         }
     }
@@ -2985,6 +3219,12 @@ impl Array {
                 NumericArray::UInt16(a) => a.data[i].cmp(&a.data[j]),
                 NumericArray::Float32(a) => a.data[i].total_cmp(&a.data[j]),
                 NumericArray::Float64(a) => a.data[i].total_cmp(&a.data[j]),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.data[i].cmp(&a.data[j]),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.data[i].cmp(&a.data[j]),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.data[i].cmp(&a.data[j]),
                 NumericArray::Null => Ordering::Equal,
             },
             Array::BooleanArray(b) => b.data.get(i).cmp(&b.data.get(j)),
@@ -3075,6 +3315,18 @@ impl Array {
                 (NumericArray::Float64(x), NumericArray::Float64(y)) => {
                     let (a, b) = (x.data[idx], y.data[other_idx]);
                     if a.is_nan() { b.is_nan() } else { a == b }
+                }
+                #[cfg(feature = "decimal")]
+                (NumericArray::Decimal32(x), NumericArray::Decimal32(y)) => {
+                    x.data[idx] == y.data[other_idx]
+                }
+                #[cfg(feature = "decimal")]
+                (NumericArray::Decimal64(x), NumericArray::Decimal64(y)) => {
+                    x.data[idx] == y.data[other_idx]
+                }
+                #[cfg(feature = "decimal")]
+                (NumericArray::Decimal128(x), NumericArray::Decimal128(y)) => {
+                    x.data[idx] == y.data[other_idx]
                 }
                 (NumericArray::Null, NumericArray::Null) => true,
                 _ => false,
@@ -3173,6 +3425,12 @@ impl Array {
                         if v.is_nan() { 0x7ff8_0000_0000_0000u64 } else { (v + 0.0).to_bits() };
                     bits.hash(state);
                 }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.data[idx].hash(state),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.data[idx].hash(state),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.data[idx].hash(state),
                 NumericArray::Null => 0xDEAD_BEEF_u64.hash(state),
             },
             Array::BooleanArray(b) => b.data.get(idx).hash(state),
@@ -3240,6 +3498,18 @@ impl Array {
                         Arc::make_mut(arr).set_null_mask(Some(mask));
                     }
                     NumericArray::UInt64(arr) => {
+                        Arc::make_mut(arr).set_null_mask(Some(mask));
+                    }
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal32(arr) => {
+                        Arc::make_mut(arr).set_null_mask(Some(mask));
+                    }
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal64(arr) => {
+                        Arc::make_mut(arr).set_null_mask(Some(mask));
+                    }
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal128(arr) => {
                         Arc::make_mut(arr).set_null_mask(Some(mask));
                     }
                     NumericArray::Null => {} // No-op for null arrays
@@ -3352,6 +3622,24 @@ impl Array {
                     a.len(),
                     std::mem::size_of::<f64>(),
                 ),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => (
+                    a.data.as_ptr() as *const u8,
+                    a.len(),
+                    std::mem::size_of::<i32>(),
+                ),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => (
+                    a.data.as_ptr() as *const u8,
+                    a.len(),
+                    std::mem::size_of::<i64>(),
+                ),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => (
+                    a.data.as_ptr() as *const u8,
+                    a.len(),
+                    std::mem::size_of::<i128>(),
+                ),
                 NumericArray::Null => (std::ptr::null(), 0, 0),
             },
             Array::BooleanArray(a) => (a.data.as_ptr() as *const u8, a.data.len(), 1),
@@ -3426,6 +3714,18 @@ impl Array {
                     a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
                 }
                 NumericArray::Float64(a) => {
+                    a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
                     a.null_mask.as_ref().map(|m| (m.as_ptr(), m.capacity()))
                 }
                 NumericArray::Null => None,
@@ -3507,6 +3807,12 @@ impl Array {
                 NumericArray::UInt64(a) => a.null_count(),
                 NumericArray::Float32(a) => a.null_count(),
                 NumericArray::Float64(a) => a.null_count(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => a.null_count(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => a.null_count(),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => a.null_count(),
                 NumericArray::Null => 0,
             },
             Array::BooleanArray(a) => a.null_count(),
@@ -6860,5 +7166,170 @@ mod arr_macro_extensions_tests {
         assert_eq!(arr.get::<FloatArray<f64>>(0), Some(1.0));
         assert_eq!(arr.get::<FloatArray<f64>>(1), None);
         assert_eq!(arr.get::<FloatArray<f64>>(3), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Decimal Array integration
+    // -----------------------------------------------------------------------
+
+    #[cfg(feature = "decimal")]
+    mod decimal_integration {
+        use super::*;
+        use crate::DecimalArray;
+        use std::sync::Arc;
+
+        #[test]
+        fn from_decimal_constructors() {
+            let d32 = DecimalArray::<i32>::from_slice(&[12345], 9, 2);
+            let arr = Array::from_decimal32(d32);
+            assert_eq!(arr.len(), 1);
+            assert_eq!(arr.arrow_type(), crate::ffi::arrow_dtype::ArrowType::Decimal32(9, 2));
+
+            let d64 = DecimalArray::<i64>::from_slice(&[99999], 18, 4);
+            let arr = Array::from_decimal64(d64);
+            assert_eq!(arr.len(), 1);
+
+            let d128 = DecimalArray::<i128>::from_slice(&[1000000], 38, 10);
+            let arr = Array::from_decimal128(d128);
+            assert_eq!(arr.len(), 1);
+        }
+
+        #[test]
+        fn from_impl_decimal_to_array() {
+            let d = DecimalArray::<i64>::from_slice(&[42], 18, 4);
+            let arr: Array = d.into();
+            assert_eq!(arr.len(), 1);
+            assert!(arr.is_numerical_array());
+        }
+
+        #[test]
+        fn from_arc_decimal_to_array() {
+            let d = Arc::new(DecimalArray::<i128>::from_slice(&[999], 38, 10));
+            let arr: Array = d.into();
+            assert_eq!(arr.len(), 1);
+        }
+
+        #[test]
+        fn decimal_through_num_accessor() {
+            let d = DecimalArray::<i64>::from_slice(&[12345, 67890], 18, 2);
+            let arr = Array::from_decimal64(d);
+            let num = arr.num();
+            let inner = num.dec64();
+            assert_eq!(inner.len(), 2);
+            assert_eq!(inner.get(0), Some(12345i64));
+        }
+
+        #[test]
+        fn decimal_try_dec128_widening_through_array() {
+            let d = DecimalArray::<i32>::from_slice(&[42], 9, 3);
+            let arr = Array::from_decimal32(d);
+            let num = arr.num();
+            let wide = num.try_dec128().unwrap();
+            assert_eq!(wide.get(0), Some(42i128));
+            assert_eq!(wide.scale, 3);
+        }
+
+        #[test]
+        fn decimal_null_mask_through_array() {
+            let mut d = DecimalArray::<i32>::with_capacity(2, true, 9, 2);
+            d.push(10);
+            d.push_null();
+            let arr = Array::from_decimal32(d);
+            assert!(arr.null_mask().is_some());
+            assert!(arr.has_nulls());
+        }
+
+        #[test]
+        fn decimal_len_and_delete_range() {
+            let d = DecimalArray::<i64>::from_slice(&[1, 2, 3, 4], 18, 0);
+            let mut arr = Array::from_decimal64(d);
+            assert_eq!(arr.len(), 4);
+            arr.delete_range(1, 3);
+            assert_eq!(arr.len(), 2);
+        }
+
+        #[test]
+        fn decimal_from_arrow_dtype() {
+            use crate::ffi::arrow_dtype::ArrowType;
+            let arr = Array::from_arrow_dtype(&ArrowType::Decimal64(18, 4));
+            assert_eq!(arr.len(), 0);
+            assert_eq!(arr.arrow_type(), ArrowType::Decimal64(18, 4));
+        }
+
+        #[test]
+        fn decimal_null_array() {
+            use crate::ffi::arrow_dtype::ArrowType;
+            let arr = Array::null_array(&ArrowType::Decimal128(38, 10), 5);
+            assert_eq!(arr.len(), 5);
+            assert!(arr.null_mask().is_some());
+        }
+
+        #[test]
+        fn field_array_round_trip() {
+            let d = DecimalArray::<i64>::from_slice(&[12345, 67890], 18, 2);
+            let arr = Array::from_decimal64(d);
+            let fa = arr.fa("amount");
+            assert_eq!(fa.field.name, "amount");
+            assert_eq!(fa.len(), 2);
+            assert_eq!(
+                fa.arrow_type(),
+                crate::ffi::arrow_dtype::ArrowType::Decimal64(18, 2)
+            );
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn get_scalar_decimal() {
+            let d = DecimalArray::<i32>::from_slice(&[12345], 9, 2);
+            let arr = Array::from_decimal32(d);
+            let s = arr.get_scalar(0).unwrap();
+            match s {
+                crate::Scalar::Decimal32(v, scale) => {
+                    assert_eq!(v, 12345);
+                    assert_eq!(scale, 2);
+                }
+                _ => panic!("expected Scalar::Decimal32"),
+            }
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn scalar_decimal_display() {
+            let s = crate::Scalar::Decimal64(12345, 2);
+            assert_eq!(format!("{}", s), "123.45");
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn scalar_decimal_zero_scale() {
+            let s = crate::Scalar::Decimal128(42, 0);
+            assert_eq!(format!("{}", s), "42");
+        }
+
+        #[cfg(feature = "scalar_type")]
+        #[test]
+        fn scalar_decimal_negative_scale() {
+            let s = crate::Scalar::Decimal32(5, -2);
+            assert_eq!(format!("{}", s), "500");
+        }
+
+        #[cfg(feature = "hash")]
+        #[test]
+        fn decimal_value_eq_and_hash_agree() {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::Hasher;
+
+            let a = Array::from_decimal64(DecimalArray::<i64>::from_slice(&[100, 200], 18, 2));
+            let b = Array::from_decimal64(DecimalArray::<i64>::from_slice(&[100, 300], 18, 2));
+
+            assert!(a.value_eq(0, &b, 0));
+            assert!(!a.value_eq(1, &b, 1));
+
+            let mut h1 = DefaultHasher::new();
+            let mut h2 = DefaultHasher::new();
+            a.hash_element_at(0, &mut h1);
+            b.hash_element_at(0, &mut h2);
+            assert_eq!(h1.finish(), h2.finish());
+        }
     }
 }

--- a/src/enums/collections/numeric_array.rs
+++ b/src/enums/collections/numeric_array.rs
@@ -32,6 +32,10 @@ use std::{
 
 use crate::{Bitmask, FloatArray, IntegerArray, MaskedArray, Vec64};
 use crate::{BooleanArray, StringArray};
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
+#[cfg(feature = "decimal")]
+use crate::structs::variants::decimal::format_decimal_value;
 use crate::{
     enums::{error::MinarrowError, shape_dim::ShapeDim},
     traits::{concatenate::Concatenate, shape::Shape},
@@ -93,8 +97,95 @@ pub enum NumericArray {
     UInt64(Arc<IntegerArray<u64>>),
     Float32(Arc<FloatArray<f32>>),
     Float64(Arc<FloatArray<f64>>),
+    #[cfg(feature = "decimal")]
+    Decimal32(Arc<DecimalArray<i32>>),
+    #[cfg(feature = "decimal")]
+    Decimal64(Arc<DecimalArray<i64>>),
+    #[cfg(feature = "decimal")]
+    Decimal128(Arc<DecimalArray<i128>>),
     #[default]
     Null, // Default Marker for mem::take
+}
+
+// Decimal-to-integer conversion: divides raw value by 10^scale (truncating),
+// then converts to the target integer type via TryFrom.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_integer {
+    ($arc:expr, $target:ty) => {{
+        use num_traits::ToPrimitive;
+        let scale_divisor = 10i128.pow($arc.scale.max(0) as u32);
+        let data: Result<Vec64<$target>, _> = $arc
+            .data
+            .as_slice()
+            .iter()
+            .map(|v| {
+                let scaled = v.to_i128().unwrap() / scale_divisor;
+                <$target as TryFrom<i128>>::try_from(scaled).map_err(|_| {
+                    MinarrowError::TypeError {
+                        from: "DecimalArray",
+                        to: stringify!(IntegerArray<$target>),
+                        message: Some(format!(
+                            "overflow converting {scaled} to {}",
+                            stringify!($target)
+                        )),
+                    }
+                })
+            })
+            .collect();
+        Ok(Arc::new(IntegerArray::new(data?, $arc.null_mask.clone())))
+    }};
+}
+
+// Decimal-to-float conversion: raw as f_type / 10^scale.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_float {
+    ($arc:expr, f32) => {{
+        use num_traits::ToPrimitive;
+        let scale_factor = 10f32.powi($arc.scale as i32);
+        let data: Vec64<f32> = $arc
+            .data
+            .as_slice()
+            .iter()
+            .map(|v| v.to_f64().unwrap() as f32 / scale_factor)
+            .collect();
+        Ok(Arc::new(FloatArray::new(data, $arc.null_mask.clone())))
+    }};
+    ($arc:expr, f64) => {{
+        use num_traits::ToPrimitive;
+        let scale_factor = 10f64.powi($arc.scale as i32);
+        let data: Vec64<f64> = $arc
+            .data
+            .as_slice()
+            .iter()
+            .map(|v| v.to_f64().unwrap() / scale_factor)
+            .collect();
+        Ok(Arc::new(FloatArray::new(data, $arc.null_mask.clone())))
+    }};
+}
+
+// Decimal-to-bool conversion: non-zero raw values are true.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_bool {
+    ($arc:expr) => {{
+        let mut data = Bitmask::with_capacity($arc.data.len());
+        for (i, v) in $arc.data.as_slice().iter().enumerate() {
+            data.set(i, !num_traits::Zero::is_zero(v));
+        }
+        Ok(Arc::new(BooleanArray::new(data, $arc.null_mask.clone())))
+    }};
+}
+
+// Decimal-to-string conversion: scale-aware formatting per element.
+#[cfg(feature = "decimal")]
+macro_rules! decimal_to_str {
+    ($arc:expr) => {{
+        let mut arr = StringArray::<u32>::with_capacity($arc.len(), $arc.len() * 8, false);
+        for v in $arc.data.as_slice() {
+            arr.push(format_decimal_value(*v, $arc.scale));
+        }
+        arr.null_mask = $arc.null_mask.clone();
+        Ok(Arc::new(arr))
+    }};
 }
 
 impl NumericArray {
@@ -116,6 +207,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.len(),
             NumericArray::Float32(arr) => arr.len(),
             NumericArray::Float64(arr) => arr.len(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.len(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.len(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.len(),
             NumericArray::Null => 0,
         }
     }
@@ -141,6 +238,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.delete_range(start, end),
             NumericArray::Float32(arr) => arr.delete_range(start, end),
             NumericArray::Float64(arr) => arr.delete_range(start, end),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.delete_range(start, end),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.delete_range(start, end),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.delete_range(start, end),
             NumericArray::Null => {
                 assert!(
                     start == 0 && end == 0,
@@ -168,6 +271,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.null_mask.as_ref(),
             NumericArray::Float32(arr) => arr.null_mask.as_ref(),
             NumericArray::Float64(arr) => arr.null_mask.as_ref(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.null_mask.as_ref(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.null_mask.as_ref(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.null_mask.as_ref(),
             NumericArray::Null => None,
         }
     }
@@ -193,6 +302,12 @@ impl NumericArray {
             NumericArray::UInt64(arr) => arr.has_nulls(),
             NumericArray::Float32(arr) => arr.has_nulls(),
             NumericArray::Float64(arr) => arr.has_nulls(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.has_nulls(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.has_nulls(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.has_nulls(),
             NumericArray::Null => false,
         }
     }
@@ -228,6 +343,19 @@ impl NumericArray {
                 Arc::make_mut(a).append_array(b)
             }
             (NumericArray::Float64(a), NumericArray::Float64(b)) => {
+                Arc::make_mut(a).append_array(b)
+            }
+
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                Arc::make_mut(a).append_array(b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                Arc::make_mut(a).append_array(b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
                 Arc::make_mut(a).append_array(b)
             }
 
@@ -275,6 +403,18 @@ impl NumericArray {
                 Arc::make_mut(a).append_range(b, offset, len)
             }
             (NumericArray::Float64(a), NumericArray::Float64(b)) => {
+                Arc::make_mut(a).append_range(b, offset, len)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                Arc::make_mut(a).append_range(b, offset, len)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                Arc::make_mut(a).append_range(b, offset, len)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
                 Arc::make_mut(a).append_range(b, offset, len)
             }
             (NumericArray::Null, NumericArray::Null) => Ok(()),
@@ -330,6 +470,19 @@ impl NumericArray {
                 Arc::make_mut(a).insert_rows(index, b)
             }
             (NumericArray::Float64(a), NumericArray::Float64(b)) => {
+                Arc::make_mut(a).insert_rows(index, b)
+            }
+
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                Arc::make_mut(a).insert_rows(index, b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                Arc::make_mut(a).insert_rows(index, b)
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
                 Arc::make_mut(a).insert_rows(index, b)
             }
 
@@ -444,6 +597,36 @@ impl NumericArray {
                     NumericArray::Float64(Arc::new(right)),
                 ))
             }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => {
+                let (left, right) = Arc::try_unwrap(a)
+                    .unwrap_or_else(|arc| (*arc).clone())
+                    .split(index)?;
+                Ok((
+                    NumericArray::Decimal32(Arc::new(left)),
+                    NumericArray::Decimal32(Arc::new(right)),
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => {
+                let (left, right) = Arc::try_unwrap(a)
+                    .unwrap_or_else(|arc| (*arc).clone())
+                    .split(index)?;
+                Ok((
+                    NumericArray::Decimal64(Arc::new(left)),
+                    NumericArray::Decimal64(Arc::new(right)),
+                ))
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => {
+                let (left, right) = Arc::try_unwrap(a)
+                    .unwrap_or_else(|arc| (*arc).clone())
+                    .split(index)?;
+                Ok((
+                    NumericArray::Decimal128(Arc::new(left)),
+                    NumericArray::Decimal128(Arc::new(right)),
+                ))
+            }
             NumericArray::Null => Err(MinarrowError::IndexError(
                 "Cannot split Null array".to_string(),
             )),
@@ -478,6 +661,12 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<i32>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, i32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, i32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, i32),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -510,6 +699,12 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<i64>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, i64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, i64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, i64),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -542,6 +737,12 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<u32>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, u32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, u32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, u32),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -574,6 +775,12 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(a.clone()),
             NumericArray::Float32(a) => Ok(Arc::new(IntegerArray::<u64>::try_from(&**a)?)),
             NumericArray::Float64(a) => Ok(Arc::new(IntegerArray::<u64>::try_from(&**a)?)),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_integer!(a, u64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_integer!(a, u64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_integer!(a, u64),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -606,6 +813,12 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(FloatArray::<f32>::from(&**a))),
             NumericArray::Float32(a) => Ok(a.clone()),
             NumericArray::Float64(a) => Ok(Arc::new(FloatArray::<f32>::from(&**a))),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_float!(a, f32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_float!(a, f32),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_float!(a, f32),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -636,6 +849,36 @@ impl NumericArray {
                 }
             };
         }
+        #[cfg(feature = "decimal")]
+        macro_rules! decimal_cow_f64 {
+            ($arc:expr) => {{
+                use num_traits::ToPrimitive;
+                let scale_factor = 10f64.powi($arc.scale as i32);
+                match Arc::try_unwrap($arc) {
+                    Ok(owned) => {
+                        let data: Vec64<f64> = owned
+                            .data
+                            .as_slice()
+                            .iter()
+                            .map(|v| v.to_f64().unwrap() / scale_factor)
+                            .collect();
+                        NumericArray::Float64(Arc::new(FloatArray::new(data, owned.null_mask)))
+                    }
+                    Err(shared) => {
+                        let data: Vec64<f64> = shared
+                            .data
+                            .as_slice()
+                            .iter()
+                            .map(|v| v.to_f64().unwrap() / scale_factor)
+                            .collect();
+                        NumericArray::Float64(Arc::new(FloatArray::new(
+                            data,
+                            shared.null_mask.clone(),
+                        )))
+                    }
+                }
+            }};
+        }
 
         match self {
             NumericArray::Float64(_) => self,
@@ -652,6 +895,12 @@ impl NumericArray {
             NumericArray::UInt8(arc) => cast_arc!(arc),
             #[cfg(feature = "extended_numeric_types")]
             NumericArray::UInt16(arc) => cast_arc!(arc),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arc) => decimal_cow_f64!(arc),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arc) => decimal_cow_f64!(arc),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arc) => decimal_cow_f64!(arc),
             NumericArray::Null => {
                 NumericArray::Float64(Arc::new(FloatArray::new(Vec64::new(), None)))
             }
@@ -686,6 +935,12 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(FloatArray::<f64>::from(&**a))),
             NumericArray::Float32(a) => Ok(Arc::new(FloatArray::<f64>::from(&**a))),
             NumericArray::Float64(a) => Ok(a.clone()),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_float!(a, f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_float!(a, f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_float!(a, f64),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -718,6 +973,12 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
             NumericArray::Float32(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
             NumericArray::Float64(a) => Ok(Arc::new(BooleanArray::<u8>::from(&**a))),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_bool!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_bool!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_bool!(a),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
         }
     }
@@ -750,7 +1011,95 @@ impl NumericArray {
             NumericArray::UInt64(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
             NumericArray::Float32(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
             NumericArray::Float64(a) => Ok(Arc::new(StringArray::<u32>::from(&**a))),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => decimal_to_str!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => decimal_to_str!(a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => decimal_to_str!(a),
             NumericArray::Null => Err(MinarrowError::NullError { message: None }),
+        }
+    }
+
+    /// Returns the inner array as `Arc<DecimalArray<i32>>`.
+    ///
+    /// - Panics on failure. Consider the try variant for a safe alternative.
+    #[cfg(feature = "decimal")]
+    #[inline]
+    pub fn dec32(&self) -> Arc<DecimalArray<i32>> {
+        self.try_dec32().unwrap()
+    }
+
+    /// Retrieve a DecimalArray<i32> from this NumericArray.
+    ///
+    /// The matching variant returns as a shared handle without copying data.
+    /// Decimal64 and Decimal128 variants cannot be narrowed to Decimal32.
+    #[cfg(feature = "decimal")]
+    pub fn try_dec32(&self) -> Result<Arc<DecimalArray<i32>>, MinarrowError> {
+        match self {
+            NumericArray::Decimal32(a) => Ok(a.clone()),
+            _ => Err(MinarrowError::TypeError {
+                from: "NumericArray",
+                to: "DecimalArray<i32>",
+                message: Some("variant is not Decimal32".to_string()),
+            }),
+        }
+    }
+
+    /// Returns the inner array as `Arc<DecimalArray<i64>>`.
+    ///
+    /// - Panics on failure. Consider the try variant for a safe alternative.
+    #[cfg(feature = "decimal")]
+    #[inline]
+    pub fn dec64(&self) -> Arc<DecimalArray<i64>> {
+        self.try_dec64().unwrap()
+    }
+
+    /// Retrieve a DecimalArray<i64> from this NumericArray.
+    ///
+    /// The matching variant returns as a shared handle without copying data.
+    /// A Decimal32 variant is widened to DecimalArray<i64> losslessly.
+    /// Decimal128 cannot be narrowed to Decimal64.
+    #[cfg(feature = "decimal")]
+    pub fn try_dec64(&self) -> Result<Arc<DecimalArray<i64>>, MinarrowError> {
+        match self {
+            NumericArray::Decimal64(a) => Ok(a.clone()),
+            NumericArray::Decimal32(a) => Ok(Arc::new(DecimalArray::<i64>::from((**a).clone()))),
+            _ => Err(MinarrowError::TypeError {
+                from: "NumericArray",
+                to: "DecimalArray<i64>",
+                message: Some("variant is not Decimal32 or Decimal64".to_string()),
+            }),
+        }
+    }
+
+    /// Returns the inner array as `Arc<DecimalArray<i128>>`.
+    ///
+    /// - Panics on failure. Consider the try variant for a safe alternative.
+    #[cfg(feature = "decimal")]
+    #[inline]
+    pub fn dec128(&self) -> Arc<DecimalArray<i128>> {
+        self.try_dec128().unwrap()
+    }
+
+    /// Retrieve a DecimalArray<i128> from this NumericArray.
+    ///
+    /// The matching variant returns as a shared handle without copying data.
+    /// Decimal32 and Decimal64 variants are widened to DecimalArray<i128> losslessly.
+    #[cfg(feature = "decimal")]
+    pub fn try_dec128(&self) -> Result<Arc<DecimalArray<i128>>, MinarrowError> {
+        match self {
+            NumericArray::Decimal128(a) => Ok(a.clone()),
+            NumericArray::Decimal64(a) => Ok(Arc::new(DecimalArray::<i128>::from((**a).clone()))),
+            NumericArray::Decimal32(a) => {
+                let intermediate = DecimalArray::<i64>::from((**a).clone());
+                Ok(Arc::new(DecimalArray::<i128>::from(intermediate)))
+            }
+            _ => Err(MinarrowError::TypeError {
+                from: "NumericArray",
+                to: "DecimalArray<i128>",
+                message: Some("variant is not a decimal type".to_string()),
+            }),
         }
     }
 }
@@ -775,6 +1124,18 @@ impl Display for NumericArray {
             }
             NumericArray::Float64(arr) => {
                 write_numeric_array_with_header(f, "Float64", arr.as_ref())
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => {
+                write_numeric_array_with_header(f, "Decimal32", arr.as_ref())
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => {
+                write_numeric_array_with_header(f, "Decimal64", arr.as_ref())
+            }
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => {
+                write_numeric_array_with_header(f, "Decimal128", arr.as_ref())
             }
             NumericArray::Null => writeln!(f, "NullNumericArray [0 values]"),
         }
@@ -861,6 +1222,24 @@ impl Concatenate for NumericArray {
                 let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
                 Ok(NumericArray::Float64(Arc::new(a.concat(b)?)))
             }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal32(a), NumericArray::Decimal32(b)) => {
+                let a = Arc::try_unwrap(a).unwrap_or_else(|arc| (*arc).clone());
+                let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
+                Ok(NumericArray::Decimal32(Arc::new(a.concat(b)?)))
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal64(a), NumericArray::Decimal64(b)) => {
+                let a = Arc::try_unwrap(a).unwrap_or_else(|arc| (*arc).clone());
+                let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
+                Ok(NumericArray::Decimal64(Arc::new(a.concat(b)?)))
+            }
+            #[cfg(feature = "decimal")]
+            (NumericArray::Decimal128(a), NumericArray::Decimal128(b)) => {
+                let a = Arc::try_unwrap(a).unwrap_or_else(|arc| (*arc).clone());
+                let b = Arc::try_unwrap(b).unwrap_or_else(|arc| (*arc).clone());
+                Ok(NumericArray::Decimal128(Arc::new(a.concat(b)?)))
+            }
             (NumericArray::Null, NumericArray::Null) => Ok(NumericArray::Null),
             (lhs, rhs) => Err(MinarrowError::IncompatibleTypeError {
                 from: "NumericArray",
@@ -892,6 +1271,223 @@ fn variant_name(arr: &NumericArray) -> &'static str {
         NumericArray::UInt64(_) => "UInt64",
         NumericArray::Float32(_) => "Float32",
         NumericArray::Float64(_) => "Float64",
+        #[cfg(feature = "decimal")]
+        NumericArray::Decimal32(_) => "Decimal32",
+        #[cfg(feature = "decimal")]
+        NumericArray::Decimal64(_) => "Decimal64",
+        #[cfg(feature = "decimal")]
+        NumericArray::Decimal128(_) => "Decimal128",
         NumericArray::Null => "Null",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// From impls - DecimalArray -> NumericArray
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "decimal")]
+impl From<DecimalArray<i32>> for NumericArray {
+    fn from(arr: DecimalArray<i32>) -> Self {
+        NumericArray::Decimal32(Arc::new(arr))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<DecimalArray<i64>> for NumericArray {
+    fn from(arr: DecimalArray<i64>) -> Self {
+        NumericArray::Decimal64(Arc::new(arr))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<DecimalArray<i128>> for NumericArray {
+    fn from(arr: DecimalArray<i128>) -> Self {
+        NumericArray::Decimal128(Arc::new(arr))
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<DecimalArray<i32>>> for NumericArray {
+    fn from(arr: Arc<DecimalArray<i32>>) -> Self {
+        NumericArray::Decimal32(arr)
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<DecimalArray<i64>>> for NumericArray {
+    fn from(arr: Arc<DecimalArray<i64>>) -> Self {
+        NumericArray::Decimal64(arr)
+    }
+}
+
+#[cfg(feature = "decimal")]
+impl From<Arc<DecimalArray<i128>>> for NumericArray {
+    fn from(arr: Arc<DecimalArray<i128>>) -> Self {
+        NumericArray::Decimal128(arr)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "decimal")]
+mod decimal_tests {
+    use super::*;
+    use crate::{DecimalArray, MaskedArray};
+
+    #[test]
+    fn from_decimal_array_into_numeric() {
+        let dec = DecimalArray::<i32>::from_slice(&[12345, 67890], 9, 2);
+        let num = NumericArray::from(dec);
+        assert_eq!(num.len(), 2);
+        match &num {
+            NumericArray::Decimal32(a) => {
+                assert_eq!(a.get(0), Some(12345));
+                assert_eq!(a.precision, 9);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal32"),
+        }
+    }
+
+    #[test]
+    fn from_arc_decimal_array_into_numeric() {
+        let dec = Arc::new(DecimalArray::<i64>::from_slice(&[100, 200], 18, 4));
+        let num = NumericArray::from(dec);
+        assert_eq!(num.len(), 2);
+        match &num {
+            NumericArray::Decimal64(a) => assert_eq!(a.scale, 4),
+            _ => panic!("expected Decimal64"),
+        }
+    }
+
+    #[test]
+    fn accessor_dec32() {
+        let dec = DecimalArray::<i32>::from_slice(&[42], 9, 2);
+        let num = NumericArray::from(dec);
+        let inner = num.dec32();
+        assert_eq!(inner.get(0), Some(42));
+    }
+
+    #[test]
+    fn accessor_dec64() {
+        let dec = DecimalArray::<i64>::from_slice(&[99], 18, 4);
+        let num = NumericArray::from(dec);
+        let inner = num.dec64();
+        assert_eq!(inner.get(0), Some(99));
+    }
+
+    #[test]
+    fn accessor_dec128() {
+        let dec = DecimalArray::<i128>::from_slice(&[1000], 38, 10);
+        let num = NumericArray::from(dec);
+        let inner = num.dec128();
+        assert_eq!(inner.get(0), Some(1000));
+    }
+
+    #[test]
+    fn try_dec128_widens_from_decimal64() {
+        let dec = DecimalArray::<i64>::from_slice(&[500], 18, 4);
+        let num = NumericArray::from(dec);
+        let widened = num.try_dec128().unwrap();
+        assert_eq!(widened.get(0), Some(500i128));
+        assert_eq!(widened.scale, 4);
+    }
+
+    #[test]
+    fn try_dec128_widens_from_decimal32() {
+        let dec = DecimalArray::<i32>::from_slice(&[42], 9, 2);
+        let num = NumericArray::from(dec);
+        let widened = num.try_dec128().unwrap();
+        assert_eq!(widened.get(0), Some(42i128));
+        assert_eq!(widened.scale, 2);
+    }
+
+    #[test]
+    fn try_dec64_widens_from_decimal32() {
+        let dec = DecimalArray::<i32>::from_slice(&[7], 9, 3);
+        let num = NumericArray::from(dec);
+        let widened = num.try_dec64().unwrap();
+        assert_eq!(widened.get(0), Some(7i64));
+        assert_eq!(widened.scale, 3);
+    }
+
+    #[test]
+    fn try_dec32_on_non_decimal_returns_error() {
+        let num = NumericArray::Int32(Arc::new(crate::IntegerArray::<i32>::from_slice(&[1])));
+        assert!(num.try_dec32().is_err());
+    }
+
+    #[test]
+    fn decimal_len_and_is_empty() {
+        let dec = DecimalArray::<i32>::from_slice(&[1, 2, 3], 9, 2);
+        let num = NumericArray::from(dec);
+        assert_eq!(num.len(), 3);
+
+        let empty = DecimalArray::<i64>::from_slice(&[], 18, 0);
+        let num_empty = NumericArray::from(empty);
+        assert_eq!(num_empty.len(), 0);
+    }
+
+    #[test]
+    fn decimal_null_mask() {
+        let mut dec = DecimalArray::<i32>::with_capacity(3, true, 9, 2);
+        dec.push(10);
+        dec.push_null();
+        dec.push(30);
+        let num = NumericArray::from(dec);
+        assert!(num.null_mask().is_some());
+        assert!(num.has_nulls());
+    }
+
+    #[test]
+    fn decimal_delete_range() {
+        let dec = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40], 9, 2);
+        let mut num = NumericArray::from(dec);
+        num.delete_range(1, 3);
+        assert_eq!(num.len(), 2);
+        let inner = num.dec32();
+        assert_eq!(inner.get(0), Some(10));
+        assert_eq!(inner.get(1), Some(40));
+    }
+
+    #[test]
+    fn decimal_append_array() {
+        let a = DecimalArray::<i64>::from_slice(&[10, 20], 18, 4);
+        let b = DecimalArray::<i64>::from_slice(&[30, 40], 18, 4);
+        let mut num_a = NumericArray::from(a);
+        let num_b = NumericArray::from(b);
+        num_a.append_array(&num_b);
+        assert_eq!(num_a.len(), 4);
+    }
+
+    #[test]
+    fn decimal_split() {
+        let dec = DecimalArray::<i128>::from_slice(&[100, 200, 300, 400], 38, 10);
+        let num = NumericArray::from(dec);
+        let (left, right) = num.split(2).unwrap();
+        assert_eq!(left.len(), 2);
+        assert_eq!(right.len(), 2);
+        assert_eq!(left.dec128().get(0), Some(100i128));
+        assert_eq!(right.dec128().get(0), Some(300i128));
+    }
+
+    #[test]
+    fn decimal_concat() {
+        use crate::traits::concatenate::Concatenate;
+        let a = NumericArray::from(DecimalArray::<i32>::from_slice(&[1, 2], 9, 2));
+        let b = NumericArray::from(DecimalArray::<i32>::from_slice(&[3, 4], 9, 2));
+        let result = a.concat(b).unwrap();
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn decimal_display() {
+        let dec = DecimalArray::<i32>::from_slice(&[12345], 9, 2);
+        let num = NumericArray::from(dec);
+        let display = format!("{}", num);
+        assert!(display.contains("Decimal32"), "got: {display}");
     }
 }

--- a/src/enums/error.rs
+++ b/src/enums/error.rs
@@ -232,6 +232,9 @@ pub enum KernelError {
 
     /// Division by zero or similar mathematical errors.
     DivideByZero(String),
+
+    /// Arithmetic overflow detected during a kernel operation.
+    Overflow(String),
 }
 
 impl fmt::Display for KernelError {
@@ -247,6 +250,7 @@ impl fmt::Display for KernelError {
             KernelError::Plan(msg) => write!(f, "Planning error: {}", msg),
             KernelError::OutOfBounds(msg) => write!(f, "Out of bounds: {}", msg),
             KernelError::DivideByZero(msg) => write!(f, "Divide by Zero error: {}", msg),
+            KernelError::Overflow(msg) => write!(f, "Arithmetic overflow: {}", msg),
         }
     }
 }

--- a/src/enums/scalar.rs
+++ b/src/enums/scalar.rs
@@ -39,6 +39,37 @@ use crate::{
     Array, ArrowType, Bitmask, BooleanArray, FloatArray, IntegerArray, MaskedArray, StringArray
 };
 
+/// Scale-aware formatting for decimal scalar values.
+#[cfg(all(feature = "scalar_type", feature = "decimal"))]
+fn format_decimal_scalar(raw: i128, scale: i8) -> String {
+    let raw_str = format!("{}", raw);
+    if scale == 0 {
+        return raw_str;
+    }
+    if scale < 0 {
+        let zeros = (-scale) as usize;
+        return format!("{}{}", raw_str, "0".repeat(zeros));
+    }
+    let scale_usize = scale as usize;
+    let (is_negative, digits) = if raw_str.starts_with('-') {
+        (true, &raw_str[1..])
+    } else {
+        (false, raw_str.as_str())
+    };
+    let padded = if digits.len() <= scale_usize {
+        format!("{:0>width$}", digits, width = scale_usize + 1)
+    } else {
+        digits.to_string()
+    };
+    let split_pos = padded.len() - scale_usize;
+    let (int_part, frac_part) = padded.split_at(split_pos);
+    if is_negative {
+        format!("-{}.{}", int_part, frac_part)
+    } else {
+        format!("{}.{}", int_part, frac_part)
+    }
+}
+
 /// # Scalar
 ///
 /// Scalar literals (single values) covering all supported types.
@@ -72,6 +103,13 @@ pub enum Scalar {
     // Floats
     Float32(f32),
     Float64(f64),
+    // Decimals - unscaled integer value + scale
+    #[cfg(feature = "decimal")]
+    Decimal32(i32, i8),
+    #[cfg(feature = "decimal")]
+    Decimal64(i64, i8),
+    #[cfg(feature = "decimal")]
+    Decimal128(i128, i8),
     // String strings
     String32(String),
     #[cfg(feature = "large_string")]
@@ -104,6 +142,12 @@ impl Display for Scalar {
             Scalar::UInt64(v) => Display::fmt(v, f),
             Scalar::Float32(v) => Display::fmt(v, f),
             Scalar::Float64(v) => Display::fmt(v, f),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, scale) => write!(f, "{}", format_decimal_scalar(*v as i128, *scale)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, scale) => write!(f, "{}", format_decimal_scalar(*v as i128, *scale)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, scale) => write!(f, "{}", format_decimal_scalar(*v, *scale)),
             Scalar::String32(v) => f.write_str(v),
             #[cfg(feature = "large_string")]
             Scalar::String64(v) => f.write_str(v),
@@ -141,6 +185,12 @@ impl Scalar {
             Scalar::UInt64(v) => *v != 0,
             Scalar::Float32(v) => *v != 0.0,
             Scalar::Float64(v) => *v != 0.0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => *v != 0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => *v != 0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => *v != 0,
             Scalar::Null => panic!("Cannot convert Null to bool"),
             Scalar::String32(s) => {
                 let s = s.trim();
@@ -206,6 +256,12 @@ impl Scalar {
             Scalar::UInt64(v) => i8::try_from(*v).expect("u64 out of range for i8"),
             Scalar::Float32(v) => i8::try_from(*v as i32).expect("f32 out of range for i8"),
             Scalar::Float64(v) => i8::try_from(*v as i32).expect("f64 out of range for i8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i8::try_from(*v).expect("Decimal32 out of range for i8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i8::try_from(*v).expect("Decimal64 out of range for i8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i8::try_from(*v).expect("Decimal128 out of range for i8"),
             Scalar::Null => panic!("Cannot convert Null to i8"),
             Scalar::String32(s) => s.parse::<i8>().expect("Cannot parse string as i8"),
             #[cfg(feature = "large_string")]
@@ -244,6 +300,12 @@ impl Scalar {
             Scalar::UInt64(v) => i16::try_from(*v).expect("u64 out of range for i16"),
             Scalar::Float32(v) => i16::try_from(*v as i32).expect("f32 out of range for i16"),
             Scalar::Float64(v) => i16::try_from(*v as i32).expect("f64 out of range for i16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i16::try_from(*v).expect("Decimal32 out of range for i16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i16::try_from(*v).expect("Decimal64 out of range for i16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i16::try_from(*v).expect("Decimal128 out of range for i16"),
             Scalar::Null => panic!("Cannot convert Null to i16"),
             Scalar::String32(s) => s.parse::<i16>().expect("Cannot parse string as i16"),
             #[cfg(feature = "large_string")]
@@ -285,6 +347,12 @@ impl Scalar {
             Scalar::UInt64(v) => i32::try_from(*v).expect("u64 out of range for i32"),
             Scalar::Float32(v) => *v as i32,
             Scalar::Float64(v) => *v as i32,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => *v,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i32::try_from(*v).expect("Decimal64 out of range for i32"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i32::try_from(*v).expect("Decimal128 out of range for i32"),
             Scalar::Null => panic!("Cannot convert Null to i32"),
             Scalar::String32(s) => s.parse::<i32>().expect("Cannot parse string as i32"),
             #[cfg(feature = "large_string")]
@@ -332,6 +400,12 @@ impl Scalar {
             }
             Scalar::Float32(v) => *v as i64,
             Scalar::Float64(v) => *v as i64,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => *v as i64,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => *v,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i64::try_from(*v).expect("Decimal128 out of range for i64"),
             Scalar::Null => panic!("Cannot convert Null to i64"),
             Scalar::String32(s) => s.parse::<i64>().expect("Cannot parse string as i64"),
             #[cfg(feature = "large_string")]
@@ -373,6 +447,12 @@ impl Scalar {
             Scalar::UInt64(v) => u8::try_from(*v).expect("u64 out of range for u8"),
             Scalar::Float32(v) => u8::try_from(*v as i32).expect("f32 out of range for u8"),
             Scalar::Float64(v) => u8::try_from(*v as i32).expect("f64 out of range for u8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u8::try_from(*v).expect("Decimal32 out of range for u8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u8::try_from(*v).expect("Decimal64 out of range for u8"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u8::try_from(*v).expect("Decimal128 out of range for u8"),
             Scalar::Null => panic!("Cannot convert Null to u8"),
             Scalar::String32(s) => s.parse::<u8>().expect("Cannot parse string as u8"),
             #[cfg(feature = "large_string")]
@@ -414,6 +494,12 @@ impl Scalar {
             Scalar::UInt64(v) => u16::try_from(*v).expect("u64 out of range for u16"),
             Scalar::Float32(v) => u16::try_from(*v as i32).expect("f32 out of range for u16"),
             Scalar::Float64(v) => u16::try_from(*v as i32).expect("f64 out of range for u16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u16::try_from(*v).expect("Decimal32 out of range for u16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u16::try_from(*v).expect("Decimal64 out of range for u16"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u16::try_from(*v).expect("Decimal128 out of range for u16"),
             Scalar::Null => panic!("Cannot convert Null to u16"),
             Scalar::String32(s) => s.parse::<u16>().expect("Cannot parse string as u16"),
             #[cfg(feature = "large_string")]
@@ -455,6 +541,12 @@ impl Scalar {
             Scalar::UInt64(v) => u32::try_from(*v).expect("u64 out of range for u32"),
             Scalar::Float32(v) => *v as u32,
             Scalar::Float64(v) => *v as u32,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u32::try_from(*v).expect("Decimal32 out of range for u32"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u32::try_from(*v).expect("Decimal64 out of range for u32"),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u32::try_from(*v).expect("Decimal128 out of range for u32"),
             Scalar::Null => panic!("Cannot convert Null to u32"),
             Scalar::String32(s) => s.parse::<u32>().expect("Cannot parse string as u32"),
             #[cfg(feature = "large_string")]
@@ -532,6 +624,16 @@ impl Scalar {
                     panic!("f64 out of range for u64")
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => {
+                if *v >= 0 { *v as u64 } else { panic!("Decimal32 out of range for u64") }
+            },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => {
+                if *v >= 0 { *v as u64 } else { panic!("Decimal64 out of range for u64") }
+            },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u64::try_from(*v).expect("Decimal128 out of range for u64"),
             Scalar::Null => panic!("Cannot convert Null to u64"),
             Scalar::String32(s) => s.parse::<u64>().expect("Cannot parse string as u64"),
             #[cfg(feature = "large_string")]
@@ -573,6 +675,12 @@ impl Scalar {
             Scalar::UInt64(v) => *v as f32,
             Scalar::Float32(v) => *v,
             Scalar::Float64(v) => *v as f32,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => *v as f32 / 10f32.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => *v as f32 / 10f32.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => *v as f32 / 10f32.powi(*s as i32),
             Scalar::Boolean(v) => {
                 if *v {
                     1.0
@@ -614,6 +722,12 @@ impl Scalar {
             Scalar::UInt64(v) => *v as f64,
             Scalar::Float32(v) => *v as f64,
             Scalar::Float64(v) => *v,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => *v as f64 / 10f64.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => *v as f64 / 10f64.powi(*s as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => *v as f64 / 10f64.powi(*s as i32),
             Scalar::Boolean(v) => {
                 if *v {
                     1.0
@@ -659,6 +773,12 @@ impl Scalar {
             Scalar::UInt64(v) => v.to_string(),
             Scalar::Float32(v) => v.to_string(),
             Scalar::Float64(v) => v.to_string(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => format_decimal_scalar(*v as i128, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => format_decimal_scalar(*v as i128, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => format_decimal_scalar(*v, *s),
             Scalar::Null => panic!("Cannot convert Null to String"),
             #[cfg(feature = "datetime")]
             Scalar::Datetime32(v) => v.to_string(),
@@ -728,6 +848,8 @@ impl Scalar {
                     panic!("f64 out of range for dt32")
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => panic!("Cannot convert Decimal to dt32"),
             Scalar::String32(s) => s.parse::<u32>().expect("Cannot parse string as dt32"),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u32>().expect("Cannot parse string as dt32"),
@@ -815,6 +937,8 @@ impl Scalar {
                     panic!("f64 out of range for dt64")
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => panic!("Cannot convert Decimal to dt64"),
             Scalar::String32(s) => s.parse::<u64>().expect("Cannot parse string as dt64"),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u64>().expect("Cannot parse string as dt64"),
@@ -854,6 +978,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(*v != 0),
             Scalar::Float32(v) => Some(*v != 0.0),
             Scalar::Float64(v) => Some(*v != 0.0),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => Some(*v != 0),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => Some(*v != 0),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => Some(*v != 0),
             Scalar::Null => None,
             Scalar::String32(s) => {
                 let s = s.trim();
@@ -916,6 +1046,12 @@ impl Scalar {
             Scalar::UInt64(v) => i8::try_from(*v).ok(),
             Scalar::Float32(v) => i8::try_from(*v as i32).ok(),
             Scalar::Float64(v) => i8::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i8::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i8>().ok(),
             #[cfg(feature = "large_string")]
@@ -945,6 +1081,12 @@ impl Scalar {
             Scalar::UInt64(v) => i16::try_from(*v).ok(),
             Scalar::Float32(v) => i16::try_from(*v as i32).ok(),
             Scalar::Float64(v) => i16::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => i16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i16::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i16>().ok(),
             #[cfg(feature = "large_string")]
@@ -977,6 +1119,12 @@ impl Scalar {
             Scalar::UInt64(v) => i32::try_from(*v).ok(),
             Scalar::Float32(v) => Some(*v as i32),
             Scalar::Float64(v) => Some(*v as i32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => Some(*v),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => i32::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i32::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i32>().ok(),
             #[cfg(feature = "large_string")]
@@ -1015,6 +1163,12 @@ impl Scalar {
             }
             Scalar::Float32(v) => Some(*v as i64),
             Scalar::Float64(v) => Some(*v as i64),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => Some(*v as i64),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => Some(*v),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => i64::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<i64>().ok(),
             #[cfg(feature = "large_string")]
@@ -1047,6 +1201,12 @@ impl Scalar {
             Scalar::UInt64(v) => u8::try_from(*v).ok(),
             Scalar::Float32(v) => u8::try_from(*v as i32).ok(),
             Scalar::Float64(v) => u8::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u8::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u8::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u8>().ok(),
             #[cfg(feature = "large_string")]
@@ -1079,6 +1239,12 @@ impl Scalar {
             Scalar::UInt64(v) => u16::try_from(*v).ok(),
             Scalar::Float32(v) => u16::try_from(*v as i32).ok(),
             Scalar::Float64(v) => u16::try_from(*v as i32).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u16::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u16::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u16>().ok(),
             #[cfg(feature = "large_string")]
@@ -1111,6 +1277,12 @@ impl Scalar {
             Scalar::UInt64(v) => u32::try_from(*v).ok(),
             Scalar::Float32(v) => Some(*v as u32),
             Scalar::Float64(v) => Some(*v as u32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => u32::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => u32::try_from(*v).ok(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u32::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u32>().ok(),
             #[cfg(feature = "large_string")]
@@ -1179,6 +1351,12 @@ impl Scalar {
                     None
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, _) => if *v >= 0 { Some(*v as u64) } else { None },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, _) => if *v >= 0 { Some(*v as u64) } else { None },
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, _) => u64::try_from(*v).ok(),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<u64>().ok(),
             #[cfg(feature = "large_string")]
@@ -1223,6 +1401,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(*v as f32),
             Scalar::Float32(v) => Some(*v),
             Scalar::Float64(v) => Some(*v as f32),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => Some(*v as f32 / 10f32.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => Some(*v as f32 / 10f32.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => Some(*v as f32 / 10f32.powi(*s as i32)),
             Scalar::Boolean(v) => Some(if *v { 1.0 } else { 0.0 }),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<f32>().ok(),
@@ -1255,6 +1439,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(*v as f64),
             Scalar::Float32(v) => Some(*v as f64),
             Scalar::Float64(v) => Some(*v),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => Some(*v as f64 / 10f64.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => Some(*v as f64 / 10f64.powi(*s as i32)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => Some(*v as f64 / 10f64.powi(*s as i32)),
             Scalar::Boolean(v) => Some(if *v { 1.0 } else { 0.0 }),
             Scalar::Null => None,
             Scalar::String32(s) => s.parse::<f64>().ok(),
@@ -1291,6 +1481,12 @@ impl Scalar {
             Scalar::UInt64(v) => Some(v.to_string()),
             Scalar::Float32(v) => Some(v.to_string()),
             Scalar::Float64(v) => Some(v.to_string()),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => Some(format_decimal_scalar(*v as i128, *s)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => Some(format_decimal_scalar(*v as i128, *s)),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => Some(format_decimal_scalar(*v, *s)),
             Scalar::Null => None,
             #[cfg(feature = "datetime")]
             Scalar::Datetime32(v) => Some(v.to_string()),
@@ -1351,6 +1547,8 @@ impl Scalar {
                     None
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => None,
             Scalar::String32(s) => s.parse::<u32>().ok(),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u32>().ok(),
@@ -1429,6 +1627,8 @@ impl Scalar {
                     None
                 }
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => None,
             Scalar::String32(s) => s.parse::<u64>().ok(),
             #[cfg(feature = "large_string")]
             Scalar::String64(s) => s.parse::<u64>().ok(),
@@ -1476,6 +1676,12 @@ impl Scalar {
             Scalar::UInt64(_) => ArrowType::UInt64,
             Scalar::Float32(_) => ArrowType::Float32,
             Scalar::Float64(_) => ArrowType::Float64,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, s) => ArrowType::Decimal32(0, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(_, s) => ArrowType::Decimal64(0, *s),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(_, s) => ArrowType::Decimal128(0, *s),
             Scalar::String32(_) => ArrowType::String,
             #[cfg(feature = "large_string")]
             Scalar::String64(_) => ArrowType::LargeString,
@@ -1565,6 +1771,30 @@ impl Scalar {
                 }
                 Array::from_float64(arr)
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => {
+                let mut arr = crate::DecimalArray::<i32>::with_capacity(len, false, 0, s);
+                for _ in 0..len {
+                    arr.push(v);
+                }
+                Array::NumericArray(crate::NumericArray::Decimal32(std::sync::Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => {
+                let mut arr = crate::DecimalArray::<i64>::with_capacity(len, false, 0, s);
+                for _ in 0..len {
+                    arr.push(v);
+                }
+                Array::NumericArray(crate::NumericArray::Decimal64(std::sync::Arc::new(arr)))
+            }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => {
+                let mut arr = crate::DecimalArray::<i128>::with_capacity(len, false, 0, s);
+                for _ in 0..len {
+                    arr.push(v);
+                }
+                Array::NumericArray(crate::NumericArray::Decimal128(std::sync::Arc::new(arr)))
+            }
             Scalar::Boolean(v) => {
                 let mut arr = BooleanArray::with_capacity(len, false);
                 for _ in 0..len {
@@ -1642,6 +1872,12 @@ impl PartialEq for Scalar {
             // equal to itself when used as a map or group key.
             (Float32(a), Float32(b)) => if a.is_nan() { b.is_nan() } else { a == b },
             (Float64(a), Float64(b)) => if a.is_nan() { b.is_nan() } else { a == b },
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, sa), Decimal32(b, sb)) => a == b && sa == sb,
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, sa), Decimal64(b, sb)) => a == b && sa == sb,
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, sa), Decimal128(b, sb)) => a == b && sa == sb,
             (String32(a), String32(b)) => a == b,
             #[cfg(feature = "large_string")]
             (String64(a), String64(b)) => a == b,
@@ -1690,6 +1926,12 @@ impl std::hash::Hash for Scalar {
                     if v.is_nan() { 0x7ff8_0000_0000_0000u64 } else { (*v + 0.0).to_bits() };
                 bits.hash(state);
             }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(v, s) => { v.hash(state); s.hash(state); }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(v, s) => { v.hash(state); s.hash(state); }
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(v, s) => { v.hash(state); s.hash(state); }
             Scalar::String32(v) => v.hash(state),
             #[cfg(feature = "large_string")]
             Scalar::String64(v) => v.hash(state),
@@ -1808,6 +2050,20 @@ impl Add for Scalar {
             // Nulls propagate
             (Null, _) | (_, Null) => Null,
 
+            // Decimal promotes to f64
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) + b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64() + b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) + b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64() + b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) + b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64() + b as f64 / 10f64.powi(s as i32)),
+
             // Float promotion
             (Float64(a), b) => Float64(a + b.f64()),
             (a, Float64(b)) => Float64(a.f64() + b),
@@ -1891,6 +2147,19 @@ impl Sub for Scalar {
         match (self, rhs) {
             (Null, _) | (_, Null) => Null,
 
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) - b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64() - b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) - b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64() - b as f64 / 10f64.powi(s as i32)),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) - b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64() - b as f64 / 10f64.powi(s as i32)),
+
             (Float64(a), b) => Float64(a - b.f64()),
             (a, Float64(b)) => Float64(a.f64() - b),
             (Float32(a), b) => Float32(a - b.f32()),
@@ -1961,6 +2230,19 @@ impl Mul for Scalar {
 
         match (self, rhs) {
             (Null, _) | (_, Null) => Null,
+
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) * b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64() * (b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) * b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64() * (b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64(a as f64 / 10f64.powi(s as i32) * b.f64()),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64() * (b as f64 / 10f64.powi(s as i32))),
 
             (Float64(a), b) => Float64(a * b.f64()),
             (a, Float64(b)) => Float64(a.f64() * b),
@@ -2059,6 +2341,19 @@ impl Pow<Scalar> for Scalar {
         match (self, rhs) {
             // Nulls propagate
             (Null, _) | (_, Null) => Null,
+
+            #[cfg(feature = "decimal")]
+            (Decimal32(a, s), b) => Float64((a as f64 / 10f64.powi(s as i32)).powf(b.f64())),
+            #[cfg(feature = "decimal")]
+            (a, Decimal32(b, s)) => Float64(a.f64().powf(b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal64(a, s), b) => Float64((a as f64 / 10f64.powi(s as i32)).powf(b.f64())),
+            #[cfg(feature = "decimal")]
+            (a, Decimal64(b, s)) => Float64(a.f64().powf(b as f64 / 10f64.powi(s as i32))),
+            #[cfg(feature = "decimal")]
+            (Decimal128(a, s), b) => Float64((a as f64 / 10f64.powi(s as i32)).powf(b.f64())),
+            #[cfg(feature = "decimal")]
+            (a, Decimal128(b, s)) => Float64(a.f64().powf(b as f64 / 10f64.powi(s as i32))),
 
             #[cfg(feature = "datetime")]
             (Interval, _) => panic!("Cannot exponentiate Interval"),

--- a/src/enums/value/impls.rs
+++ b/src/enums/value/impls.rs
@@ -614,6 +614,12 @@ fn scalar_variant_name(scalar: &crate::Scalar) -> &'static str {
         Datetime64(_) => "Datetime64",
         #[cfg(feature = "datetime")]
         Interval => "Interval",
+        #[cfg(feature = "decimal")]
+        Decimal32(_, _) => "Decimal32",
+        #[cfg(feature = "decimal")]
+        Decimal64(_, _) => "Decimal64",
+        #[cfg(feature = "decimal")]
+        Decimal128(_, _) => "Decimal128",
     }
 }
 

--- a/src/enums/value/mod.rs
+++ b/src/enums/value/mod.rs
@@ -562,4 +562,55 @@ mod tests {
             assert_eq!(table.n_cols(), 2);
         }
     }
+
+    /// Decimal arrays flow through Value::Array and Value::ArrayView
+    /// correctly. The Value enum wraps Arc<Array>, so decimal support is
+    /// inherited from the Array and NumericArray enums.
+    #[cfg(feature = "decimal")]
+    mod decimal_value_tests {
+        use super::*;
+
+        fn decimal_array(n: usize) -> Array {
+            let vals: Vec<i32> = (0..n as i32).map(|i| i * 100).collect();
+            Array::from_decimal32(crate::DecimalArray::from_slice(&vals, 10, 2))
+        }
+
+        #[test]
+        fn decimal_len_counts_correctly() {
+            let value = Value::Array(Arc::new(decimal_array(5)));
+            assert_eq!(value.len(), 5);
+        }
+
+        #[cfg(feature = "views")]
+        #[test]
+        fn decimal_slice_returns_array_view() {
+            let value = Value::Array(Arc::new(decimal_array(10)));
+            let sliced = value.slice(3, 4);
+
+            if let Value::ArrayView(av) = &sliced {
+                assert_eq!(av.len(), 4);
+                assert_eq!(av.offset, 3);
+            } else {
+                panic!("Expected Value::ArrayView");
+            }
+            assert_eq!(sliced.len(), 4);
+        }
+
+        #[cfg(feature = "views")]
+        #[test]
+        fn decimal_view_re_slices() {
+            let value = Value::Array(Arc::new(decimal_array(10)));
+            let view = value.slice(2, 6);
+            let sub = view.slice(1, 3);
+            assert_eq!(sub.len(), 3);
+        }
+
+        #[test]
+        fn decimal_round_trips_through_value() {
+            let arr = decimal_array(3);
+            let value = Value::Array(Arc::new(arr.clone()));
+            let extracted = Array::try_from(value).unwrap();
+            assert_eq!(extracted, arr);
+        }
+    }
 }

--- a/src/ffi/arrow_c_ffi.rs
+++ b/src/ffi/arrow_c_ffi.rs
@@ -66,6 +66,8 @@ use crate::{
 };
 #[cfg(feature = "datetime")]
 use crate::{DatetimeArray, IntervalUnit, TemporalArray, TimeUnit};
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 
 // Provides compatibility with the cross-platform `Apache Arrow` standard
 // via the `C Data Interface` specification:
@@ -456,6 +458,38 @@ fn validate_temporal_field(array: &Array, dtype: &ArrowType) {
     }
 }
 
+fn validate_numeric_field(array: &Array, dtype: &ArrowType) {
+    #[cfg(feature = "decimal")]
+    {
+        use crate::enums::collections::numeric_array::NumericArray;
+        match (array, dtype) {
+            (Array::NumericArray(NumericArray::Decimal32(a)), ArrowType::Decimal32(p, s)) => {
+                assert!(
+                    a.precision == *p && a.scale == *s,
+                    "FFI export: Field=Decimal32(p={p},s={s}) does not match array (p={},s={})",
+                    a.precision, a.scale
+                );
+            }
+            (Array::NumericArray(NumericArray::Decimal64(a)), ArrowType::Decimal64(p, s)) => {
+                assert!(
+                    a.precision == *p && a.scale == *s,
+                    "FFI export: Field=Decimal64(p={p},s={s}) does not match array (p={},s={})",
+                    a.precision, a.scale
+                );
+            }
+            (Array::NumericArray(NumericArray::Decimal128(a)), ArrowType::Decimal128(p, s)) => {
+                assert!(
+                    a.precision == *p && a.scale == *s,
+                    "FFI export: Field=Decimal128(p={p},s={s}) does not match array (p={},s={})",
+                    a.precision, a.scale
+                );
+            }
+            _ => {}
+        }
+    }
+    let _ = (array, dtype);
+}
+
 /// Exports a Minarrow array to Arrow C Data Interface pointers.
 ///
 /// Equivalent to [`export_view_to_c`] with offset = 0 and length = `array.len()`.
@@ -485,6 +519,11 @@ pub fn export_view_to_c(
         let field_ty = &schema.fields[0].dtype;
         // Validate temporal logical type <-> physical unit before export.
         validate_temporal_field(&*array, field_ty);
+    }
+
+    {
+        let field_ty = &schema.fields[0].dtype;
+        validate_numeric_field(&*array, field_ty);
     }
 
     match &*array {
@@ -781,6 +820,8 @@ pub unsafe fn import_from_c(arr_ptr: *const ArrowArray, sch_ptr: *const ArrowSch
             };
             ArrowType::Timestamp(unit, tz)
         }
+        #[cfg(feature = "decimal")]
+        _ if fmt.starts_with(b"d:") => parse_decimal_format(fmt),
         o => panic!("unsupported format {:?}", o),
     };
 
@@ -887,9 +928,17 @@ pub unsafe fn import_from_c(arr_ptr: *const ArrowArray, sch_ptr: *const ArrowSch
                 panic!("FFI import_from_c: Arrow Interval types are not yet supported");
             }
             #[cfg(feature = "decimal")]
-            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
-                panic!("FFI import_from_c: Decimal array import is not yet implemented")
-            }
+            ArrowType::Decimal32(p, s) => unsafe {
+                import_decimal::<i32>(arr, None, p, s, Array::from_decimal32)
+            },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => unsafe {
+                import_decimal::<i64>(arr, None, p, s, Array::from_decimal64)
+            },
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => unsafe {
+                import_decimal::<i128>(arr, None, p, s, Array::from_decimal128)
+            },
             ArrowType::Null => {
                 panic!("FFI import_from_c: Arrow Null arrays types are not yet supported")
             }
@@ -1035,8 +1084,16 @@ pub unsafe fn import_from_c_owned(
                 panic!("FFI import_from_c_owned: Arrow Interval types are not yet supported");
             }
             #[cfg(feature = "decimal")]
-            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
-                panic!("FFI import_from_c_owned: Decimal array import is not yet implemented")
+            ArrowType::Decimal32(p, s) => {
+                import_decimal::<i32>(arr, Some(arr_box), p, s, Array::from_decimal32)
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => {
+                import_decimal::<i64>(arr, Some(arr_box), p, s, Array::from_decimal64)
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => {
+                import_decimal::<i128>(arr, Some(arr_box), p, s, Array::from_decimal128)
             }
             ArrowType::Null => {
                 panic!("FFI import_from_c_owned: Arrow Null arrays types are not yet supported")
@@ -1165,8 +1222,16 @@ unsafe fn import_array_zero_copy(
                 panic!("import_array_zero_copy: Interval types are not yet supported");
             }
             #[cfg(feature = "decimal")]
-            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
-                panic!("import_array_zero_copy: Decimal array import is not yet implemented")
+            ArrowType::Decimal32(p, s) => {
+                import_decimal::<i32>(arr, Some(arr_box), p, s, Array::from_decimal32)
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => {
+                import_decimal::<i64>(arr, Some(arr_box), p, s, Array::from_decimal64)
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => {
+                import_decimal::<i128>(arr, Some(arr_box), p, s, Array::from_decimal128)
             }
             ArrowType::Null => {
                 panic!("import_array_zero_copy: Null array types are not yet supported");
@@ -1866,6 +1931,64 @@ unsafe fn import_datetime<T: Integer>(
     } else {
         panic!("Unsupported DatetimeArray type (expected i32 or i64)");
     }
+}
+
+/// Imports a decimal array from Arrow C format.
+///
+/// The backing integer type `T` (i32, i64, or i128) determines the element
+/// width. Precision and scale come from the parsed format string and are
+/// stored on the resulting `DecimalArray`.
+///
+/// # Arguments
+/// * `arr` - Reference to the ArrowArray containing the data
+/// * `ownership` - If `Some(box)`, takes ownership and does zero-copy via ForeignBuffer.
+///                 If `None`, copies the data.
+/// * `precision` - total significant digits
+/// * `scale` - digits after the decimal point
+/// * `tag` - constructor function to wrap the array
+///
+/// # Safety
+/// `arr` must contain valid buffers of expected length and type.
+#[cfg(feature = "decimal")]
+unsafe fn import_decimal<T: Integer>(
+    arr: &ArrowArray,
+    ownership: Option<Box<ArrowArray>>,
+    precision: u8,
+    scale: i8,
+    tag: fn(DecimalArray<T>) -> Array,
+) -> Arc<Array> {
+    let len = arr.length as usize;
+    let offset = arr.offset as usize;
+    let buffers = unsafe { slice::from_raw_parts(arr.buffers, 2) };
+    let data_ptr = unsafe { (buffers[1] as *const T).add(offset) };
+    let data_len_bytes = len * std::mem::size_of::<T>();
+
+    // Null mask is always copied to honour the bit-level offset.
+    let null_mask = if !buffers[0].is_null() {
+        Some(unsafe { import_null_mask_offset(buffers[0], offset, len) })
+    } else {
+        None
+    };
+
+    // For empty arrays, create an empty buffer rather than reading from the foreign pointer.
+    let buffer: Buffer<T> = if len == 0 {
+        Buffer::default()
+    } else if let Some(arr_box) = ownership {
+        // Zero-copy: wrap foreign buffer
+        let foreign = ForeignBuffer {
+            ptr: data_ptr as *const u8,
+            len: data_len_bytes,
+            array: Some(arr_box),
+        };
+        let shared = SharedBuffer::from_owner(foreign);
+        Buffer::from_shared(shared)
+    } else {
+        let data = unsafe { slice::from_raw_parts(data_ptr, len) };
+        Vec64::from(data).into()
+    };
+
+    let dec_arr = DecimalArray::<T>::new(buffer, null_mask, precision, scale);
+    Arc::new(tag(dec_arr))
 }
 
 /// Verifies that all buffer pointers are 64-byte aligned.
@@ -4764,5 +4887,160 @@ mod tests {
         assert_eq!(cstr.to_str().unwrap(), "d:10,-3");
         let parsed = parse_arrow_format(cstr.as_bytes());
         assert_eq!(parsed, d);
+    }
+
+    // ── Decimal C Data Interface round-trip tests ────────────────────────
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal128_export_import_roundtrip() {
+        use super::import_from_c;
+        use crate::DecimalArray;
+
+        let arr = DecimalArray::<i128>::from_slice(&[12345, -67890, 0], 10, 2);
+        let array = Arc::new(Array::from_decimal128(arr));
+        let schema = schema_for("dec128", ArrowType::Decimal128(10, 2), false);
+
+        let (arr_ptr, sch_ptr) = export_to_c(array.clone(), schema);
+
+        unsafe {
+            assert_eq!((*arr_ptr).length, 3);
+            let fmt = std::ffi::CStr::from_ptr((*sch_ptr).format).to_bytes();
+            assert_eq!(fmt, b"d:10,2");
+
+            let imported = import_from_c(arr_ptr as *const _, sch_ptr as *const _);
+            assert_eq!(*imported, *array);
+
+            ((*arr_ptr).release.unwrap())(arr_ptr);
+            ((*sch_ptr).release.unwrap())(sch_ptr);
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal64_export_import_roundtrip() {
+        use super::import_from_c;
+        use crate::DecimalArray;
+
+        let arr = DecimalArray::<i64>::from_slice(&[999, -1, 42], 18, 4);
+        let array = Arc::new(Array::from_decimal64(arr));
+        let schema = schema_for("dec64", ArrowType::Decimal64(18, 4), false);
+
+        let (arr_ptr, sch_ptr) = export_to_c(array.clone(), schema);
+
+        unsafe {
+            assert_eq!((*arr_ptr).length, 3);
+            let fmt = std::ffi::CStr::from_ptr((*sch_ptr).format).to_bytes();
+            assert_eq!(fmt, b"d:18,4,64");
+
+            let imported = import_from_c(arr_ptr as *const _, sch_ptr as *const _);
+            assert_eq!(*imported, *array);
+
+            ((*arr_ptr).release.unwrap())(arr_ptr);
+            ((*sch_ptr).release.unwrap())(sch_ptr);
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal32_export_import_roundtrip() {
+        use super::import_from_c;
+        use crate::DecimalArray;
+
+        let arr = DecimalArray::<i32>::from_slice(&[100, 200, -300], 9, 2);
+        let array = Arc::new(Array::from_decimal32(arr));
+        let schema = schema_for("dec32", ArrowType::Decimal32(9, 2), false);
+
+        let (arr_ptr, sch_ptr) = export_to_c(array.clone(), schema);
+
+        unsafe {
+            assert_eq!((*arr_ptr).length, 3);
+            let fmt = std::ffi::CStr::from_ptr((*sch_ptr).format).to_bytes();
+            assert_eq!(fmt, b"d:9,2,32");
+
+            let imported = import_from_c(arr_ptr as *const _, sch_ptr as *const _);
+            assert_eq!(*imported, *array);
+
+            ((*arr_ptr).release.unwrap())(arr_ptr);
+            ((*sch_ptr).release.unwrap())(sch_ptr);
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal128_owned_roundtrip() {
+        use super::import_from_c_owned;
+        use crate::DecimalArray;
+
+        let arr = DecimalArray::<i128>::from_slice(&[12345, -67890], 10, 2);
+        let array = Arc::new(Array::from_decimal128(arr));
+        let schema = schema_for("dec128", ArrowType::Decimal128(10, 2), false);
+
+        let (arr_ptr, sch_ptr) = export_to_c(array.clone(), schema);
+
+        unsafe {
+            let arr_box = Box::from_raw(arr_ptr);
+            let sch_box = Box::from_raw(sch_ptr);
+            let (imported, field) = import_from_c_owned(arr_box, sch_box);
+            assert_eq!(*imported, *array);
+            assert_eq!(field.dtype, ArrowType::Decimal128(10, 2));
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_with_nulls_roundtrip() {
+        use super::import_from_c_owned;
+        use crate::{DecimalArray, MaskedArray as _};
+
+        let mut arr = DecimalArray::<i128>::with_capacity(4, true, 10, 2);
+        arr.push(12345);
+        arr.push_null();
+        arr.push(67890);
+        arr.push_null();
+
+        let array = Arc::new(Array::from_decimal128(arr));
+        let schema = schema_for("dec128_nulls", ArrowType::Decimal128(10, 2), true);
+
+        let (arr_ptr, sch_ptr) = export_to_c(array.clone(), schema);
+
+        unsafe {
+            let arr_box = Box::from_raw(arr_ptr);
+            let sch_box = Box::from_raw(sch_ptr);
+            let (imported, field) = import_from_c_owned(arr_box, sch_box);
+            assert_eq!(*imported, *array);
+            assert_eq!(field.dtype, ArrowType::Decimal128(10, 2));
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_record_batch_stream_roundtrip() {
+        use super::{export_record_batch_stream, import_record_batch_stream};
+        use crate::DecimalArray;
+
+        let field = Field::new("amount", ArrowType::Decimal128(10, 2), false, None);
+        let arr = DecimalArray::<i128>::from_slice(&[12345, 67890], 10, 2);
+        let array = Arc::new(Array::from_decimal128(arr));
+        let col_schema = Schema {
+            fields: vec![field.clone()],
+            metadata: Default::default(),
+        };
+
+        let batches = vec![vec![(array.clone(), col_schema)]];
+        let fields = vec![field];
+
+        let stream = export_record_batch_stream(batches, fields);
+        let stream_ptr = Box::into_raw(stream);
+
+        unsafe {
+            let result = import_record_batch_stream(stream_ptr);
+            assert_eq!(result.len(), 1);
+            let batch = &result[0];
+            assert_eq!(batch.len(), 1);
+            let (imported, imported_field) = &batch[0];
+            assert_eq!(**imported, *array);
+            assert_eq!(imported_field.dtype, ArrowType::Decimal128(10, 2));
+        }
     }
 }

--- a/src/ffi/arrow_c_ffi.rs
+++ b/src/ffi/arrow_c_ffi.rs
@@ -265,6 +265,24 @@ unsafe extern "C" fn release_arrow_schema(s: *mut ArrowSchema) {
 
 /// Constructs the Arrow C FFI format string for the given ArrowType.
 pub fn fmt_c(dtype: ArrowType) -> CString {
+    #[cfg(feature = "decimal")]
+    match &dtype {
+        // Decimal128 is the Arrow default so the bitwidth suffix is omitted.
+        ArrowType::Decimal128(p, s) => {
+            let fmt = format!("d:{p},{s}");
+            return CString::new(fmt).expect("CString formatting failed: invalid bytes");
+        }
+        ArrowType::Decimal32(p, s) => {
+            let fmt = format!("d:{p},{s},32");
+            return CString::new(fmt).expect("CString formatting failed: invalid bytes");
+        }
+        ArrowType::Decimal64(p, s) => {
+            let fmt = format!("d:{p},{s},64");
+            return CString::new(fmt).expect("CString formatting failed: invalid bytes");
+        }
+        _ => {}
+    }
+
     #[cfg(feature = "datetime")]
     if let ArrowType::Timestamp(u, tz) = &dtype {
         let unit_str = match u {
@@ -347,6 +365,11 @@ pub fn fmt_c(dtype: ArrowType) -> CString {
             IntervalUnit::DaysTime => b"tiD",
             IntervalUnit::MonthDaysNs => b"tin",
         },
+
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+            unreachable!("decimal cases handled by the early return above")
+        }
 
         // ---- dictionary (categorical) ----
         ArrowType::Dictionary(idx) => match idx {
@@ -863,6 +886,10 @@ pub unsafe fn import_from_c(arr_ptr: *const ArrowArray, sch_ptr: *const ArrowSch
             ArrowType::Interval(_u) => {
                 panic!("FFI import_from_c: Arrow Interval types are not yet supported");
             }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("FFI import_from_c: Decimal array import is not yet implemented")
+            }
             ArrowType::Null => {
                 panic!("FFI import_from_c: Arrow Null arrays types are not yet supported")
             }
@@ -1007,6 +1034,10 @@ pub unsafe fn import_from_c_owned(
             ArrowType::Interval(_u) => {
                 panic!("FFI import_from_c_owned: Arrow Interval types are not yet supported");
             }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("FFI import_from_c_owned: Decimal array import is not yet implemented")
+            }
             ArrowType::Null => {
                 panic!("FFI import_from_c_owned: Arrow Null arrays types are not yet supported")
             }
@@ -1132,6 +1163,10 @@ unsafe fn import_array_zero_copy(
             #[cfg(feature = "datetime")]
             ArrowType::Interval(_u) => {
                 panic!("import_array_zero_copy: Interval types are not yet supported");
+            }
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _) | ArrowType::Decimal64(_, _) | ArrowType::Decimal128(_, _) => {
+                panic!("import_array_zero_copy: Decimal array import is not yet implemented")
             }
             ArrowType::Null => {
                 panic!("import_array_zero_copy: Null array types are not yet supported");
@@ -3408,6 +3443,38 @@ unsafe fn field_from_c_schema(schema: &ArrowSchema) -> crate::Field {
     crate::Field::new(name, dtype, nullable, metadata)
 }
 
+/// Parses an Arrow C decimal format string (`d:P,S` or `d:P,S,N`) into an ArrowType.
+///
+/// Two-component form (`d:P,S`) is Decimal128 per the Arrow spec where 128
+/// is the default bitwidth. Three-component form (`d:P,S,N`) selects the
+/// bitwidth from N. Accepts `d:P,S,128` as equivalent to `d:P,S`.
+#[cfg(feature = "decimal")]
+fn parse_decimal_format(fmt: &[u8]) -> ArrowType {
+    let s = std::str::from_utf8(&fmt[2..]).unwrap_or_else(|_| {
+        panic!(
+            "FFI parse_decimal_format: non-UTF8 decimal format {:?}",
+            fmt
+        )
+    });
+    let parts: Vec<&str> = s.split(',').collect();
+    let precision: u8 = parts[0].parse().unwrap_or_else(|_| {
+        panic!("FFI parse_decimal_format: invalid precision in {:?}", s)
+    });
+    let scale: i8 = parts[1].parse().unwrap_or_else(|_| {
+        panic!("FFI parse_decimal_format: invalid scale in {:?}", s)
+    });
+    match parts.len() {
+        2 => ArrowType::Decimal128(precision, scale),
+        3 => match parts[2] {
+            "32" => ArrowType::Decimal32(precision, scale),
+            "64" => ArrowType::Decimal64(precision, scale),
+            "128" => ArrowType::Decimal128(precision, scale),
+            w => panic!("FFI parse_decimal_format: unsupported decimal bitwidth {w}"),
+        },
+        _ => panic!("FFI parse_decimal_format: malformed decimal format {:?}", s),
+    }
+}
+
 /// Parses an Arrow C format string into an ArrowType.
 /// Shared between import_from_c, import_from_c_owned, and stream import.
 fn parse_arrow_format(fmt: &[u8]) -> ArrowType {
@@ -3459,6 +3526,10 @@ fn parse_arrow_format(fmt: &[u8]) -> ArrowType {
         #[cfg(feature = "datetime")]
         b"tin" => ArrowType::Interval(crate::IntervalUnit::MonthDaysNs),
         b"+s" => ArrowType::Null, // struct marker (handled at stream level)
+        #[cfg(feature = "decimal")]
+        _ if fmt.starts_with(b"d:") => {
+            parse_decimal_format(fmt)
+        }
         #[cfg(feature = "datetime")]
         _ if fmt.starts_with(b"tss")
             || fmt.starts_with(b"tsm")
@@ -4644,5 +4715,54 @@ mod tests {
             ((*arr_ptr).release.unwrap())(arr_ptr);
             ((*sch_ptr).release.unwrap())(sch_ptr);
         }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_fmt_c_roundtrip() {
+        use super::{fmt_c, parse_arrow_format};
+
+        // Decimal128 emits d:P,S (no bitwidth suffix)
+        let d128 = ArrowType::Decimal128(38, 10);
+        let cstr = fmt_c(d128.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:38,10");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d128);
+
+        // Decimal64 emits d:P,S,64
+        let d64 = ArrowType::Decimal64(18, 4);
+        let cstr = fmt_c(d64.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:18,4,64");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d64);
+
+        // Decimal32 emits d:P,S,32
+        let d32 = ArrowType::Decimal32(9, 2);
+        let cstr = fmt_c(d32.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:9,2,32");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d32);
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_parse_128_explicit_bitwidth() {
+        use super::parse_arrow_format;
+
+        // d:P,S,128 is an alias for Decimal128
+        let parsed = parse_arrow_format(b"d:38,10,128");
+        assert_eq!(parsed, ArrowType::Decimal128(38, 10));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_negative_scale_roundtrip() {
+        use super::{fmt_c, parse_arrow_format};
+
+        let d = ArrowType::Decimal128(10, -3);
+        let cstr = fmt_c(d.clone());
+        assert_eq!(cstr.to_str().unwrap(), "d:10,-3");
+        let parsed = parse_arrow_format(cstr.as_bytes());
+        assert_eq!(parsed, d);
     }
 }

--- a/src/ffi/arrow_dtype.rs
+++ b/src/ffi/arrow_dtype.rs
@@ -116,6 +116,13 @@ pub enum ArrowType {
     LargeString,
     Utf8View,
 
+    #[cfg(feature = "decimal")]
+    Decimal32(u8, i8),
+    #[cfg(feature = "decimal")]
+    Decimal64(u8, i8),
+    #[cfg(feature = "decimal")]
+    Decimal128(u8, i8),
+
     // Integer size for the categorical dictionary key,
     // and therefore how much storage space for each entry there is,
     // on top of the base string collection.
@@ -141,6 +148,10 @@ impl ArrowType {
             | ArrowType::UInt64
             | ArrowType::Float32
             | ArrowType::Float64 => "Numeric",
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(_, _)
+            | ArrowType::Decimal64(_, _)
+            | ArrowType::Decimal128(_, _) => "Numeric",
             #[cfg(feature = "datetime")]
             ArrowType::Date32
             | ArrowType::Date64
@@ -189,11 +200,14 @@ impl ArrowType {
 
         /// Promotion axis of a numeric type: family plus bit width.
         /// Numeric pairs promote on these two properties alone, so the
-        /// ten numeric types resolve through one set of rules.
+        /// standard numeric types resolve through one set of rules.
+        /// Decimal types carry precision and scale alongside their width.
         enum PromotionVariant {
             Signed(u32),
             Unsigned(u32),
             Float(u32),
+            #[cfg(feature = "decimal")]
+            Decimal(u32, u8, i8),
         }
         /// Classifies a type onto its promotion axis. Exhaustive over
         /// every `ArrowType` variant so a new variant does not compile
@@ -214,6 +228,12 @@ impl ArrowType {
                 ArrowType::UInt64 => Some(PromotionVariant::Unsigned(64)),
                 ArrowType::Float32 => Some(PromotionVariant::Float(32)),
                 ArrowType::Float64 => Some(PromotionVariant::Float(64)),
+                #[cfg(feature = "decimal")]
+                ArrowType::Decimal32(p, s) => Some(PromotionVariant::Decimal(32, *p, *s)),
+                #[cfg(feature = "decimal")]
+                ArrowType::Decimal64(p, s) => Some(PromotionVariant::Decimal(64, *p, *s)),
+                #[cfg(feature = "decimal")]
+                ArrowType::Decimal128(p, s) => Some(PromotionVariant::Decimal(128, *p, *s)),
                 ArrowType::Null | ArrowType::Boolean => None,
                 ArrowType::String | ArrowType::Utf8View | ArrowType::Dictionary(_) => None,
                 #[cfg(feature = "large_string")]
@@ -249,6 +269,14 @@ impl ArrowType {
                 _ => ArrowType::UInt64,
             }
         }
+        #[cfg(feature = "decimal")]
+        fn decimal(bits: u32, precision: u8, scale: i8) -> ArrowType {
+            match bits {
+                32 => ArrowType::Decimal32(precision, scale),
+                64 => ArrowType::Decimal64(precision, scale),
+                _ => ArrowType::Decimal128(precision, scale),
+            }
+        }
 
         if let (Some(a), Some(b)) = (promotion_variant(self), promotion_variant(other)) {
             use PromotionVariant::*;
@@ -273,6 +301,18 @@ impl ArrowType {
                 // at 64 bits where conversion validates the values.
                 (Signed(s), Unsigned(u)) | (Unsigned(u), Signed(s)) => {
                     signed(s.max((u * 2).min(64)))
+                }
+                // Demote to Float64 so the caller accepts the precision trade.
+                #[cfg(feature = "decimal")]
+                (Decimal(_, _, _), Float(_)) | (Float(_), Decimal(_, _, _)) => Float64,
+                // Promote the integer into the decimal's width and scale.
+                #[cfg(feature = "decimal")]
+                (Decimal(w, p, s), Signed(_) | Unsigned(_))
+                | (Signed(_) | Unsigned(_), Decimal(w, p, s)) => decimal(w, p, s),
+                // Widen to the broader width with the finer scale and max precision.
+                #[cfg(feature = "decimal")]
+                (Decimal(w1, p1, s1), Decimal(w2, p2, s2)) => {
+                    decimal(w1.max(w2), p1.max(p2), s1.max(s2))
                 }
             });
         }
@@ -358,12 +398,26 @@ impl ArrowType {
             | (_, Null | Boolean | String | Utf8View | Dictionary(_)) => None,
             #[cfg(feature = "large_string")]
             (LargeString, _) | (_, LargeString) => None,
-            #[cfg(feature = "extended_numeric_types")]
+            #[cfg(all(feature = "extended_numeric_types", feature = "decimal"))]
+            (
+                Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+                Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+            ) => unreachable!("numeric pairs resolve in the numeric rules above"),
+            #[cfg(all(feature = "extended_numeric_types", not(feature = "decimal")))]
             (
                 Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
                 Int8 | Int16 | UInt8 | UInt16 | Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
             ) => unreachable!("numeric pairs resolve in the numeric rules above"),
-            #[cfg(not(feature = "extended_numeric_types"))]
+            #[cfg(all(not(feature = "extended_numeric_types"), feature = "decimal"))]
+            (
+                Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+                Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64
+                | Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _),
+            ) => unreachable!("numeric pairs resolve in the numeric rules above"),
+            #[cfg(not(any(feature = "extended_numeric_types", feature = "decimal")))]
             (
                 Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
                 Int32 | Int64 | UInt32 | UInt64 | Float32 | Float64,
@@ -542,6 +596,13 @@ impl Display for ArrowType {
 
             ArrowType::Float32 => f.write_str("Float32"),
             ArrowType::Float64 => f.write_str("Float64"),
+
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal32(p, s) => write!(f, "Decimal32({p}, {s})"),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal64(p, s) => write!(f, "Decimal64({p}, {s})"),
+            #[cfg(feature = "decimal")]
+            ArrowType::Decimal128(p, s) => write!(f, "Decimal128({p}, {s})"),
 
             #[cfg(feature = "datetime")]
             ArrowType::Date32 => f.write_str("Date32"),
@@ -723,5 +784,130 @@ mod tests {
         assert_eq!(Null.upcast(&Null), None);
         assert_eq!(Boolean.upcast(&Boolean), None);
         assert_eq!(String.upcast(&String), None);
+    }
+
+    // ---- Decimal tests ----
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_display() {
+        assert_eq!(ArrowType::Decimal32(9, 2).to_string(), "Decimal32(9, 2)");
+        assert_eq!(ArrowType::Decimal64(18, 4).to_string(), "Decimal64(18, 4)");
+        assert_eq!(
+            ArrowType::Decimal128(38, 10).to_string(),
+            "Decimal128(38, 10)"
+        );
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_negative_scale_display() {
+        assert_eq!(
+            ArrowType::Decimal128(10, -3).to_string(),
+            "Decimal128(10, -3)"
+        );
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn decimal_category_label() {
+        assert_eq!(ArrowType::Decimal32(9, 2).minarrow_category_label(), "Numeric");
+        assert_eq!(ArrowType::Decimal64(18, 4).minarrow_category_label(), "Numeric");
+        assert_eq!(
+            ArrowType::Decimal128(38, 10).minarrow_category_label(),
+            "Numeric"
+        );
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_identity() {
+        let d32 = ArrowType::Decimal32(9, 2);
+        let d64 = ArrowType::Decimal64(18, 4);
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d32.upcast(&d32), Some(d32));
+        assert_eq!(d64.upcast(&d64), Some(d64));
+        assert_eq!(d128.upcast(&d128), Some(d128));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_same_width_same_scale_max_precision() {
+        let a = ArrowType::Decimal128(20, 5);
+        let b = ArrowType::Decimal128(30, 5);
+        assert_eq!(a.upcast(&b), Some(ArrowType::Decimal128(30, 5)));
+        assert_eq!(b.upcast(&a), Some(ArrowType::Decimal128(30, 5)));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_different_width() {
+        let d32 = ArrowType::Decimal32(9, 2);
+        let d64 = ArrowType::Decimal64(18, 4);
+        let d128 = ArrowType::Decimal128(38, 10);
+
+        // Wider width wins, finer scale preserved
+        let r = d32.upcast(&d64).unwrap();
+        assert_eq!(r, ArrowType::Decimal64(18, 4));
+
+        let r = d32.upcast(&d128).unwrap();
+        assert_eq!(r, ArrowType::Decimal128(38, 10));
+
+        let r = d64.upcast(&d128).unwrap();
+        assert_eq!(r, ArrowType::Decimal128(38, 10));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_symmetry() {
+        let types = vec![
+            ArrowType::Decimal32(9, 2),
+            ArrowType::Decimal64(18, 4),
+            ArrowType::Decimal128(38, 10),
+        ];
+        for a in &types {
+            for b in &types {
+                assert_eq!(
+                    a.upcast(b),
+                    b.upcast(a),
+                    "decimal upcast symmetry for {a:?} x {b:?}"
+                );
+            }
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_x_integer() {
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d128.upcast(&ArrowType::Int32), Some(d128.clone()));
+        assert_eq!(ArrowType::Int32.upcast(&d128), Some(d128.clone()));
+        assert_eq!(ArrowType::Int64.upcast(&d128), Some(d128.clone()));
+        assert_eq!(ArrowType::UInt64.upcast(&d128), Some(d128.clone()));
+
+        let d32 = ArrowType::Decimal32(9, 2);
+        assert_eq!(d32.upcast(&ArrowType::Int64), Some(d32.clone()));
+        assert_eq!(ArrowType::UInt32.upcast(&d32), Some(d32.clone()));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_x_float() {
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d128.upcast(&ArrowType::Float32), Some(ArrowType::Float64));
+        assert_eq!(d128.upcast(&ArrowType::Float64), Some(ArrowType::Float64));
+        assert_eq!(ArrowType::Float32.upcast(&d128), Some(ArrowType::Float64));
+        assert_eq!(ArrowType::Float64.upcast(&d128), Some(ArrowType::Float64));
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn upcast_decimal_x_non_numeric() {
+        let d128 = ArrowType::Decimal128(38, 10);
+        assert_eq!(d128.upcast(&ArrowType::Boolean), None);
+        assert_eq!(d128.upcast(&ArrowType::String), None);
+        assert_eq!(d128.upcast(&ArrowType::Null), None);
+        assert_eq!(ArrowType::Boolean.upcast(&d128), None);
+        assert_eq!(ArrowType::String.upcast(&d128), None);
     }
 }

--- a/src/ffi/polars.rs
+++ b/src/ffi/polars.rs
@@ -256,6 +256,11 @@ fn arrow_type_to_polars_dtype(dtype: &ArrowType) -> polars_arrow::datatypes::Arr
             crate::IntervalUnit::MonthDaysNs => polars_arrow::datatypes::IntervalUnit::MonthDayNano,
         }),
 
+        #[cfg(feature = "decimal")]
+        ArrowType::Decimal32(p, s) | ArrowType::Decimal64(p, s) | ArrowType::Decimal128(p, s) => {
+            polars_arrow::datatypes::ArrowDataType::Decimal(*p as usize, *s as usize)
+        }
+
         ArrowType::Dictionary(idx) => {
             let key: polars_arrow::datatypes::IntegerType = match idx {
                 #[cfg(feature = "default_categorical_8")]

--- a/src/kernels/arithmetic/decimal.rs
+++ b/src/kernels/arithmetic/decimal.rs
@@ -1,0 +1,852 @@
+// Copyright 2025 Peter Garfield Bower
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Arithmetic kernels for decimal arrays with overflow detection.
+//!
+//! All operations use checked arithmetic and return `KernelError::Overflow`
+//! when the result exceeds the integer width. Scale reconciliation and
+//! result-precision computation are handled here so the caller passes
+//! `DecimalArray` pairs and receives a correctly-typed `DecimalArray` result.
+
+use crate::enums::error::KernelError;
+use crate::enums::operators::ArithmeticOperator;
+use crate::kernels::bitmask::merge_bitmasks_to_new;
+use crate::traits::type_unions::Integer;
+use crate::{Bitmask, DecimalArray, MaskedArray, Vec64};
+
+/// Maximum precision per backing integer width.
+fn max_precision<T: Integer + 'static>() -> u8 {
+    use std::any::TypeId;
+    let tid = TypeId::of::<T>();
+    if tid == TypeId::of::<i32>() {
+        9
+    } else if tid == TypeId::of::<i64>() {
+        18
+    } else {
+        38
+    }
+}
+
+/// Compute `10^exp` as T using checked multiplication.
+///
+/// Returns `None` if the result overflows the backing integer width.
+fn checked_pow10<T: Integer>(exp: u32) -> Option<T> {
+    let ten = T::from_usize(10);
+    let mut acc = T::one();
+    for _ in 0..exp {
+        acc = acc.checked_mul(&ten)?;
+    }
+    Some(acc)
+}
+
+/// Element-wise checked binary arithmetic on two `DecimalArray<T>` operands.
+///
+/// Reconciles scale for add/subtract, computes result scale for
+/// multiply/divide, and detects overflow across all operations.
+/// The merged null mask from both operands propagates through the result.
+///
+/// ## Scale rules
+/// - Add/Subtract: operands are rescaled to the finer scale. Result
+///   precision is capped at the width maximum.
+/// - Multiply: result scale = s1 + s2, result precision = p1 + p2,
+///   capped at the width maximum.
+/// - Divide: the numerator is scaled up so integer division preserves
+///   the desired number of fractional digits. Result scale is max of
+///   the two input scales.
+/// - Negate and Abs are unary and handled by separate functions.
+pub fn decimal_binary<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    op: ArithmeticOperator,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    if len != rhs.len() {
+        return Err(KernelError::LengthMismatch(format!(
+            "decimal_binary: lhs {} vs rhs {}",
+            len,
+            rhs.len()
+        )));
+    }
+
+    let merged_mask = merge_bitmasks_to_new(
+        lhs.null_mask.as_ref(),
+        rhs.null_mask.as_ref(),
+        len,
+    );
+
+    match op {
+        ArithmeticOperator::Add | ArithmeticOperator::Subtract => {
+            decimal_add_sub(lhs, rhs, op, merged_mask)
+        }
+        ArithmeticOperator::Multiply => decimal_multiply(lhs, rhs, merged_mask),
+        ArithmeticOperator::Divide | ArithmeticOperator::FloorDiv => {
+            decimal_divide(lhs, rhs, merged_mask)
+        }
+        ArithmeticOperator::Remainder => decimal_remainder(lhs, rhs, merged_mask),
+        ArithmeticOperator::Power => Err(KernelError::UnsupportedType(
+            "Power is not supported for decimal arrays - consider converting to float64 first"
+                .to_string(),
+        )),
+    }
+}
+
+/// Add or subtract two decimal arrays, reconciling scale when they differ.
+fn decimal_add_sub<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    op: ArithmeticOperator,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let ls = lhs.scale;
+    let rs = rhs.scale;
+    let result_scale = ls.max(rs);
+    let result_precision = (lhs.precision.max(rhs.precision) + 1).min(max_precision::<T>());
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    let is_add = matches!(op, ArithmeticOperator::Add);
+
+    if ls == rs {
+        // Same scale - operate on raw values
+        for i in 0..len {
+            if is_masked_null(&merged_mask, i) {
+                out[i] = T::zero();
+                continue;
+            }
+            let l = lhs.data[i];
+            let r = rhs.data[i];
+            let result = if is_add {
+                l.checked_add(&r)
+            } else {
+                l.checked_sub(&r)
+            };
+            out[i] = result.ok_or_else(|| overflow_error("add/subtract"))?;
+        }
+    } else {
+        // Different scale - rescale the coarser operand to the finer scale
+        let scale_diff = (ls - rs).unsigned_abs() as u32;
+        let scale_factor = checked_pow10::<T>(scale_diff)
+            .ok_or_else(|| overflow_error("scale factor computation"))?;
+
+        for i in 0..len {
+            if is_masked_null(&merged_mask, i) {
+                out[i] = T::zero();
+                continue;
+            }
+            let (l, r) = if ls < rs {
+                // lhs has coarser scale, rescale lhs up
+                let scaled_l = lhs.data[i]
+                    .checked_mul(&scale_factor)
+                    .ok_or_else(|| overflow_error("rescale for add/subtract"))?;
+                (scaled_l, rhs.data[i])
+            } else {
+                // rhs has coarser scale, rescale rhs up
+                let scaled_r = rhs.data[i]
+                    .checked_mul(&scale_factor)
+                    .ok_or_else(|| overflow_error("rescale for add/subtract"))?;
+                (lhs.data[i], scaled_r)
+            };
+            let result = if is_add {
+                l.checked_add(&r)
+            } else {
+                l.checked_sub(&r)
+            };
+            out[i] = result.ok_or_else(|| overflow_error("add/subtract"))?;
+        }
+    }
+
+    Ok(DecimalArray::new(out, merged_mask, result_precision, result_scale))
+}
+
+/// Multiply two decimal arrays. Result scale = s1 + s2, result
+/// precision = p1 + p2, capped at the width maximum.
+fn decimal_multiply<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let result_scale = lhs.scale + rhs.scale;
+    let result_precision = (lhs.precision + rhs.precision).min(max_precision::<T>());
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if is_masked_null(&merged_mask, i) {
+            out[i] = T::zero();
+            continue;
+        }
+        out[i] = lhs.data[i]
+            .checked_mul(&rhs.data[i])
+            .ok_or_else(|| overflow_error("multiply"))?;
+    }
+
+    Ok(DecimalArray::new(out, merged_mask, result_precision, result_scale))
+}
+
+/// Divide two decimal arrays. The numerator is scaled up so integer division
+/// preserves fractional digits. Result scale = max of the two input scales.
+fn decimal_divide<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let result_scale = lhs.scale.max(rhs.scale);
+    let result_precision = lhs.precision.max(rhs.precision).min(max_precision::<T>());
+
+    // Scale up the numerator so that integer division produces digits at
+    // the desired result scale: numerator * 10^(result_scale - lhs.scale + rhs.scale)
+    let extra_scale = (result_scale - lhs.scale + rhs.scale) as u32;
+    let scale_up = if extra_scale > 0 {
+        checked_pow10::<T>(extra_scale)
+            .ok_or_else(|| overflow_error("division scale-up factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+    let mut out_mask = merged_mask.clone();
+
+    for i in 0..len {
+        if is_masked_null(&out_mask, i) {
+            out[i] = T::zero();
+            continue;
+        }
+        let divisor = rhs.data[i];
+        if divisor == T::zero() {
+            // Division by zero produces null
+            out[i] = T::zero();
+            ensure_mask_null(&mut out_mask, len, i);
+            continue;
+        }
+        let scaled_num = lhs.data[i]
+            .checked_mul(&scale_up)
+            .ok_or_else(|| overflow_error("division numerator scale-up"))?;
+        out[i] = scaled_num / divisor;
+    }
+
+    Ok(DecimalArray::new(out, out_mask, result_precision, result_scale))
+}
+
+/// Remainder of two decimal arrays. Operands must have the same scale,
+/// or the coarser operand is rescaled first.
+fn decimal_remainder<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    merged_mask: Option<Bitmask>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = lhs.len();
+    let ls = lhs.scale;
+    let rs = rhs.scale;
+    let result_scale = ls.max(rs);
+    let result_precision = lhs.precision.max(rhs.precision).min(max_precision::<T>());
+
+    let scale_diff = (ls - rs).unsigned_abs() as u32;
+    let scale_factor = if scale_diff > 0 {
+        checked_pow10::<T>(scale_diff)
+            .ok_or_else(|| overflow_error("remainder scale factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+    let mut out_mask = merged_mask.clone();
+
+    for i in 0..len {
+        if is_masked_null(&out_mask, i) {
+            out[i] = T::zero();
+            continue;
+        }
+        let (l, r) = if ls == rs {
+            (lhs.data[i], rhs.data[i])
+        } else if ls < rs {
+            let scaled_l = lhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("remainder rescale"))?;
+            (scaled_l, rhs.data[i])
+        } else {
+            let scaled_r = rhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("remainder rescale"))?;
+            (lhs.data[i], scaled_r)
+        };
+        if r == T::zero() {
+            out[i] = T::zero();
+            ensure_mask_null(&mut out_mask, len, i);
+            continue;
+        }
+        out[i] = l % r;
+    }
+
+    Ok(DecimalArray::new(out, out_mask, result_precision, result_scale))
+}
+
+/// Element-wise negate on a decimal array. Overflow is only possible when
+/// negating the minimum value of the backing integer, for e.g. i32::MIN.
+pub fn decimal_negate<T: Integer + 'static>(
+    arr: &DecimalArray<T>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = arr.len();
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if arr.is_null(i) {
+            out[i] = T::zero();
+            continue;
+        }
+        out[i] = T::zero()
+            .checked_sub(&arr.data[i])
+            .ok_or_else(|| overflow_error("negate"))?;
+    }
+
+    Ok(DecimalArray::new(out, arr.null_mask.clone(), arr.precision, arr.scale))
+}
+
+/// Element-wise absolute value on a decimal array.
+pub fn decimal_abs<T: Integer + 'static>(
+    arr: &DecimalArray<T>,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = arr.len();
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if arr.is_null(i) {
+            out[i] = T::zero();
+            continue;
+        }
+        let v = arr.data[i];
+        if v < T::zero() {
+            out[i] = T::zero()
+                .checked_sub(&v)
+                .ok_or_else(|| overflow_error("abs"))?;
+        } else {
+            out[i] = v;
+        }
+    }
+
+    Ok(DecimalArray::new(out, arr.null_mask.clone(), arr.precision, arr.scale))
+}
+
+/// Rescale a decimal array to a new scale, multiplying or dividing the raw
+/// values by 10^|new_scale - old_scale|.
+///
+/// Scaling up multiplies raw values by the power-of-ten difference using
+/// checked arithmetic. Scaling down divides and truncates.
+pub fn decimal_rescale<T: Integer + 'static>(
+    arr: &DecimalArray<T>,
+    new_scale: i8,
+) -> Result<DecimalArray<T>, KernelError> {
+    if new_scale == arr.scale {
+        return Ok(arr.clone());
+    }
+
+    let len = arr.len();
+    let diff = (new_scale as i32 - arr.scale as i32).unsigned_abs();
+    let factor = checked_pow10::<T>(diff)
+        .ok_or_else(|| overflow_error("rescale factor"))?;
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    if new_scale > arr.scale {
+        // Scale up: multiply by factor
+        for i in 0..len {
+            if arr.is_null(i) {
+                out[i] = T::zero();
+                continue;
+            }
+            out[i] = arr.data[i]
+                .checked_mul(&factor)
+                .ok_or_else(|| overflow_error("rescale up"))?;
+        }
+    } else {
+        // Scale down: truncating division by factor
+        for i in 0..len {
+            if arr.is_null(i) {
+                out[i] = T::zero();
+                continue;
+            }
+            out[i] = arr.data[i] / factor;
+        }
+    }
+
+    Ok(DecimalArray::new(out, arr.null_mask.clone(), arr.precision, new_scale))
+}
+
+/// Element-wise comparison of two decimal arrays, returning a `Bitmask`.
+/// Operands with different scales are rescaled to the finer scale before
+/// comparing.
+pub fn decimal_compare<T: Integer + 'static>(
+    lhs: &DecimalArray<T>,
+    rhs: &DecimalArray<T>,
+    op: crate::enums::operators::ComparisonOperator,
+) -> Result<Bitmask, KernelError> {
+    use crate::enums::operators::ComparisonOperator::*;
+
+    let len = lhs.len();
+    if len != rhs.len() {
+        return Err(KernelError::LengthMismatch(format!(
+            "decimal_compare: lhs {} vs rhs {}",
+            len,
+            rhs.len()
+        )));
+    }
+
+    let ls = lhs.scale;
+    let rs = rhs.scale;
+    let scale_diff = (ls - rs).unsigned_abs() as u32;
+    let need_rescale = ls != rs;
+    let scale_factor = if need_rescale {
+        checked_pow10::<T>(scale_diff)
+            .ok_or_else(|| overflow_error("comparison rescale factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut result = Bitmask::new_set_all(len, false);
+
+    for i in 0..len {
+        // Null on either side produces false for all comparisons
+        if lhs.is_null(i) || rhs.is_null(i) {
+            continue;
+        }
+        let (l, r) = if !need_rescale {
+            (lhs.data[i], rhs.data[i])
+        } else if ls < rs {
+            let scaled_l = lhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("comparison rescale"))?;
+            (scaled_l, rhs.data[i])
+        } else {
+            let scaled_r = rhs.data[i]
+                .checked_mul(&scale_factor)
+                .ok_or_else(|| overflow_error("comparison rescale"))?;
+            (lhs.data[i], scaled_r)
+        };
+
+        let cmp_result = match op {
+            Equals => l == r,
+            NotEquals => l != r,
+            LessThan => l < r,
+            LessThanOrEqualTo => l <= r,
+            GreaterThan => l > r,
+            GreaterThanOrEqualTo => l >= r,
+            _ => {
+                return Err(KernelError::UnsupportedType(format!(
+                    "Comparison operator {:?} not supported for decimal arrays",
+                    op
+                )));
+            }
+        };
+        result.set(i, cmp_result);
+    }
+
+    Ok(result)
+}
+
+/// Convert an integer array to a DecimalArray at the given scale by
+/// multiplying each value by 10^scale. Used for Integer + Decimal
+/// auto-promotion.
+pub fn integer_to_decimal<T: Integer + 'static>(
+    data: &[T],
+    null_mask: Option<&Bitmask>,
+    precision: u8,
+    scale: i8,
+) -> Result<DecimalArray<T>, KernelError> {
+    let len = data.len();
+    let factor = if scale > 0 {
+        checked_pow10::<T>(scale as u32)
+            .ok_or_else(|| overflow_error("integer-to-decimal scale factor"))?
+    } else {
+        T::one()
+    };
+
+    let mut out = Vec64::<T>::with_capacity(len);
+    unsafe { out.set_len(len) };
+
+    for i in 0..len {
+        if null_mask.map(|m| !m.get(i)).unwrap_or(false) {
+            out[i] = T::zero();
+            continue;
+        }
+        out[i] = data[i]
+            .checked_mul(&factor)
+            .ok_or_else(|| overflow_error("integer-to-decimal conversion"))?;
+    }
+
+    Ok(DecimalArray::new(out, null_mask.cloned(), precision, scale))
+}
+
+// ---------------------------------------------------------------------------
+// Internal utilities
+// ---------------------------------------------------------------------------
+
+#[inline(always)]
+fn is_masked_null(mask: &Option<Bitmask>, i: usize) -> bool {
+    mask.as_ref().map(|m| !m.get(i)).unwrap_or(false)
+}
+
+/// Ensure the mask exists and mark position `i` as null.
+fn ensure_mask_null(mask: &mut Option<Bitmask>, len: usize, i: usize) {
+    match mask {
+        Some(m) => m.set(i, false),
+        None => {
+            let mut m = Bitmask::new_set_all(len, true);
+            m.set(i, false);
+            *mask = Some(m);
+        }
+    }
+}
+
+fn overflow_error(context: &str) -> KernelError {
+    KernelError::Overflow(format!("Decimal arithmetic overflow in {}", context))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::enums::operators::ArithmeticOperator::*;
+
+    fn dec32(vals: &[i32], p: u8, s: i8) -> DecimalArray<i32> {
+        DecimalArray::<i32>::from_slice(vals, p, s)
+    }
+
+    fn dec64(vals: &[i64], p: u8, s: i8) -> DecimalArray<i64> {
+        DecimalArray::<i64>::from_slice(vals, p, s)
+    }
+
+    fn dec128(vals: &[i128], p: u8, s: i8) -> DecimalArray<i128> {
+        DecimalArray::<i128>::from_slice(vals, p, s)
+    }
+
+    // -----------------------------------------------------------------------
+    // Same-scale add/subtract
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_same_scale_i32() {
+        let a = dec32(&[12345, 67890], 9, 2);
+        let b = dec32(&[11111, 22222], 9, 2);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.data.as_slice(), &[23456, 90112]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn subtract_same_scale_i64() {
+        let a = dec64(&[50000, 30000], 18, 4);
+        let b = dec64(&[10000, 20000], 18, 4);
+        let result = decimal_binary(&a, &b, Subtract).unwrap();
+        assert_eq!(result.data.as_slice(), &[40000, 10000]);
+        assert_eq!(result.scale, 4);
+    }
+
+    // -----------------------------------------------------------------------
+    // Different-scale add/subtract
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_different_scale() {
+        // 100.0 at scale=1 + 10.00 at scale=2 = 110.00 at scale=2
+        let a = dec64(&[1000], 18, 1); // raw 1000, scale 1 => 100.0
+        let b = dec64(&[1000], 18, 2); // raw 1000, scale 2 => 10.00
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        // lhs rescaled: 1000 * 10 = 10000 at scale 2 => 100.00
+        // 10000 + 1000 = 11000 at scale 2 => 110.00
+        assert_eq!(result.data.as_slice(), &[11000]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn subtract_different_scale() {
+        let a = dec32(&[1000], 9, 1); // 100.0
+        let b = dec32(&[500], 9, 2);  // 5.00
+        let result = decimal_binary(&a, &b, Subtract).unwrap();
+        // lhs rescaled: 1000 * 10 = 10000 at scale 2 => 100.00
+        // 10000 - 500 = 9500 => 95.00
+        assert_eq!(result.data.as_slice(), &[9500]);
+        assert_eq!(result.scale, 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiply
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn multiply_basic() {
+        // 12.34 * 5.67 = 69.9678
+        let a = dec64(&[1234], 18, 2);
+        let b = dec64(&[567], 18, 2);
+        let result = decimal_binary(&a, &b, Multiply).unwrap();
+        assert_eq!(result.data.as_slice(), &[699678]);
+        assert_eq!(result.scale, 4); // 2 + 2
+    }
+
+    // -----------------------------------------------------------------------
+    // Divide
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn divide_same_scale() {
+        // 100.00 / 4.00 = 25.00
+        let a = dec64(&[10000], 18, 2);
+        let b = dec64(&[400], 18, 2);
+        let result = decimal_binary(&a, &b, Divide).unwrap();
+        // result_scale = max(2, 2) = 2
+        // extra_scale = 2 - 2 + 2 = 2
+        // scaled_num = 10000 * 100 = 1000000
+        // 1000000 / 400 = 2500 at scale 2 => 25.00
+        assert_eq!(result.data.as_slice(), &[2500]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn divide_by_zero_produces_null() {
+        let a = dec32(&[100, 200], 9, 2);
+        let b = dec32(&[0, 50], 9, 2);
+        let result = decimal_binary(&a, &b, Divide).unwrap();
+        assert_eq!(result.data[0], 0);
+        assert!(result.is_null(0));
+        assert!(!result.is_null(1));
+    }
+
+    // -----------------------------------------------------------------------
+    // Remainder
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remainder_same_scale() {
+        // 10.00 % 3.00 = 1.00
+        let a = dec64(&[1000], 18, 2);
+        let b = dec64(&[300], 18, 2);
+        let result = decimal_binary(&a, &b, Remainder).unwrap();
+        assert_eq!(result.data.as_slice(), &[100]); // 1000 % 300 = 100
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn remainder_by_zero_produces_null() {
+        let a = dec32(&[100], 9, 2);
+        let b = dec32(&[0], 9, 2);
+        let result = decimal_binary(&a, &b, Remainder).unwrap();
+        assert!(result.is_null(0));
+    }
+
+    // -----------------------------------------------------------------------
+    // Negate and Abs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn negate_basic() {
+        let a = dec32(&[100, -200, 0], 9, 2);
+        let result = decimal_negate(&a).unwrap();
+        assert_eq!(result.data.as_slice(), &[-100, 200, 0]);
+        assert_eq!(result.scale, 2);
+        assert_eq!(result.precision, 9);
+    }
+
+    #[test]
+    fn abs_basic() {
+        let a = dec64(&[-500, 300, 0, -1], 18, 4);
+        let result = decimal_abs(&a).unwrap();
+        assert_eq!(result.data.as_slice(), &[500, 300, 0, 1]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Overflow detection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_overflow_returns_error() {
+        let a = dec32(&[i32::MAX], 9, 0);
+        let b = dec32(&[1], 9, 0);
+        let result = decimal_binary(&a, &b, Add);
+        assert!(result.is_err());
+        let err = format!("{}", result.unwrap_err());
+        assert!(err.contains("overflow"), "got: {err}");
+    }
+
+    #[test]
+    fn multiply_overflow_returns_error() {
+        let a = dec32(&[i32::MAX], 9, 0);
+        let b = dec32(&[2], 9, 0);
+        let result = decimal_binary(&a, &b, Multiply);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Null propagation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn null_propagation() {
+        let mut a = DecimalArray::<i32>::with_capacity(3, true, 9, 2);
+        a.push(100);
+        a.push_null();
+        a.push(300);
+
+        let b = dec32(&[10, 20, 30], 9, 2);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.get(0), Some(110));
+        assert_eq!(result.get(1), None);
+        assert_eq!(result.get(2), Some(330));
+    }
+
+    // -----------------------------------------------------------------------
+    // Rescale
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rescale_up() {
+        let a = dec64(&[100, 200], 18, 2);
+        let result = decimal_rescale(&a, 4).unwrap();
+        assert_eq!(result.data.as_slice(), &[10000, 20000]);
+        assert_eq!(result.scale, 4);
+    }
+
+    #[test]
+    fn rescale_down_truncates() {
+        let a = dec64(&[12345, 67899], 18, 4);
+        let result = decimal_rescale(&a, 2).unwrap();
+        assert_eq!(result.data.as_slice(), &[123, 678]);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn rescale_noop() {
+        let a = dec32(&[100], 9, 2);
+        let result = decimal_rescale(&a, 2).unwrap();
+        assert_eq!(result.data.as_slice(), &[100]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Comparison
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compare_same_scale() {
+        use crate::enums::operators::ComparisonOperator::*;
+
+        let a = dec32(&[100, 200, 300], 9, 2);
+        let b = dec32(&[200, 200, 100], 9, 2);
+
+        let eq = decimal_compare(&a, &b, Equals).unwrap();
+        assert!(!eq.get(0));
+        assert!(eq.get(1));
+        assert!(!eq.get(2));
+
+        let lt = decimal_compare(&a, &b, LessThan).unwrap();
+        assert!(lt.get(0));
+        assert!(!lt.get(1));
+        assert!(!lt.get(2));
+
+        let gt = decimal_compare(&a, &b, GreaterThan).unwrap();
+        assert!(!gt.get(0));
+        assert!(!gt.get(1));
+        assert!(gt.get(2));
+    }
+
+    #[test]
+    fn compare_different_scale() {
+        use crate::enums::operators::ComparisonOperator::*;
+
+        // 10.0 at scale=1 vs 10.00 at scale=2 should be equal
+        let a = dec64(&[100], 18, 1);  // 10.0
+        let b = dec64(&[1000], 18, 2); // 10.00
+        let eq = decimal_compare(&a, &b, Equals).unwrap();
+        assert!(eq.get(0));
+    }
+
+    #[test]
+    fn compare_null_produces_false() {
+        use crate::enums::operators::ComparisonOperator::*;
+
+        let mut a = DecimalArray::<i32>::with_capacity(2, true, 9, 2);
+        a.push(100);
+        a.push_null();
+        let b = dec32(&[100, 100], 9, 2);
+        let eq = decimal_compare(&a, &b, Equals).unwrap();
+        assert!(eq.get(0));
+        assert!(!eq.get(1)); // null comparison is false
+    }
+
+    // -----------------------------------------------------------------------
+    // i128 operations
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn add_i128() {
+        let a = dec128(&[100_000_000_000i128, 200_000_000_000], 38, 6);
+        let b = dec128(&[50_000_000_000, 100_000_000_000], 38, 6);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.data.as_slice(), &[150_000_000_000i128, 300_000_000_000]);
+    }
+
+    #[test]
+    fn multiply_i128() {
+        let a = dec128(&[1000i128], 38, 2);
+        let b = dec128(&[2000i128], 38, 3);
+        let result = decimal_binary(&a, &b, Multiply).unwrap();
+        assert_eq!(result.data.as_slice(), &[2_000_000i128]);
+        assert_eq!(result.scale, 5); // 2 + 3
+    }
+
+    // -----------------------------------------------------------------------
+    // Integer to decimal conversion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn integer_to_decimal_basic() {
+        let data = [10i64, 20, 30];
+        let result = integer_to_decimal(&data, None, 18, 2).unwrap();
+        assert_eq!(result.data.as_slice(), &[1000, 2000, 3000]);
+        assert_eq!(result.scale, 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Power is unsupported
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn power_returns_error() {
+        let a = dec32(&[100], 9, 2);
+        let b = dec32(&[2], 9, 0);
+        let result = decimal_binary(&a, &b, Power);
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty arrays
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_arrays() {
+        let a = dec32(&[], 9, 2);
+        let b = dec32(&[], 9, 2);
+        let result = decimal_binary(&a, &b, Add).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+}

--- a/src/kernels/arithmetic/mod.rs
+++ b/src/kernels/arithmetic/mod.rs
@@ -31,6 +31,8 @@
 //! which is app-specific.**.
 
 pub mod dispatch;
+#[cfg(feature = "decimal")]
+pub mod decimal;
 #[cfg(feature = "simd")]
 pub mod simd;
 pub mod std;

--- a/src/kernels/broadcast/array.rs
+++ b/src/kernels/broadcast/array.rs
@@ -172,6 +172,18 @@ pub fn broadcast_array_to_scalar(
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
         Scalar::Interval => {

--- a/src/kernels/broadcast/scalar.rs
+++ b/src/kernels/broadcast/scalar.rs
@@ -202,6 +202,18 @@ pub fn broadcast_scalar_to_array(
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
         Scalar::Interval => {
@@ -634,6 +646,14 @@ pub fn broadcast_scalar_to_text_arrayview(
                 feature: "Float scalar with TextArrayView".to_string(),
             });
         }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(_, _), _)
+        | (Scalar::Decimal64(_, _), _)
+        | (Scalar::Decimal128(_, _), _) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TextArrayView".to_string(),
+            });
+        }
         #[cfg(feature = "datetime")]
         (Scalar::Datetime32(_), _) | (Scalar::Datetime64(_), _) | (Scalar::Interval, _) => {
             return Err(MinarrowError::NotImplemented {
@@ -742,6 +762,14 @@ pub fn broadcast_text_arrayview_to_scalar(
                 feature: "Float scalar with TextArrayView".to_string(),
             });
         }
+        #[cfg(feature = "decimal")]
+        (_, Scalar::Decimal32(_, _))
+        | (_, Scalar::Decimal64(_, _))
+        | (_, Scalar::Decimal128(_, _)) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TextArrayView".to_string(),
+            });
+        }
         #[cfg(feature = "datetime")]
         (_, Scalar::Datetime32(_)) | (_, Scalar::Datetime64(_)) | (_, Scalar::Interval) => {
             return Err(MinarrowError::NotImplemented {
@@ -793,6 +821,18 @@ pub fn broadcast_scalar_to_fieldarray(
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
         Scalar::Interval => {
@@ -837,6 +877,18 @@ pub fn broadcast_fieldarray_to_scalar(
         #[cfg(feature = "datetime")]
         Scalar::Datetime64(val) => {
             Array::from_datetime_i64(DatetimeArray::from_slice(&[*val], None))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(val, s) => {
+            Array::from_decimal32(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal64(val, s) => {
+            Array::from_decimal64(crate::DecimalArray::from_slice(&[*val], 0, *s))
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal128(val, s) => {
+            Array::from_decimal128(crate::DecimalArray::from_slice(&[*val], 0, *s))
         }
         Scalar::Null => Array::Null,
         #[cfg(feature = "datetime")]
@@ -894,6 +946,12 @@ pub fn broadcast_scalar_to_temporal_arrayview(
                 feature: "String scalar with TemporalArrayView".to_string(),
             });
         }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TemporalArrayView".to_string(),
+            });
+        }
         Scalar::Null => {
             return Err(MinarrowError::NullError { message: None });
         }
@@ -944,6 +1002,12 @@ pub fn broadcast_temporal_arrayview_to_scalar(
         Scalar::String64(_) => {
             return Err(MinarrowError::NotImplemented {
                 feature: "String scalar with TemporalArrayView".to_string(),
+            });
+        }
+        #[cfg(feature = "decimal")]
+        Scalar::Decimal32(_, _) | Scalar::Decimal64(_, _) | Scalar::Decimal128(_, _) => {
+            return Err(MinarrowError::NotImplemented {
+                feature: "Decimal scalar with TemporalArrayView".to_string(),
             });
         }
         Scalar::Null => {

--- a/src/kernels/routing/arithmetic.rs
+++ b/src/kernels/routing/arithmetic.rs
@@ -14,6 +14,8 @@
 
 #[cfg(feature = "scalar_type")]
 use crate::Scalar;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 use crate::enums::error::MinarrowError;
 use crate::kernels::routing::broadcast::maybe_broadcast_scalar_array;
 use crate::{Array, ArrayV, Bitmask, TextArray};
@@ -26,6 +28,8 @@ use crate::kernels::arithmetic::{
     },
     string_ops::apply_str_str,
 };
+#[cfg(feature = "decimal")]
+use crate::kernels::arithmetic::decimal::{decimal_binary, integer_to_decimal};
 
 use crate::enums::{error::KernelError, operators::ArithmeticOperator};
 
@@ -188,6 +192,80 @@ pub fn scalar_arithmetic(
         (Scalar::String32(l), Scalar::String64(r), Add) => Scalar::String64(format!("{}{}", l, r)),
         #[cfg(feature = "large_string")]
         (Scalar::String64(l), Scalar::String32(r), Add) => Scalar::String64(format!("{}{}", l, r)),
+
+        // Decimal scalar operations at matching width and scale
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, ls), Scalar::Decimal32(r, rs), Add) if ls == rs => {
+            Scalar::Decimal32(l.checked_add(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal32 overflow in addition".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, ls), Scalar::Decimal32(r, rs), Subtract) if ls == rs => {
+            Scalar::Decimal32(l.checked_sub(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal32 overflow in subtraction".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, ls), Scalar::Decimal32(r, _rs), Multiply) => {
+            Scalar::Decimal32(l.checked_mul(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal32 overflow in multiplication".to_string()),
+            ))?, ls + _rs)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, ls), Scalar::Decimal64(r, rs), Add) if ls == rs => {
+            Scalar::Decimal64(l.checked_add(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal64 overflow in addition".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, ls), Scalar::Decimal64(r, rs), Subtract) if ls == rs => {
+            Scalar::Decimal64(l.checked_sub(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal64 overflow in subtraction".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, ls), Scalar::Decimal64(r, _rs), Multiply) => {
+            Scalar::Decimal64(l.checked_mul(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal64 overflow in multiplication".to_string()),
+            ))?, ls + _rs)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, ls), Scalar::Decimal128(r, rs), Add) if ls == rs => {
+            Scalar::Decimal128(l.checked_add(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal128 overflow in addition".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, ls), Scalar::Decimal128(r, rs), Subtract) if ls == rs => {
+            Scalar::Decimal128(l.checked_sub(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal128 overflow in subtraction".to_string()),
+            ))?, ls)
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, ls), Scalar::Decimal128(r, _rs), Multiply) => {
+            Scalar::Decimal128(l.checked_mul(r).ok_or_else(|| MinarrowError::KernelError(
+                Some("Decimal128 overflow in multiplication".to_string()),
+            ))?, ls + _rs)
+        }
+
+        // Decimal + Float -> Float64 scalar promotion
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal32(l, s), Scalar::Float64(r), op) | (Scalar::Float64(r), Scalar::Decimal32(l, s), op) => {
+            let l_f64 = l as f64 / 10f64.powi(s as i32);
+            return scalar_arithmetic(Scalar::Float64(l_f64), Scalar::Float64(r), op);
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal64(l, s), Scalar::Float64(r), op) | (Scalar::Float64(r), Scalar::Decimal64(l, s), op) => {
+            let l_f64 = l as f64 / 10f64.powi(s as i32);
+            return scalar_arithmetic(Scalar::Float64(l_f64), Scalar::Float64(r), op);
+        }
+        #[cfg(feature = "decimal")]
+        (Scalar::Decimal128(l, s), Scalar::Float64(r), op) | (Scalar::Float64(r), Scalar::Decimal128(l, s), op) => {
+            use num_traits::ToPrimitive;
+            let l_f64 = l.to_f64().unwrap() / 10f64.powi(s as i32);
+            return scalar_arithmetic(Scalar::Float64(l_f64), Scalar::Float64(r), op);
+        }
 
         // Null handling
         (Scalar::Null, _, _) | (_, Scalar::Null, _) => {
@@ -401,9 +479,673 @@ fn arithmetic_dispatch(
             }
         }
 
+        // -----------------------------------------------------------------
+        // Decimal same-type dispatch
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let result = decimal_binary(l.as_ref(), r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal32(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let result = decimal_binary(l.as_ref(), r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let result = decimal_binary(l.as_ref(), r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+
+        // -----------------------------------------------------------------
+        // Decimal width promotion, narrower widened to wider
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let widened = DecimalArray::<i64>::from(l.as_ref().clone());
+            let result = decimal_binary(&widened, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let widened = DecimalArray::<i64>::from(r.as_ref().clone());
+            let result = decimal_binary(l.as_ref(), &widened, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let widened: DecimalArray<i128> =
+                DecimalArray::<i64>::from(l.as_ref().clone()).into();
+            let result = decimal_binary(&widened, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let widened: DecimalArray<i128> =
+                DecimalArray::<i64>::from(r.as_ref().clone()).into();
+            let result = decimal_binary(l.as_ref(), &widened, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let widened = DecimalArray::<i128>::from(l.as_ref().clone());
+            let result = decimal_binary(&widened, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let widened = DecimalArray::<i128>::from(r.as_ref().clone());
+            let result = decimal_binary(l.as_ref(), &widened, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+
+        // -----------------------------------------------------------------
+        // Integer + Decimal auto-promotion, integer promoted to decimal
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int32(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let promoted = integer_to_decimal(lhs_slice, l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal32(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Int32(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let promoted = integer_to_decimal(rhs_slice, r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal32(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int64(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let promoted = integer_to_decimal(lhs_slice, l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Int64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let promoted = integer_to_decimal(rhs_slice, r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal64(result.into())))
+        }
+
+        // Int32/Int64 + Decimal128: widen the integer to i128, promote to decimal
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int32(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let data_i128: Vec64<i128> = lhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Int32(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let data_i128: Vec64<i128> = rhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Int64(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let data_i128: Vec64<i128> = lhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), l.null_mask.as_ref(), r.precision, r.scale)?;
+            let result = decimal_binary(&promoted, r.as_ref(), op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Int64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let data_i128: Vec64<i128> = rhs_slice.iter().map(|&v| v as i128).collect();
+            let promoted = integer_to_decimal(data_i128.as_slice(), r.null_mask.as_ref(), l.precision, l.scale)?;
+            let result = decimal_binary(l.as_ref(), &promoted, op)?;
+            Ok(Array::NumericArray(NumericArray::Decimal128(result.into())))
+        }
+
+        // -----------------------------------------------------------------
+        // Float + Decimal auto-promotion, decimal demoted to Float64
+        // -----------------------------------------------------------------
+
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float64(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(lhs_slice, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Float64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, rhs_slice, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float64(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(lhs_slice, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Float64(r)),
+        ) => {
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, rhs_slice, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float64(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let lhs_slice = &l.data.as_slice()[lhs_offset..lhs_offset + lhs_len];
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(lhs_slice, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Float64(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let rhs_slice = &r.data.as_slice()[rhs_offset..rhs_offset + rhs_len];
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(l.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, rhs_slice, op, null_mask)?.into(),
+            )))
+        }
+
+        // Float32 + Decimal -> Float64, both promoted to f64
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float32(l)),
+            Array::NumericArray(NumericArray::Decimal32(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice()[lhs_offset..lhs_offset + lhs_len]
+                .iter().map(|&v| v as f64).collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal32(l)),
+            Array::NumericArray(NumericArray::Float32(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice()[rhs_offset..rhs_offset + rhs_len]
+                .iter().map(|&v| v as f64).collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float32(l)),
+            Array::NumericArray(NumericArray::Decimal64(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice()[lhs_offset..lhs_offset + lhs_len]
+                .iter().map(|&v| v as f64).collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal64(l)),
+            Array::NumericArray(NumericArray::Float32(r)),
+        ) => {
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|&v| v as f64 / 10f64.powi(l.scale as i32))
+                .collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice()[rhs_offset..rhs_offset + rhs_len]
+                .iter().map(|&v| v as f64).collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Float32(l)),
+            Array::NumericArray(NumericArray::Decimal128(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let lhs_f64: Vec64<f64> = l.data.as_slice()[lhs_offset..lhs_offset + lhs_len]
+                .iter().map(|&v| v as f64).collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(r.scale as i32))
+                .collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        (
+            Array::NumericArray(NumericArray::Decimal128(l)),
+            Array::NumericArray(NumericArray::Float32(r)),
+        ) => {
+            use num_traits::ToPrimitive;
+            let lhs_f64: Vec64<f64> = l.data.as_slice().iter()
+                .map(|v| v.to_f64().unwrap() / 10f64.powi(l.scale as i32))
+                .collect();
+            let rhs_f64: Vec64<f64> = r.data.as_slice()[rhs_offset..rhs_offset + rhs_len]
+                .iter().map(|&v| v as f64).collect();
+            Ok(Array::NumericArray(NumericArray::Float64(
+                apply_float_f64(&lhs_f64, &rhs_f64, op, null_mask)?.into(),
+            )))
+        }
+
         // Unsupported combinations
         _ => Err(KernelError::UnsupportedType(
             "Unsupported array type combination for arithmetic operations".to_string(),
         )),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Decimal dispatch integration tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[cfg(feature = "decimal")]
+mod decimal_dispatch_tests {
+    use super::*;
+    use crate::{
+        arr_dec128, arr_dec32, arr_dec64, arr_f64, arr_i32, arr_i64, Array, DecimalArray,
+        MaskedArray, NumericArray,
+    };
+
+    // -----------------------------------------------------------------------
+    // Same-type decimal arithmetic through dispatch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal32_add() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec32!(&[100, 200, 300], 9, 2),
+            arr_dec32!(&[10, 20, 30], 9, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal32(a)) => {
+                assert_eq!(a.data.as_slice(), &[110, 220, 330]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal32 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_subtract() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Subtract,
+            arr_dec64!(&[5000, 3000], 18, 4),
+            arr_dec64!(&[1000, 2000], 18, 4),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[4000, 1000]);
+                assert_eq!(a.scale, 4);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal128_multiply() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Multiply,
+            arr_dec128!(&[1000i128], 38, 2),
+            arr_dec128!(&[200i128], 38, 3),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal128(a)) => {
+                assert_eq!(a.data.as_slice(), &[200_000i128]);
+                assert_eq!(a.scale, 5); // 2 + 3
+            }
+            _ => panic!("expected Decimal128 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-scale decimal arithmetic
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_add_different_scale() {
+        // 10.0 at scale=1 + 1.00 at scale=2 = 11.00 at scale=2
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec64!(&[100], 18, 1),
+            arr_dec64!(&[100], 18, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[1100]); // 100*10 + 100
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Decimal width promotion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal32_plus_decimal64_widens() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec32!(&[100], 9, 2),
+            arr_dec64!(&[200], 18, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[300i64]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_plus_decimal128_widens() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec64!(&[500], 18, 2),
+            arr_dec128!(&[600i128], 38, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal128(a)) => {
+                assert_eq!(a.data.as_slice(), &[1100i128]);
+            }
+            _ => panic!("expected Decimal128 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Integer + Decimal auto-promotion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_int32_plus_decimal32() {
+        // integer 5 + decimal 1.00, raw=100 at scale=2
+        // integer promoted: 5 * 100 = 500 at scale 2
+        // 500 + 100 = 600 at scale 2 => 6.00
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_i32!(&[5]),
+            arr_dec32!(&[100], 9, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal32(a)) => {
+                assert_eq!(a.data.as_slice(), &[600]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal32 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_minus_int64() {
+        // decimal 10.00, raw=1000 at scale=2, minus integer 3
+        // integer promoted: 3 * 100 = 300 at scale 2
+        // 1000 - 300 = 700 at scale 2 => 7.00
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Subtract,
+            arr_dec64!(&[1000], 18, 2),
+            arr_i64!(&[3]),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[700]);
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Float + Decimal auto-promotion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_float64_plus_decimal32() {
+        // 2.5 + 1.00 raw=100 at scale=2 = 3.5
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_f64!(&[2.5]),
+            arr_dec32!(&[100], 9, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Float64(a)) => {
+                assert!((a.data[0] - 3.5).abs() < 1e-12);
+            }
+            _ => panic!("expected Float64 result, got: {:?}", result),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal64_times_float64() {
+        // 10.00 raw=1000 at scale=2 * 2.0 = 20.0
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Multiply,
+            arr_dec64!(&[1000], 18, 2),
+            arr_f64!(&[2.0]),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Float64(a)) => {
+                assert!((a.data[0] - 20.0).abs() < 1e-12);
+            }
+            _ => panic!("expected Float64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Overflow detection through dispatch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_overflow_returns_error() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec32!(&[i32::MAX], 9, 0),
+            arr_dec32!(&[1], 9, 0),
+            None,
+        );
+        assert!(result.is_err(), "expected overflow error");
+    }
+
+    // -----------------------------------------------------------------------
+    // Broadcasting with length-1 decimal
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_broadcast_scalar() {
+        // [1.00, 2.00, 3.00] + [0.50] => [1.50, 2.50, 3.50]
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Add,
+            arr_dec64!(&[100, 200, 300], 18, 2),
+            arr_dec64!(&[50], 18, 2),
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[150, 250, 350]);
+                assert_eq!(a.len(), 3);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Division and remainder
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dispatch_decimal_divide() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Divide,
+            arr_dec64!(&[10000], 18, 2), // 100.00
+            arr_dec64!(&[400], 18, 2),   // 4.00
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[2500]); // 25.00
+                assert_eq!(a.scale, 2);
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
+    }
+
+    #[test]
+    fn dispatch_decimal_remainder() {
+        let result = resolve_binary_arithmetic(
+            ArithmeticOperator::Remainder,
+            arr_dec64!(&[1000], 18, 2), // 10.00
+            arr_dec64!(&[300], 18, 2),  // 3.00
+            None,
+        )
+        .unwrap();
+
+        match result {
+            Array::NumericArray(NumericArray::Decimal64(a)) => {
+                assert_eq!(a.data.as_slice(), &[100]); // 1.00
+            }
+            _ => panic!("expected Decimal64 result"),
+        }
     }
 }

--- a/src/kernels/routing/broadcast.rs
+++ b/src/kernels/routing/broadcast.rs
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 use crate::enums::error::KernelError;
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 use crate::{
-    Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, MaskedArray, NumericArray,
+    Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, NumericArray,
     StringArray, TextArray, Vec64, vec64,
 };
 #[cfg(feature = "decimal")]
@@ -25,89 +27,58 @@ use crate::DecimalArray;
 pub fn broadcast_length_1_array(av: ArrayV, len: usize) -> Result<Array, KernelError> {
     debug_assert_eq!(av.len(), 1, "caller guarantees scalar input");
 
+    let null_mask = match av.array.null_mask() {
+        Some(m) if !m.get(0) => Some(Bitmask::new_set_all(len, false)),
+        _ => None,
+    };
+
     match av.array {
         Array::NumericArray(NumericArray::Int32(a)) => Ok(Array::from_int32(
-            IntegerArray::<i32>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<i32>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::Int64(a)) => Ok(Array::from_int64(
-            IntegerArray::<i64>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<i64>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::UInt32(a)) => Ok(Array::from_uint32(
-            IntegerArray::<u32>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<u32>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::UInt64(a)) => Ok(Array::from_uint64(
-            IntegerArray::<u64>::from_vec64(vec64![a.data[0]; len], None),
+            IntegerArray::<u64>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::Float32(a)) => Ok(Array::from_float32(
-            FloatArray::<f32>::from_vec64(vec64![a.data[0]; len], None),
+            FloatArray::<f32>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
         Array::NumericArray(NumericArray::Float64(a)) => Ok(Array::from_float64(
-            FloatArray::<f64>::from_vec64(vec64![a.data[0]; len], None),
+            FloatArray::<f64>::from_vec64(vec64![a.data[0]; len], null_mask),
         )),
-        Array::BooleanArray(a) => match a.get(0) {
-            Some(v) => {
-                let bitmask = Bitmask::new_set_all(len, v);
-                Ok(Array::BooleanArray(BooleanArray::new(bitmask, None).into()))
-            }
-            None => Err(KernelError::UnsupportedType(
-                "broadcasting null boolean values not supported when no mask is supplied".into(),
-            )),
-        },
+        Array::BooleanArray(a) => {
+            let v = a.data.get(0);
+            let bitmask = Bitmask::new_set_all(len, v);
+            Ok(Array::BooleanArray(BooleanArray::new(bitmask, null_mask).into()))
+        }
         Array::TextArray(TextArray::String32(a)) => {
-            // Get the first string from the array, which should have exactly 1 string
             let s = a.get_str(av.offset).unwrap_or("");
             let strs: Vec64<&str> = std::iter::repeat(s).take(len).collect();
-            Ok(Array::from_string32(StringArray::from_vec64(strs, None)))
+            Ok(Array::from_string32(StringArray::from_vec64(strs, null_mask)))
         }
         #[cfg(feature = "large_string")]
         Array::TextArray(TextArray::String64(a)) => {
-            // Get the first string from the array, which should have exactly 1 string
             let s = a.get_str(av.offset).unwrap_or("");
             let strs: Vec64<&str> = std::iter::repeat(s).take(len).collect();
-            Ok(Array::from_string64(StringArray::from_vec64(strs, None)))
+            Ok(Array::from_string64(StringArray::from_vec64(strs, null_mask)))
         }
         #[cfg(feature = "decimal")]
-        Array::NumericArray(NumericArray::Decimal32(a)) => {
-            let null_mask = if a.is_null(0) {
-                Some(Bitmask::new_set_all(len, false))
-            } else {
-                None
-            };
-            Ok(Array::from_decimal32(DecimalArray::from_vec64(
-                vec64![a.data[0]; len],
-                null_mask,
-                a.precision,
-                a.scale,
-            )))
-        }
+        Array::NumericArray(NumericArray::Decimal32(a)) => Ok(Array::from_decimal32(
+            DecimalArray::from_vec64(vec64![a.data[0]; len], null_mask, a.precision, a.scale),
+        )),
         #[cfg(feature = "decimal")]
-        Array::NumericArray(NumericArray::Decimal64(a)) => {
-            let null_mask = if a.is_null(0) {
-                Some(Bitmask::new_set_all(len, false))
-            } else {
-                None
-            };
-            Ok(Array::from_decimal64(DecimalArray::from_vec64(
-                vec64![a.data[0]; len],
-                null_mask,
-                a.precision,
-                a.scale,
-            )))
-        }
+        Array::NumericArray(NumericArray::Decimal64(a)) => Ok(Array::from_decimal64(
+            DecimalArray::from_vec64(vec64![a.data[0]; len], null_mask, a.precision, a.scale),
+        )),
         #[cfg(feature = "decimal")]
-        Array::NumericArray(NumericArray::Decimal128(a)) => {
-            let null_mask = if a.is_null(0) {
-                Some(Bitmask::new_set_all(len, false))
-            } else {
-                None
-            };
-            Ok(Array::from_decimal128(DecimalArray::from_vec64(
-                vec64![a.data[0]; len],
-                null_mask,
-                a.precision,
-                a.scale,
-            )))
-        }
+        Array::NumericArray(NumericArray::Decimal128(a)) => Ok(Array::from_decimal128(
+            DecimalArray::from_vec64(vec64![a.data[0]; len], null_mask, a.precision, a.scale),
+        )),
         _ => {
             return Err(KernelError::UnsupportedType(
                 "broadcast not yet implemented for this array variant".into(),

--- a/src/kernels/routing/broadcast.rs
+++ b/src/kernels/routing/broadcast.rs
@@ -19,10 +19,8 @@ use crate::{
     Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, NumericArray,
     StringArray, TextArray, Vec64, vec64,
 };
-#[cfg(feature = "decimal")]
-use crate::DecimalArray;
 
-/// Repeat a length-1 `Array` to `len`.  
+/// Repeat a length-1 `Array` to `len`.
 /// Errors if the input length is *not* 1, or the variant is unsupported.  
 pub fn broadcast_length_1_array(av: ArrayV, len: usize) -> Result<Array, KernelError> {
     debug_assert_eq!(av.len(), 1, "caller guarantees scalar input");

--- a/src/kernels/routing/broadcast.rs
+++ b/src/kernels/routing/broadcast.rs
@@ -17,6 +17,8 @@ use crate::{
     Array, ArrayV, Bitmask, BooleanArray, FloatArray, IntegerArray, MaskedArray, NumericArray,
     StringArray, TextArray, Vec64, vec64,
 };
+#[cfg(feature = "decimal")]
+use crate::DecimalArray;
 
 /// Repeat a length-1 `Array` to `len`.  
 /// Errors if the input length is *not* 1, or the variant is unsupported.  
@@ -64,6 +66,48 @@ pub fn broadcast_length_1_array(av: ArrayV, len: usize) -> Result<Array, KernelE
             let strs: Vec64<&str> = std::iter::repeat(s).take(len).collect();
             Ok(Array::from_string64(StringArray::from_vec64(strs, None)))
         }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal32(a)) => {
+            let null_mask = if a.is_null(0) {
+                Some(Bitmask::new_set_all(len, false))
+            } else {
+                None
+            };
+            Ok(Array::from_decimal32(DecimalArray::from_vec64(
+                vec64![a.data[0]; len],
+                null_mask,
+                a.precision,
+                a.scale,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal64(a)) => {
+            let null_mask = if a.is_null(0) {
+                Some(Bitmask::new_set_all(len, false))
+            } else {
+                None
+            };
+            Ok(Array::from_decimal64(DecimalArray::from_vec64(
+                vec64![a.data[0]; len],
+                null_mask,
+                a.precision,
+                a.scale,
+            )))
+        }
+        #[cfg(feature = "decimal")]
+        Array::NumericArray(NumericArray::Decimal128(a)) => {
+            let null_mask = if a.is_null(0) {
+                Some(Bitmask::new_set_all(len, false))
+            } else {
+                None
+            };
+            Ok(Array::from_decimal128(DecimalArray::from_vec64(
+                vec64![a.data[0]; len],
+                null_mask,
+                a.precision,
+                a.scale,
+            )))
+        }
         _ => {
             return Err(KernelError::UnsupportedType(
                 "broadcast not yet implemented for this array variant".into(),
@@ -99,4 +143,94 @@ pub fn maybe_broadcast_scalar_array<'a>(
     Err(KernelError::LengthMismatch(format!(
         "cannot broadcast arrays of length {l} and {r}"
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal32() {
+        let arr = Array::from_decimal32(DecimalArray::from_slice(&[12345i32], 10, 2));
+        let av = ArrayV::new(arr, 0, 1);
+        let result = broadcast_length_1_array(av, 4).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal32(a)) = result {
+            assert_eq!(a.data.as_slice(), &[12345, 12345, 12345, 12345]);
+            assert_eq!(a.precision, 10);
+            assert_eq!(a.scale, 2);
+            assert!(a.null_mask.is_none());
+        } else {
+            panic!("Expected Decimal32 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal64() {
+        let arr = Array::from_decimal64(DecimalArray::from_slice(&[99999i64], 18, 4));
+        let av = ArrayV::new(arr, 0, 1);
+        let result = broadcast_length_1_array(av, 3).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal64(a)) = result {
+            assert_eq!(a.data.as_slice(), &[99999, 99999, 99999]);
+            assert_eq!(a.precision, 18);
+            assert_eq!(a.scale, 4);
+        } else {
+            panic!("Expected Decimal64 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal128() {
+        let arr = Array::from_decimal128(DecimalArray::from_slice(&[500i128], 38, 0));
+        let av = ArrayV::new(arr, 0, 1);
+        let result = broadcast_length_1_array(av, 2).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal128(a)) = result {
+            assert_eq!(a.data.as_slice(), &[500, 500]);
+            assert_eq!(a.precision, 38);
+            assert_eq!(a.scale, 0);
+        } else {
+            panic!("Expected Decimal128 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_broadcast_length_1_decimal_null_propagation() {
+        let mut arr = DecimalArray::from_slice(&[0i64], 10, 2);
+        arr.null_mask = Some(Bitmask::new_set_all(1, false));
+        let av = ArrayV::new(Array::from_decimal64(arr), 0, 1);
+        let result = broadcast_length_1_array(av, 3).unwrap();
+        if let Array::NumericArray(NumericArray::Decimal64(a)) = result {
+            assert_eq!(a.data.len(), 3);
+            let mask = a.null_mask.as_ref().unwrap();
+            for i in 0..3 {
+                assert!(!mask.get(i), "element {i} should be null");
+            }
+        } else {
+            panic!("Expected Decimal64 array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_maybe_broadcast_decimal_scalar_array() {
+        let scalar = Array::from_decimal32(DecimalArray::from_slice(&[100i32], 5, 1));
+        let target = Array::from_decimal32(DecimalArray::from_slice(&[1, 2, 3], 5, 1));
+        let (lhs, rhs) = maybe_broadcast_scalar_array(
+            ArrayV::new(scalar, 0, 1),
+            ArrayV::new(target, 0, 3),
+        )
+        .unwrap();
+        assert_eq!(lhs.len(), 3);
+        assert_eq!(rhs.len(), 3);
+        if let Array::NumericArray(NumericArray::Decimal32(a)) = &lhs.array {
+            assert_eq!(a.data.as_slice(), &[100, 100, 100]);
+            assert_eq!(a.precision, 5);
+            assert_eq!(a.scale, 1);
+        } else {
+            panic!("Expected broadcast Decimal32 array");
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,8 @@ pub mod structs {
         pub mod categorical;
         #[cfg(feature = "datetime")]
         pub mod datetime;
+        #[cfg(feature = "decimal")]
+        pub mod decimal;
         pub mod float;
         pub mod integer;
         pub mod string;
@@ -349,6 +351,8 @@ pub use structs::variants::categorical::CategoricalArray;
 pub use structs::variants::datetime::DatetimeArray;
 #[cfg(feature = "datetime")]
 pub use structs::variants::datetime::parse::{parse_iso8601_utc, parse_iso8601_utc_ns};
+#[cfg(feature = "decimal")]
+pub use structs::variants::decimal::DecimalArray;
 pub use structs::variants::float::FloatArray;
 pub use structs::variants::integer::IntegerArray;
 pub use structs::variants::string::StringArray;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -743,6 +743,12 @@ macro_rules! match_array {
                 NumericArray::UInt64(a)         => a.$method($($args),*),
                 NumericArray::Float32(a)        => a.$method($($args),*),
                 NumericArray::Float64(a)        => a.$method($($args),*),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a)      => a.$method($($args),*),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a)      => a.$method($($args),*),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a)     => a.$method($($args),*),
                 NumericArray::Null              => Default::default(),
             },
             Array::BooleanArray(a)                  => a.$method($($args),*),

--- a/src/structs/arena.rs
+++ b/src/structs/arena.rs
@@ -797,6 +797,28 @@ impl AAMaker {
                 )))
             }
 
+            #[cfg(feature = "decimal")]
+            (ArrowType::Decimal32(p, s), AAMaker::Primitive { data, mask }) => {
+                let m = mask.map(|r| r.to_bitmask(shared, n_rows));
+                Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                    crate::DecimalArray::new(data.to_buffer::<i32>(shared), m, *p, *s),
+                )))
+            }
+            #[cfg(feature = "decimal")]
+            (ArrowType::Decimal64(p, s), AAMaker::Primitive { data, mask }) => {
+                let m = mask.map(|r| r.to_bitmask(shared, n_rows));
+                Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                    crate::DecimalArray::new(data.to_buffer::<i64>(shared), m, *p, *s),
+                )))
+            }
+            #[cfg(feature = "decimal")]
+            (ArrowType::Decimal128(p, s), AAMaker::Primitive { data, mask }) => {
+                let m = mask.map(|r| r.to_bitmask(shared, n_rows));
+                Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                    crate::DecimalArray::new(data.to_buffer::<i128>(shared), m, *p, *s),
+                )))
+            }
+
             (ArrowType::Null, _) => Array::Null,
             _ => unreachable!("Mismatched ArrowType and AAMaker variant"),
         }

--- a/src/structs/arena.rs
+++ b/src/structs/arena.rs
@@ -841,6 +841,12 @@ pub(crate) fn consolidate_array_arena(chunks: &[&Array], dtype: &ArrowType) -> A
                 NumericArray::UInt8(_) => 1,
                 #[cfg(feature = "extended_numeric_types")]
                 NumericArray::UInt16(_) => 2,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => 4,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => 8,
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => 16,
                 NumericArray::Null => 0,
             };
             total_bytes += align64(n_rows * elem);
@@ -950,6 +956,12 @@ pub(crate) fn consolidate_array_arena(chunks: &[&Array], dtype: &ArrowType) -> A
                 NumericArray::UInt8(_) => write_numeric!(UInt8, u8),
                 #[cfg(feature = "extended_numeric_types")]
                 NumericArray::UInt16(_) => write_numeric!(UInt16, u16),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(_) => write_numeric!(Decimal32, i32),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(_) => write_numeric!(Decimal64, i64),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(_) => write_numeric!(Decimal128, i128),
                 NumericArray::Null => AAMaker::Primitive {
                     data: ArenaRegion::EMPTY,
                     mask: None,
@@ -1233,6 +1245,12 @@ pub(crate) fn consolidate_tables_arena(
                     NumericArray::UInt8(_) => 1,
                     #[cfg(feature = "extended_numeric_types")]
                     NumericArray::UInt16(_) => 2,
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal32(_) => 4,
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal64(_) => 8,
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal128(_) => 16,
                     NumericArray::Null => 0,
                 };
                 total_bytes += align64(n_rows * elem);
@@ -1354,6 +1372,12 @@ pub(crate) fn consolidate_tables_arena(
                     NumericArray::UInt8(_) => write_numeric!(UInt8, u8),
                     #[cfg(feature = "extended_numeric_types")]
                     NumericArray::UInt16(_) => write_numeric!(UInt16, u16),
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal32(_) => write_numeric!(Decimal32, i32),
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal64(_) => write_numeric!(Decimal64, i64),
+                    #[cfg(feature = "decimal")]
+                    NumericArray::Decimal128(_) => write_numeric!(Decimal128, i128),
                     NumericArray::Null => AAMaker::Primitive {
                         data: ArenaRegion::EMPTY,
                         mask: None,

--- a/src/structs/chunked/super_array.rs
+++ b/src/structs/chunked/super_array.rs
@@ -1838,4 +1838,92 @@ mod tests {
             _ => panic!("expected U32 dispatch"),
         }
     }
+
+    #[cfg(feature = "decimal")]
+    mod decimal_super_array_tests {
+        use super::*;
+        use crate::ffi::arrow_dtype::ArrowType;
+
+        fn decimal_array(vals: &[i32], precision: u8, scale: i8) -> Array {
+            Array::from_decimal32(crate::DecimalArray::from_slice(vals, precision, scale))
+        }
+
+        fn decimal_fa(name: &str, vals: &[i32], precision: u8, scale: i8) -> FieldArray {
+            let arr = decimal_array(vals, precision, scale);
+            let field = Field::new(name, ArrowType::Decimal32(precision, scale), false, None);
+            FieldArray::new(field, arr)
+        }
+
+        #[test]
+        fn push_and_type_validation() {
+            let mut sa = SuperArray::new();
+            sa.push(decimal_array(&[10, 20, 30], 10, 2));
+            assert_eq!(sa.n_chunks(), 1);
+            assert_eq!(sa.len(), 3);
+            sa.push(decimal_array(&[40, 50], 10, 2));
+            assert_eq!(sa.n_chunks(), 2);
+            assert_eq!(sa.len(), 5);
+        }
+
+        #[test]
+        #[should_panic(expected = "Chunk ArrowType mismatch")]
+        fn push_mismatched_scale_panics() {
+            let mut sa = SuperArray::new();
+            sa.push(decimal_array(&[10], 10, 2));
+            sa.push(decimal_array(&[20], 10, 3)); // different scale
+        }
+
+        #[test]
+        fn consolidate_decimal_chunks() {
+            let fa1 = decimal_fa("d", &[10, 20], 10, 2);
+            let fa2 = decimal_fa("d", &[30, 40, 50], 10, 2);
+            let sa = SuperArray::from_chunks(vec![fa1, fa2]);
+
+            let result = sa.consolidate();
+            assert_eq!(result.len(), 5);
+            if let Array::NumericArray(NumericArray::Decimal32(dec)) = result {
+                assert_eq!(dec.data.as_slice(), &[10, 20, 30, 40, 50]);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+            } else {
+                panic!("Expected Decimal32 Array");
+            }
+        }
+
+        #[cfg(feature = "views")]
+        #[test]
+        fn slice_and_consolidate() {
+            let fa1 = decimal_fa("d", &[10, 20, 30], 10, 2);
+            let fa2 = decimal_fa("d", &[40, 50], 10, 2);
+            let sa = SuperArray::from_chunks(vec![fa1, fa2]);
+            let view = sa.slice(2, 3); // [30, 40, 50]
+            let result = view.consolidate();
+
+            assert_eq!(result.len(), 3);
+            if let Array::NumericArray(NumericArray::Decimal32(dec)) = result {
+                assert_eq!(dec.data.as_slice(), &[30, 40, 50]);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+            } else {
+                panic!("Expected Decimal32 Array");
+            }
+        }
+
+        #[test]
+        fn concat_super_arrays() {
+            let sa1 = SuperArray::from_arrays(vec![decimal_array(&[10, 20], 10, 2)]);
+            let sa2 = SuperArray::from_arrays(vec![decimal_array(&[30], 10, 2)]);
+            let result = sa1.concat(sa2).unwrap();
+            assert_eq!(result.n_chunks(), 2);
+            assert_eq!(result.len(), 3);
+        }
+
+        #[test]
+        fn concat_mismatched_type_errors() {
+            let sa1 = SuperArray::from_arrays(vec![decimal_array(&[10], 10, 2)]);
+            let sa2 = SuperArray::from_arrays(vec![int_array(&[20])]);
+            let result = sa1.concat(sa2);
+            assert!(result.is_err());
+        }
+    }
 }

--- a/src/structs/field.rs
+++ b/src/structs/field.rs
@@ -144,6 +144,18 @@ impl Field {
                 NumericArray::Float64(a) => {
                     Field::new(name, ArrowType::Float64, a.is_nullable(), Some(metadata))
                 }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => {
+                    Field::new(name, a.arrow_type(), a.is_nullable(), Some(metadata))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => {
+                    Field::new(name, a.arrow_type(), a.is_nullable(), Some(metadata))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => {
+                    Field::new(name, a.arrow_type(), a.is_nullable(), Some(metadata))
+                }
                 NumericArray::Null => Field::new(name, ArrowType::Null, false, Some(metadata)),
             },
             Array::BooleanArray(a) => {

--- a/src/structs/field_array.rs
+++ b/src/structs/field_array.rs
@@ -493,6 +493,12 @@ pub fn create_field_for_array(
             NumericArray::UInt64(_) => ArrowType::UInt64,
             NumericArray::Float32(_) => ArrowType::Float32,
             NumericArray::Float64(_) => ArrowType::Float64,
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => a.arrow_type(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => a.arrow_type(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => a.arrow_type(),
             NumericArray::Null => ArrowType::Null,
         },
         Array::TextArray(text_arr) => match text_arr {

--- a/src/structs/variants/decimal.rs
+++ b/src/structs/variants/decimal.rs
@@ -775,6 +775,69 @@ impl<T: Integer> Concatenate for DecimalArray<T> {
 }
 
 // ---------------------------------------------------------------------------
+// Consolidate - merges view windows into a contiguous DecimalArray
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "chunked")]
+impl<'a, T: Integer> crate::traits::consolidate::Consolidate
+    for Vec<crate::aliases::DecimalAVT<'a, T>>
+{
+    type Output = DecimalArray<T>;
+
+    /// Consolidate a vector of `(DecimalArray<T>, offset, len)` view tuples
+    /// into one contiguous `DecimalArray<T>`. Reads each window from the
+    /// source buffer with no intermediate copy. Precision and scale are
+    /// taken from the first chunk and validated against all subsequent chunks.
+    fn consolidate(self) -> DecimalArray<T> {
+        use crate::traits::masked_array::MaskedArray;
+
+        assert!(
+            !self.is_empty(),
+            "consolidate() called on empty Vec<DecimalAVT>"
+        );
+
+        let (first, _, _) = &self[0];
+        let precision = first.precision;
+        let scale = first.scale;
+
+        let total_len: usize = self.iter().map(|(_, _, len)| *len).sum();
+        let has_nulls = self.iter().any(|(arr, _, _)| arr.null_mask.is_some());
+
+        let mut result = DecimalArray::<T>::with_capacity(total_len, false, precision, scale);
+        let mut result_mask: Option<Bitmask> = if has_nulls {
+            Some(Bitmask::new_set_all(0, false))
+        } else {
+            None
+        };
+
+        for (arr, offset, len) in &self {
+            debug_assert_eq!(
+                arr.precision, precision,
+                "DecimalArray consolidate: precision mismatch across chunks"
+            );
+            debug_assert_eq!(
+                arr.scale, scale,
+                "DecimalArray consolidate: scale mismatch across chunks"
+            );
+            let data: &[T] = &arr.data[*offset..*offset + *len];
+            result.data.extend_from_slice(data);
+
+            if let Some(ref mut mask) = result_mask {
+                match arr.null_mask() {
+                    Some(src) => mask.extend_from_bitmask_range(src, *offset, *len),
+                    None => mask.push_bits(true, *len),
+                }
+            }
+        }
+
+        if let Some(mask) = result_mask {
+            result.set_null_mask(Some(mask));
+        }
+        result
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Widening conversions (lossless)
 // ---------------------------------------------------------------------------
 
@@ -1616,5 +1679,106 @@ mod tests {
         arc_arr.push(40);
         assert_eq!(arc_arr.len(), 4);
         assert_eq!(arc_arr.get(3), Some(40));
+    }
+
+    // -----------------------------------------------------------------------
+    // Consolidate view tuples
+    // -----------------------------------------------------------------------
+
+    #[cfg(feature = "chunked")]
+    mod consolidate_tests {
+        use super::*;
+        use crate::traits::consolidate::Consolidate;
+
+        #[test]
+        fn consolidate_single_full_window() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30], 10, 2);
+            let views = vec![(&arr, 0, 3)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 3);
+            assert_eq!(result.precision, 10);
+            assert_eq!(result.scale, 2);
+            assert_eq!(result.get(0), Some(10));
+            assert_eq!(result.get(1), Some(20));
+            assert_eq!(result.get(2), Some(30));
+        }
+
+        #[test]
+        fn consolidate_windowed_offset() {
+            let arr = DecimalArray::<i64>::from_slice(&[100, 200, 300, 400, 500], 18, 4);
+            let views = vec![(&arr, 1, 3)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 3);
+            assert_eq!(result.precision, 18);
+            assert_eq!(result.scale, 4);
+            assert_eq!(result.get(0), Some(200));
+            assert_eq!(result.get(1), Some(300));
+            assert_eq!(result.get(2), Some(400));
+        }
+
+        #[test]
+        fn consolidate_multiple_windows() {
+            let arr1 = DecimalArray::<i32>::from_slice(&[10, 20, 30], 10, 2);
+            let arr2 = DecimalArray::<i32>::from_slice(&[40, 50], 10, 2);
+            let views = vec![(&arr1, 0, 3), (&arr2, 0, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 5);
+            assert_eq!(result.precision, 10);
+            assert_eq!(result.scale, 2);
+            assert_eq!(result.get(0), Some(10));
+            assert_eq!(result.get(4), Some(50));
+        }
+
+        #[test]
+        fn consolidate_with_null_mask_propagation() {
+            let mut arr1 = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+            arr1.push(10);
+            arr1.push_null();
+            arr1.push(30);
+
+            let arr2 = DecimalArray::<i32>::from_slice(&[40, 50], 10, 2);
+
+            let views = vec![(&arr1, 0, 3), (&arr2, 0, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 5);
+            assert_eq!(result.get(0), Some(10));
+            assert_eq!(result.get(1), None);
+            assert_eq!(result.get(2), Some(30));
+            assert_eq!(result.get(3), Some(40));
+            assert_eq!(result.get(4), Some(50));
+            assert_eq!(result.null_count(), 1);
+        }
+
+        #[test]
+        fn consolidate_decimal128() {
+            let arr = DecimalArray::<i128>::from_slice(&[100, 200, 300], 38, 10);
+            let views = vec![(&arr, 1, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 2);
+            assert_eq!(result.precision, 38);
+            assert_eq!(result.scale, 10);
+            assert_eq!(result.get(0), Some(200i128));
+            assert_eq!(result.get(1), Some(300i128));
+        }
+
+        #[test]
+        fn consolidate_cross_chunk_with_nulls_in_both() {
+            let mut arr1 = DecimalArray::<i64>::with_capacity(2, true, 18, 6);
+            arr1.push(100);
+            arr1.push_null();
+
+            let mut arr2 = DecimalArray::<i64>::with_capacity(2, true, 18, 6);
+            arr2.push_null();
+            arr2.push(400);
+
+            let views = vec![(&arr1, 0, 2), (&arr2, 0, 2)];
+            let result = views.consolidate();
+            assert_eq!(result.len(), 4);
+            assert_eq!(result.get(0), Some(100));
+            assert_eq!(result.get(1), None);
+            assert_eq!(result.get(2), None);
+            assert_eq!(result.get(3), Some(400));
+            assert_eq!(result.null_count(), 2);
+        }
     }
 }

--- a/src/structs/variants/decimal.rs
+++ b/src/structs/variants/decimal.rs
@@ -866,6 +866,372 @@ impl From<DecimalArray<i64>> for DecimalArray<i128> {
 }
 
 // ---------------------------------------------------------------------------
+// Type conversions
+// ---------------------------------------------------------------------------
+
+impl<T: Integer> DecimalArray<T> {
+    /// Converts to `FloatArray<f64>` by dividing each raw value by `10^scale`.
+    ///
+    /// Null entries propagate as nulls in the output. The conversion is
+    /// inherently lossy for large i128 values whose magnitude exceeds the
+    /// 53-bit mantissa of f64.
+    pub fn to_float64_array(&self) -> crate::FloatArray<f64> {
+        let divisor = 10_f64.powi(self.scale as i32);
+        let data: Vec64<f64> = self
+            .data
+            .iter()
+            .map(|v| v.to_f64().unwrap() / divisor)
+            .collect();
+        crate::FloatArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+        }
+    }
+
+    /// Converts to `FloatArray<f32>` by dividing each raw value by `10^scale`.
+    ///
+    /// Null entries propagate as nulls in the output. Precision loss is
+    /// greater than `to_float64_array` due to the 23-bit mantissa of f32.
+    pub fn to_float32_array(&self) -> crate::FloatArray<f32> {
+        let divisor = 10_f32.powi(self.scale as i32);
+        let data: Vec64<f32> = self
+            .data
+            .iter()
+            .map(|v| v.to_f64().unwrap() as f32 / divisor)
+            .collect();
+        crate::FloatArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+        }
+    }
+
+    /// Converts to `IntegerArray<i64>` by dividing each raw value by
+    /// `10^scale` (truncating toward zero).
+    ///
+    /// Returns `MinarrowError::Overflow` if any scaled value falls outside
+    /// the i64 range. Null entries propagate as nulls in the output.
+    pub fn to_int64_array(&self) -> Result<crate::IntegerArray<i64>, crate::enums::error::MinarrowError> {
+        let divisor = 10_i128.pow(self.scale.max(0) as u32);
+        let mut data = Vec64::with_capacity(self.len());
+        for &raw in self.data.iter() {
+            let scaled = raw.to_i128().unwrap() / divisor;
+            let val = i64::try_from(scaled).map_err(|_| crate::enums::error::MinarrowError::Overflow {
+                value: scaled.to_string(),
+                target: "i64",
+            })?;
+            data.push(val);
+        }
+        Ok(crate::IntegerArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+        })
+    }
+
+    /// Converts to `IntegerArray<i32>` by dividing each raw value by
+    /// `10^scale` (truncating toward zero).
+    ///
+    /// Returns `MinarrowError::Overflow` if any scaled value falls outside
+    /// the i32 range. Null entries propagate as nulls in the output.
+    pub fn to_int32_array(&self) -> Result<crate::IntegerArray<i32>, crate::enums::error::MinarrowError> {
+        let divisor = 10_i128.pow(self.scale.max(0) as u32);
+        let mut data = Vec64::with_capacity(self.len());
+        for &raw in self.data.iter() {
+            let scaled = raw.to_i128().unwrap() / divisor;
+            let val = i32::try_from(scaled).map_err(|_| crate::enums::error::MinarrowError::Overflow {
+                value: scaled.to_string(),
+                target: "i32",
+            })?;
+            data.push(val);
+        }
+        Ok(crate::IntegerArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+        })
+    }
+
+    /// Converts to `IntegerArray<u64>` by dividing each raw value by
+    /// `10^scale` (truncating toward zero).
+    ///
+    /// Returns `MinarrowError::Overflow` if any scaled value is negative or
+    /// exceeds the u64 range. Null entries propagate as nulls in the output.
+    pub fn to_uint64_array(&self) -> Result<crate::IntegerArray<u64>, crate::enums::error::MinarrowError> {
+        let divisor = 10_i128.pow(self.scale.max(0) as u32);
+        let mut data = Vec64::with_capacity(self.len());
+        for &raw in self.data.iter() {
+            let scaled = raw.to_i128().unwrap() / divisor;
+            let val = u64::try_from(scaled).map_err(|_| crate::enums::error::MinarrowError::Overflow {
+                value: scaled.to_string(),
+                target: "u64",
+            })?;
+            data.push(val);
+        }
+        Ok(crate::IntegerArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+        })
+    }
+
+    /// Converts to `IntegerArray<u32>` by dividing each raw value by
+    /// `10^scale` (truncating toward zero).
+    ///
+    /// Returns `MinarrowError::Overflow` if any scaled value is negative or
+    /// exceeds the u32 range. Null entries propagate as nulls in the output.
+    pub fn to_uint32_array(&self) -> Result<crate::IntegerArray<u32>, crate::enums::error::MinarrowError> {
+        let divisor = 10_i128.pow(self.scale.max(0) as u32);
+        let mut data = Vec64::with_capacity(self.len());
+        for &raw in self.data.iter() {
+            let scaled = raw.to_i128().unwrap() / divisor;
+            let val = u32::try_from(scaled).map_err(|_| crate::enums::error::MinarrowError::Overflow {
+                value: scaled.to_string(),
+                target: "u32",
+            })?;
+            data.push(val);
+        }
+        Ok(crate::IntegerArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+        })
+    }
+
+    /// Constructs a `DecimalArray<T>` from an `IntegerArray` by multiplying
+    /// each value by `10^scale`.
+    ///
+    /// Returns `MinarrowError::Overflow` if any scaled value exceeds the
+    /// range of `T`. Null entries in the source propagate as nulls in the
+    /// output.
+    ///
+    /// ## Example
+    /// ```ignore
+    /// use minarrow::{DecimalArray, IntegerArray};
+    ///
+    /// let ints = IntegerArray::<i64>::from_slice(&[100, 200, 300]);
+    /// let dec = DecimalArray::<i64>::from_integer_array(&ints, 10, 2).unwrap();
+    /// // raw values are 10000, 20000, 30000 (each multiplied by 10^2)
+    /// ```
+    pub fn from_integer_array<I>(
+        src: &crate::IntegerArray<I>,
+        precision: u8,
+        scale: i8,
+    ) -> Result<Self, crate::enums::error::MinarrowError>
+    where
+        I: Integer,
+    {
+        use num_traits::NumCast;
+        let multiplier = 10_i128.pow(scale.max(0) as u32);
+        let mut data = Vec64::with_capacity(src.len());
+        for &raw in src.data.iter() {
+            let wide = raw.to_i128().unwrap();
+            let scaled = wide.checked_mul(multiplier).ok_or_else(|| {
+                crate::enums::error::MinarrowError::Overflow {
+                    value: wide.to_string(),
+                    target: "DecimalArray",
+                }
+            })?;
+            let val: T = NumCast::from(scaled).ok_or_else(|| {
+                crate::enums::error::MinarrowError::Overflow {
+                    value: scaled.to_string(),
+                    target: "DecimalArray",
+                }
+            })?;
+            data.push(val);
+        }
+        Ok(DecimalArray {
+            data: data.into(),
+            null_mask: src.null_mask.clone(),
+            precision,
+            scale,
+        })
+    }
+
+    /// Changes the scale of this array, adjusting raw values to preserve
+    /// the represented decimal quantity.
+    ///
+    /// When `new_scale > self.scale`, raw values are multiplied by
+    /// `10^(new_scale - old_scale)` to add fractional precision. When
+    /// `new_scale < self.scale`, raw values are divided by
+    /// `10^(old_scale - new_scale)`, truncating toward zero.
+    ///
+    /// Returns `MinarrowError::Overflow` if any multiplication overflows
+    /// the backing integer type. The null mask is preserved unchanged.
+    pub fn rescale(&self, new_scale: i8) -> Result<Self, crate::enums::error::MinarrowError> {
+        use num_traits::NumCast;
+        let diff = (new_scale as i32) - (self.scale as i32);
+        let mut data = Vec64::with_capacity(self.len());
+
+        if diff == 0 {
+            // No change needed, clone the data
+            return Ok(Self {
+                data: self.data.clone(),
+                null_mask: self.null_mask.clone(),
+                precision: self.precision,
+                scale: new_scale,
+            });
+        } else if diff > 0 {
+            // Scale up: multiply raw values
+            let factor = 10_i128.pow(diff as u32);
+            for &raw in self.data.iter() {
+                let wide = raw.to_i128().unwrap();
+                let scaled = wide.checked_mul(factor).ok_or_else(|| {
+                    crate::enums::error::MinarrowError::Overflow {
+                        value: wide.to_string(),
+                        target: "DecimalArray",
+                    }
+                })?;
+                let val: T = NumCast::from(scaled).ok_or_else(|| {
+                    crate::enums::error::MinarrowError::Overflow {
+                        value: scaled.to_string(),
+                        target: "DecimalArray",
+                    }
+                })?;
+                data.push(val);
+            }
+        } else {
+            // Scale down: divide raw values (truncating toward zero)
+            let factor = 10_i128.pow((-diff) as u32);
+            for &raw in self.data.iter() {
+                let wide = raw.to_i128().unwrap();
+                let scaled = wide / factor;
+                let val: T = NumCast::from(scaled).ok_or_else(|| {
+                    crate::enums::error::MinarrowError::Overflow {
+                        value: scaled.to_string(),
+                        target: "DecimalArray",
+                    }
+                })?;
+                data.push(val);
+            }
+        }
+
+        Ok(Self {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+            precision: self.precision,
+            scale: new_scale,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Width conversions - explicit methods
+// ---------------------------------------------------------------------------
+
+impl DecimalArray<i32> {
+    /// Widens to `DecimalArray<i64>` (lossless).
+    ///
+    /// Every i32 value fits in i64 without overflow. Precision, scale, and
+    /// the null mask propagate unchanged.
+    pub fn to_dec64(&self) -> DecimalArray<i64> {
+        let data: Vec64<i64> = self.data.iter().map(|&v| v as i64).collect();
+        DecimalArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+            precision: self.precision,
+            scale: self.scale,
+        }
+    }
+
+    /// Widens to `DecimalArray<i128>` (lossless).
+    ///
+    /// Every i32 value fits in i128 without overflow. Precision, scale, and
+    /// the null mask propagate unchanged.
+    pub fn to_dec128(&self) -> DecimalArray<i128> {
+        let data: Vec64<i128> = self.data.iter().map(|&v| v as i128).collect();
+        DecimalArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+            precision: self.precision,
+            scale: self.scale,
+        }
+    }
+}
+
+impl DecimalArray<i64> {
+    /// Widens to `DecimalArray<i128>` (lossless).
+    ///
+    /// Every i64 value fits in i128 without overflow. Precision, scale, and
+    /// the null mask propagate unchanged.
+    pub fn to_dec128(&self) -> DecimalArray<i128> {
+        let data: Vec64<i128> = self.data.iter().map(|&v| v as i128).collect();
+        DecimalArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+            precision: self.precision,
+            scale: self.scale,
+        }
+    }
+
+    /// Narrows to `DecimalArray<i32>`, returning an error if any value
+    /// exceeds the i32 range.
+    ///
+    /// Precision, scale, and the null mask propagate unchanged on success.
+    pub fn to_dec32(&self) -> Result<DecimalArray<i32>, crate::enums::error::MinarrowError> {
+        let mut data = Vec64::with_capacity(self.len());
+        for &v in self.data.iter() {
+            let narrow = i32::try_from(v).map_err(|_| {
+                crate::enums::error::MinarrowError::Overflow {
+                    value: v.to_string(),
+                    target: "DecimalArray<i32>",
+                }
+            })?;
+            data.push(narrow);
+        }
+        Ok(DecimalArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+            precision: self.precision,
+            scale: self.scale,
+        })
+    }
+}
+
+impl DecimalArray<i128> {
+    /// Narrows to `DecimalArray<i64>`, returning an error if any value
+    /// exceeds the i64 range.
+    ///
+    /// Precision, scale, and the null mask propagate unchanged on success.
+    pub fn to_dec64(&self) -> Result<DecimalArray<i64>, crate::enums::error::MinarrowError> {
+        let mut data = Vec64::with_capacity(self.len());
+        for &v in self.data.iter() {
+            let narrow = i64::try_from(v).map_err(|_| {
+                crate::enums::error::MinarrowError::Overflow {
+                    value: v.to_string(),
+                    target: "DecimalArray<i64>",
+                }
+            })?;
+            data.push(narrow);
+        }
+        Ok(DecimalArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+            precision: self.precision,
+            scale: self.scale,
+        })
+    }
+
+    /// Narrows to `DecimalArray<i32>`, returning an error if any value
+    /// exceeds the i32 range.
+    ///
+    /// Precision, scale, and the null mask propagate unchanged on success.
+    pub fn to_dec32(&self) -> Result<DecimalArray<i32>, crate::enums::error::MinarrowError> {
+        let mut data = Vec64::with_capacity(self.len());
+        for &v in self.data.iter() {
+            let narrow = i32::try_from(v).map_err(|_| {
+                crate::enums::error::MinarrowError::Overflow {
+                    value: v.to_string(),
+                    target: "DecimalArray<i32>",
+                }
+            })?;
+            data.push(narrow);
+        }
+        Ok(DecimalArray {
+            data: data.into(),
+            null_mask: self.null_mask.clone(),
+            precision: self.precision,
+            scale: self.scale,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Parallel iterators (feature-gated)
 // ---------------------------------------------------------------------------
 
@@ -1780,5 +2146,462 @@ mod tests {
             assert_eq!(result.get(3), Some(400));
             assert_eq!(result.null_count(), 2);
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // to_float64_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_to_float64_array_basic() {
+        // raw=12345, scale=2 -> 123.45
+        let arr = DecimalArray::<i64>::from_slice(&[12345, -67890, 0], 10, 2);
+        let f64_arr = arr.to_float64_array();
+        assert_eq!(f64_arr.len(), 3);
+        assert!((f64_arr.data[0] - 123.45).abs() < 1e-10);
+        assert!((f64_arr.data[1] - (-678.90)).abs() < 1e-10);
+        assert!((f64_arr.data[2] - 0.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_to_float64_array_zero_scale() {
+        let arr = DecimalArray::<i32>::from_slice(&[42, -7], 5, 0);
+        let f64_arr = arr.to_float64_array();
+        assert!((f64_arr.data[0] - 42.0).abs() < 1e-10);
+        assert!((f64_arr.data[1] - (-7.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_to_float64_array_preserves_nulls() {
+        let mut arr = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+        arr.push(12345);
+        arr.push_null();
+        arr.push(67890);
+        let f64_arr = arr.to_float64_array();
+        assert_eq!(f64_arr.len(), 3);
+        assert!(f64_arr.null_mask.is_some());
+        let mask = f64_arr.null_mask.as_ref().unwrap();
+        assert!(mask.get(0));
+        assert!(!mask.get(1));
+        assert!(mask.get(2));
+    }
+
+    #[test]
+    fn test_to_float64_array_i128() {
+        let arr = DecimalArray::<i128>::from_slice(&[123456789012345i128], 38, 6);
+        let f64_arr = arr.to_float64_array();
+        assert!((f64_arr.data[0] - 123456789.012345).abs() < 1e-4);
+    }
+
+    // -----------------------------------------------------------------------
+    // to_float32_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_to_float32_array_basic() {
+        let arr = DecimalArray::<i32>::from_slice(&[12345, -500], 10, 2);
+        let f32_arr = arr.to_float32_array();
+        assert_eq!(f32_arr.len(), 2);
+        assert!((f32_arr.data[0] - 123.45).abs() < 0.01);
+        assert!((f32_arr.data[1] - (-5.0)).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_to_float32_array_preserves_nulls() {
+        let mut arr = DecimalArray::<i64>::with_capacity(2, true, 10, 2);
+        arr.push(100);
+        arr.push_null();
+        let f32_arr = arr.to_float32_array();
+        assert_eq!(f32_arr.len(), 2);
+        assert!(f32_arr.null_mask.is_some());
+        let mask = f32_arr.null_mask.as_ref().unwrap();
+        assert!(mask.get(0));
+        assert!(!mask.get(1));
+    }
+
+    // -----------------------------------------------------------------------
+    // to_int64_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_to_int64_array_basic() {
+        // raw=12345, scale=2 -> 12345/100 = 123 (truncating)
+        let arr = DecimalArray::<i64>::from_slice(&[12345, -67890, 0], 10, 2);
+        let i64_arr = arr.to_int64_array().unwrap();
+        assert_eq!(i64_arr.len(), 3);
+        assert_eq!(i64_arr.data[0], 123);
+        assert_eq!(i64_arr.data[1], -678);
+        assert_eq!(i64_arr.data[2], 0);
+    }
+
+    #[test]
+    fn test_to_int64_array_truncation() {
+        // raw=199, scale=2 -> 199/100 = 1 (truncated, not rounded)
+        let arr = DecimalArray::<i32>::from_slice(&[199, -199], 5, 2);
+        let i64_arr = arr.to_int64_array().unwrap();
+        assert_eq!(i64_arr.data[0], 1);
+        assert_eq!(i64_arr.data[1], -1);
+    }
+
+    #[test]
+    fn test_to_int64_array_zero_scale() {
+        let arr = DecimalArray::<i32>::from_slice(&[42, -7], 5, 0);
+        let i64_arr = arr.to_int64_array().unwrap();
+        assert_eq!(i64_arr.data[0], 42);
+        assert_eq!(i64_arr.data[1], -7);
+    }
+
+    #[test]
+    fn test_to_int64_array_preserves_nulls() {
+        let mut arr = DecimalArray::<i64>::with_capacity(3, true, 10, 2);
+        arr.push(12345);
+        arr.push_null();
+        arr.push(0);
+        let i64_arr = arr.to_int64_array().unwrap();
+        assert_eq!(i64_arr.len(), 3);
+        assert!(i64_arr.null_mask.is_some());
+        let mask = i64_arr.null_mask.as_ref().unwrap();
+        assert!(mask.get(0));
+        assert!(!mask.get(1));
+        assert!(mask.get(2));
+    }
+
+    #[test]
+    fn test_to_int64_array_i128_overflow() {
+        // i128 value too large for i64 after scaling
+        let arr = DecimalArray::<i128>::from_slice(
+            &[i128::MAX],
+            38,
+            0,
+        );
+        let result = arr.to_int64_array();
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // to_int32_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_to_int32_array_basic() {
+        let arr = DecimalArray::<i64>::from_slice(&[12345, -500], 10, 2);
+        let i32_arr = arr.to_int32_array().unwrap();
+        assert_eq!(i32_arr.data[0], 123);
+        assert_eq!(i32_arr.data[1], -5);
+    }
+
+    #[test]
+    fn test_to_int32_array_overflow() {
+        // raw=300000000000 / 100 = 3000000000, which exceeds i32::MAX
+        let arr = DecimalArray::<i64>::from_slice(&[300_000_000_000], 18, 2);
+        let result = arr.to_int32_array();
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // to_uint64_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_to_uint64_array_basic() {
+        let arr = DecimalArray::<i64>::from_slice(&[12345, 0], 10, 2);
+        let u64_arr = arr.to_uint64_array().unwrap();
+        assert_eq!(u64_arr.data[0], 123);
+        assert_eq!(u64_arr.data[1], 0);
+    }
+
+    #[test]
+    fn test_to_uint64_array_negative_error() {
+        let arr = DecimalArray::<i32>::from_slice(&[-100], 5, 0);
+        let result = arr.to_uint64_array();
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // to_uint32_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_to_uint32_array_basic() {
+        let arr = DecimalArray::<i32>::from_slice(&[50000, 0], 10, 2);
+        let u32_arr = arr.to_uint32_array().unwrap();
+        assert_eq!(u32_arr.data[0], 500);
+        assert_eq!(u32_arr.data[1], 0);
+    }
+
+    #[test]
+    fn test_to_uint32_array_negative_error() {
+        let arr = DecimalArray::<i64>::from_slice(&[-1], 10, 0);
+        let result = arr.to_uint32_array();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_to_uint32_array_overflow() {
+        // raw=500000000000 / 100 = 5000000000, which exceeds u32::MAX
+        let arr = DecimalArray::<i64>::from_slice(&[500_000_000_000], 18, 2);
+        let result = arr.to_uint32_array();
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // from_integer_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_from_integer_array_i64() {
+        let ints = crate::IntegerArray::<i64>::from_slice(&[100, 200, 300]);
+        let dec = DecimalArray::<i64>::from_integer_array(&ints, 10, 2).unwrap();
+        assert_eq!(dec.len(), 3);
+        assert_eq!(dec.precision, 10);
+        assert_eq!(dec.scale, 2);
+        // 100 * 100 = 10000
+        assert_eq!(dec.data[0], 10000);
+        assert_eq!(dec.data[1], 20000);
+        assert_eq!(dec.data[2], 30000);
+    }
+
+    #[test]
+    fn test_from_integer_array_i32_source() {
+        let ints = crate::IntegerArray::<i32>::from_slice(&[5, -10]);
+        let dec = DecimalArray::<i64>::from_integer_array(&ints, 10, 3).unwrap();
+        // 5 * 1000 = 5000, -10 * 1000 = -10000
+        assert_eq!(dec.data[0], 5000);
+        assert_eq!(dec.data[1], -10000);
+    }
+
+    #[test]
+    fn test_from_integer_array_preserves_nulls() {
+        let mut ints = crate::IntegerArray::<i32>::with_capacity(3, true);
+        ints.push(10);
+        ints.push_null();
+        ints.push(30);
+        let dec = DecimalArray::<i64>::from_integer_array(&ints, 10, 2).unwrap();
+        assert_eq!(dec.len(), 3);
+        assert!(dec.null_mask.is_some());
+        let mask = dec.null_mask.as_ref().unwrap();
+        assert!(mask.get(0));
+        assert!(!mask.get(1));
+        assert!(mask.get(2));
+    }
+
+    #[test]
+    fn test_from_integer_array_overflow() {
+        // i32::MAX * 10^9 overflows i32 range
+        let ints = crate::IntegerArray::<i32>::from_slice(&[i32::MAX]);
+        let result = DecimalArray::<i32>::from_integer_array(&ints, 10, 9);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_integer_array_zero_scale() {
+        let ints = crate::IntegerArray::<i64>::from_slice(&[42, -7]);
+        let dec = DecimalArray::<i64>::from_integer_array(&ints, 5, 0).unwrap();
+        assert_eq!(dec.data[0], 42);
+        assert_eq!(dec.data[1], -7);
+    }
+
+    // -----------------------------------------------------------------------
+    // rescale
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rescale_up() {
+        // scale 2 -> 4: raw values multiply by 10^2 = 100
+        let arr = DecimalArray::<i64>::from_slice(&[12345, -500], 10, 2);
+        let rescaled = arr.rescale(4).unwrap();
+        assert_eq!(rescaled.scale, 4);
+        assert_eq!(rescaled.data[0], 1234500);
+        assert_eq!(rescaled.data[1], -50000);
+    }
+
+    #[test]
+    fn test_rescale_down() {
+        // scale 4 -> 2: raw values divide by 10^2 = 100
+        let arr = DecimalArray::<i64>::from_slice(&[1234500, -50099], 10, 4);
+        let rescaled = arr.rescale(2).unwrap();
+        assert_eq!(rescaled.scale, 2);
+        assert_eq!(rescaled.data[0], 12345);
+        // -50099 / 100 = -500 (truncating toward zero)
+        assert_eq!(rescaled.data[1], -500);
+    }
+
+    #[test]
+    fn test_rescale_no_change() {
+        let arr = DecimalArray::<i32>::from_slice(&[12345], 10, 2);
+        let rescaled = arr.rescale(2).unwrap();
+        assert_eq!(rescaled.scale, 2);
+        assert_eq!(rescaled.data[0], 12345);
+    }
+
+    #[test]
+    fn test_rescale_preserves_nulls() {
+        let mut arr = DecimalArray::<i64>::with_capacity(3, true, 10, 2);
+        arr.push(12345);
+        arr.push_null();
+        arr.push(0);
+        let rescaled = arr.rescale(4).unwrap();
+        assert_eq!(rescaled.len(), 3);
+        assert!(rescaled.null_mask.is_some());
+        let mask = rescaled.null_mask.as_ref().unwrap();
+        assert!(mask.get(0));
+        assert!(!mask.get(1));
+        assert!(mask.get(2));
+    }
+
+    #[test]
+    fn test_rescale_overflow() {
+        // i32::MAX with scale 0, rescale to scale 9 would overflow i32
+        let arr = DecimalArray::<i32>::from_slice(&[i32::MAX], 10, 0);
+        let result = arr.rescale(9);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rescale_preserves_precision() {
+        let arr = DecimalArray::<i64>::from_slice(&[100], 18, 2);
+        let rescaled = arr.rescale(5).unwrap();
+        assert_eq!(rescaled.precision, 18);
+    }
+
+    // -----------------------------------------------------------------------
+    // Width conversions - explicit methods
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_to_dec64_from_dec32() {
+        let arr = DecimalArray::<i32>::from_slice(&[12345, -67890], 9, 2);
+        let arr64 = arr.to_dec64();
+        assert_eq!(arr64.len(), 2);
+        assert_eq!(arr64.data[0], 12345i64);
+        assert_eq!(arr64.data[1], -67890i64);
+        assert_eq!(arr64.precision, 9);
+        assert_eq!(arr64.scale, 2);
+    }
+
+    #[test]
+    fn test_to_dec128_from_dec32() {
+        let arr = DecimalArray::<i32>::from_slice(&[42, -99], 9, 3);
+        let arr128 = arr.to_dec128();
+        assert_eq!(arr128.len(), 2);
+        assert_eq!(arr128.data[0], 42i128);
+        assert_eq!(arr128.data[1], -99i128);
+        assert_eq!(arr128.precision, 9);
+        assert_eq!(arr128.scale, 3);
+    }
+
+    #[test]
+    fn test_to_dec128_from_dec64() {
+        let arr = DecimalArray::<i64>::from_slice(&[999_999_999_999, -1], 18, 6);
+        let arr128 = arr.to_dec128();
+        assert_eq!(arr128.len(), 2);
+        assert_eq!(arr128.data[0], 999_999_999_999i128);
+        assert_eq!(arr128.data[1], -1i128);
+        assert_eq!(arr128.precision, 18);
+        assert_eq!(arr128.scale, 6);
+    }
+
+    #[test]
+    fn test_to_dec32_from_dec64_success() {
+        let arr = DecimalArray::<i64>::from_slice(&[12345, -67890], 9, 2);
+        let arr32 = arr.to_dec32().unwrap();
+        assert_eq!(arr32.len(), 2);
+        assert_eq!(arr32.data[0], 12345i32);
+        assert_eq!(arr32.data[1], -67890i32);
+        assert_eq!(arr32.precision, 9);
+        assert_eq!(arr32.scale, 2);
+    }
+
+    #[test]
+    fn test_to_dec32_from_dec64_overflow() {
+        let arr = DecimalArray::<i64>::from_slice(&[i64::MAX], 18, 0);
+        let result = arr.to_dec32();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_to_dec64_from_dec128_success() {
+        let arr = DecimalArray::<i128>::from_slice(&[12345i128, -67890], 38, 2);
+        let arr64 = arr.to_dec64().unwrap();
+        assert_eq!(arr64.len(), 2);
+        assert_eq!(arr64.data[0], 12345i64);
+        assert_eq!(arr64.data[1], -67890i64);
+    }
+
+    #[test]
+    fn test_to_dec64_from_dec128_overflow() {
+        let arr = DecimalArray::<i128>::from_slice(&[i128::MAX], 38, 0);
+        let result = arr.to_dec64();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_to_dec32_from_dec128_success() {
+        let arr = DecimalArray::<i128>::from_slice(&[100i128, -200], 38, 2);
+        let arr32 = arr.to_dec32().unwrap();
+        assert_eq!(arr32.len(), 2);
+        assert_eq!(arr32.data[0], 100i32);
+        assert_eq!(arr32.data[1], -200i32);
+    }
+
+    #[test]
+    fn test_to_dec32_from_dec128_overflow() {
+        let arr = DecimalArray::<i128>::from_slice(&[i128::MAX], 38, 0);
+        let result = arr.to_dec32();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_width_conversion_preserves_nulls() {
+        let mut arr = DecimalArray::<i32>::with_capacity(3, true, 9, 2);
+        arr.push(100);
+        arr.push_null();
+        arr.push(300);
+
+        // Widen to i64
+        let arr64 = arr.to_dec64();
+        assert_eq!(arr64.null_count(), 1);
+        assert_eq!(arr64.get(0), Some(100i64));
+        assert_eq!(arr64.get(1), None);
+        assert_eq!(arr64.get(2), Some(300i64));
+
+        // Narrow back to i32
+        let arr32 = arr64.to_dec32().unwrap();
+        assert_eq!(arr32.null_count(), 1);
+        assert_eq!(arr32.get(0), Some(100i32));
+        assert_eq!(arr32.get(1), None);
+        assert_eq!(arr32.get(2), Some(300i32));
+    }
+
+    // -----------------------------------------------------------------------
+    // Roundtrip: from_integer_array -> to_int_array
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_roundtrip_integer_to_decimal_to_integer() {
+        let ints = crate::IntegerArray::<i64>::from_slice(&[100, 200, -50]);
+        let dec = DecimalArray::<i64>::from_integer_array(&ints, 10, 2).unwrap();
+        let back = dec.to_int64_array().unwrap();
+        assert_eq!(back.data[0], 100);
+        assert_eq!(back.data[1], 200);
+        assert_eq!(back.data[2], -50);
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty arrays
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_conversions_on_empty_array() {
+        let arr = DecimalArray::<i32>::from_slice(&[], 10, 2);
+        assert_eq!(arr.to_float64_array().len(), 0);
+        assert_eq!(arr.to_float32_array().len(), 0);
+        assert_eq!(arr.to_int64_array().unwrap().len(), 0);
+        assert_eq!(arr.to_int32_array().unwrap().len(), 0);
+        assert_eq!(arr.to_uint64_array().unwrap().len(), 0);
+        assert_eq!(arr.to_uint32_array().unwrap().len(), 0);
+        assert_eq!(arr.rescale(5).unwrap().len(), 0);
+        assert_eq!(arr.to_dec64().len(), 0);
+        assert_eq!(arr.to_dec128().len(), 0);
     }
 }

--- a/src/structs/variants/decimal.rs
+++ b/src/structs/variants/decimal.rs
@@ -62,7 +62,8 @@ use crate::traits::concatenate::Concatenate;
 use crate::traits::print::MAX_PREVIEW;
 use crate::traits::shape::Shape;
 use crate::traits::type_unions::Integer;
-use crate::{Bitmask, Buffer, Length, MaskedArray, Offset, impl_array_ref_deref};
+use crate::ffi::arrow_dtype::ArrowType;
+use crate::{Bitmask, Buffer, Length, MaskedArray, Offset, impl_arc_masked_array, impl_array_ref_deref};
 use vec64::Vec64;
 
 /// # DecimalArray
@@ -199,11 +200,21 @@ impl<T: Integer> DecimalArray<T> {
         Self::from_vec64(data.into(), None, precision, scale)
     }
 
-    // TODO(TSK376): Add `arrow_type(&self) -> ArrowType` method once
-    // ArrowType::Decimal32/64/128(u8, i8) variants are available.
-    // Implementation: match TypeId::of::<T>() returning the variant for
-    // i32 -> Decimal32, i64 -> Decimal64, i128 -> Decimal128, each
-    // carrying (self.precision, self.scale).
+    /// Returns the `ArrowType` for this decimal array, determined by the
+    /// backing integer width (i32, i64, or i128).
+    pub fn arrow_type(&self) -> ArrowType {
+        use std::any::TypeId;
+        let tid = TypeId::of::<T>();
+        if tid == TypeId::of::<i32>() {
+            ArrowType::Decimal32(self.precision, self.scale)
+        } else if tid == TypeId::of::<i64>() {
+            ArrowType::Decimal64(self.precision, self.scale)
+        } else if tid == TypeId::of::<i128>() {
+            ArrowType::Decimal128(self.precision, self.scale)
+        } else {
+            panic!("DecimalArray::arrow_type: unsupported backing type")
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -634,6 +645,16 @@ impl<T: Integer> MaskedArray for DecimalArray<T> {
 // ---------------------------------------------------------------------------
 
 impl_array_ref_deref!(DecimalArray<T>);
+impl_arc_masked_array!(
+    Inner = DecimalArray<T>,
+    T = T,
+    Container = Buffer<T>,
+    LogicalType = T,
+    CopyType = T,
+    BufferT = T,
+    Variant = NumericArray,
+    Bound = Integer,
+);
 
 // ---------------------------------------------------------------------------
 // Display - scale-aware formatting
@@ -646,7 +667,7 @@ impl_array_ref_deref!(DecimalArray<T>);
 /// inserts the decimal point `scale` digits from the right, padding with leading
 /// zeros if the value has fewer digits than scale. When scale is negative,
 /// appends `|scale|` trailing zeros.
-fn format_decimal_value<T: Integer + Display>(raw: T, scale: i8) -> String {
+pub(crate) fn format_decimal_value<T: Integer + Display>(raw: T, scale: i8) -> String {
     let raw_str = format!("{}", raw);
 
     if scale == 0 {
@@ -750,6 +771,34 @@ impl<T: Integer> Concatenate for DecimalArray<T> {
         self.precision = self.precision.max(other.precision);
         self.append_array(&other);
         Ok(self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Widening conversions (lossless)
+// ---------------------------------------------------------------------------
+
+impl From<DecimalArray<i32>> for DecimalArray<i64> {
+    fn from(src: DecimalArray<i32>) -> Self {
+        let data: Vec64<i64> = src.data.iter().map(|&v| v as i64).collect();
+        DecimalArray {
+            data: data.into(),
+            null_mask: src.null_mask,
+            precision: src.precision,
+            scale: src.scale,
+        }
+    }
+}
+
+impl From<DecimalArray<i64>> for DecimalArray<i128> {
+    fn from(src: DecimalArray<i64>) -> Self {
+        let data: Vec64<i128> = src.data.iter().map(|&v| v as i128).collect();
+        DecimalArray {
+            data: data.into(),
+            null_mask: src.null_mask,
+            precision: src.precision,
+            scale: src.scale,
+        }
     }
 }
 
@@ -1484,5 +1533,88 @@ mod tests {
         let arr2 = DecimalArray::<i32>::from_slice(&[20, 30], 10, 2);
         let result = arr1.append_range(&arr2, 1, 5);
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // arrow_type
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_arrow_type_decimal32() {
+        use crate::ffi::arrow_dtype::ArrowType;
+        let arr = DecimalArray::<i32>::from_slice(&[1], 9, 2);
+        assert_eq!(arr.arrow_type(), ArrowType::Decimal32(9, 2));
+    }
+
+    #[test]
+    fn test_arrow_type_decimal64() {
+        use crate::ffi::arrow_dtype::ArrowType;
+        let arr = DecimalArray::<i64>::from_slice(&[1], 18, 4);
+        assert_eq!(arr.arrow_type(), ArrowType::Decimal64(18, 4));
+    }
+
+    #[test]
+    fn test_arrow_type_decimal128() {
+        use crate::ffi::arrow_dtype::ArrowType;
+        let arr = DecimalArray::<i128>::from_slice(&[1], 38, 10);
+        assert_eq!(arr.arrow_type(), ArrowType::Decimal128(38, 10));
+    }
+
+    // -----------------------------------------------------------------------
+    // Widening From impls
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_widen_decimal32_to_decimal64() {
+        let arr32 = DecimalArray::<i32>::from_slice(&[12345, -67890], 9, 2);
+        let arr64 = DecimalArray::<i64>::from(arr32);
+        assert_eq!(arr64.len(), 2);
+        assert_eq!(arr64.get(0), Some(12345i64));
+        assert_eq!(arr64.get(1), Some(-67890i64));
+        assert_eq!(arr64.precision, 9);
+        assert_eq!(arr64.scale, 2);
+    }
+
+    #[test]
+    fn test_widen_decimal64_to_decimal128() {
+        let arr64 = DecimalArray::<i64>::from_slice(&[999999999999, -1], 18, 6);
+        let arr128 = DecimalArray::<i128>::from(arr64);
+        assert_eq!(arr128.len(), 2);
+        assert_eq!(arr128.get(0), Some(999999999999i128));
+        assert_eq!(arr128.get(1), Some(-1i128));
+        assert_eq!(arr128.precision, 18);
+        assert_eq!(arr128.scale, 6);
+    }
+
+    #[test]
+    fn test_widen_preserves_null_mask() {
+        let mut arr32 = DecimalArray::<i32>::with_capacity(3, true, 9, 2);
+        arr32.push(100);
+        arr32.push_null();
+        arr32.push(300);
+        let arr64 = DecimalArray::<i64>::from(arr32);
+        assert_eq!(arr64.len(), 3);
+        assert_eq!(arr64.get(0), Some(100i64));
+        assert_eq!(arr64.get(1), None);
+        assert_eq!(arr64.get(2), Some(300i64));
+        assert_eq!(arr64.null_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Arc<DecimalArray> MaskedArray delegation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_arc_masked_array_delegation() {
+        let mut arc_arr = std::sync::Arc::new(
+            DecimalArray::<i32>::from_slice(&[10, 20, 30], 9, 2),
+        );
+        assert_eq!(arc_arr.len(), 3);
+        assert_eq!(arc_arr.get(0), Some(10));
+
+        // Copy-on-write push
+        arc_arr.push(40);
+        assert_eq!(arc_arr.len(), 4);
+        assert_eq!(arc_arr.get(3), Some(40));
     }
 }

--- a/src/structs/variants/decimal.rs
+++ b/src/structs/variants/decimal.rs
@@ -1,0 +1,1488 @@
+// Copyright 2025 Peter Garfield Bower
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # DecimalArray - Fixed-Point Decimal Array
+//!
+//! Arrow-compatible, 64-byte-aligned decimal array for exact numeric values
+//! with configurable precision and scale (for e.g., monetary, accounting,
+//! and high-precision numeric columns) where floating-point approximation
+//! is not acceptable.
+//!
+//! ## Representation
+//! The array stores unscaled integer values in a 64-byte-aligned `Buffer<T>`,
+//! where `T` is one of `i32`, `i64`, or `i128` (Decimal32, Decimal64, or
+//! Decimal128 respectively). An optional Arrow-style null mask tracks valid
+//! vs. null entries.
+//!
+//! ## Precision and Scale
+//! - `precision` - total number of significant digits.
+//! - `scale` - how many of those digits follow the decimal point. Positive
+//!   scale shifts the decimal point left, negative scale appends trailing zeros.
+//! - For example, a raw value of 12345 with scale=2 represents 123.45.
+//!
+//! ## Construction and Metadata
+//! All constructors require `precision` and `scale` parameters to ensure
+//! metadata consistency. Once created, the array propagates these values
+//! through slicing, splitting, and concatenation operations. The
+//! `append_array` method validates precision and scale match before combining
+//! arrays, since mismatched decimal semantics would produce incorrect results.
+//!
+//! ## Null handling
+//! Nullness uses Arrow's 1-bit convention (1 = valid, 0 = null) via `Bitmask`,
+//! consistent with all other Minarrow array types.
+//!
+//! ## Display
+//! The `Display` impl formats values scale-aware: inserting a decimal point
+//! at the position determined by scale, using padding where needed, and
+//! honouring null entries as the string "null".
+//!
+//! ## Example
+//! ```ignore
+//! use minarrow::DecimalArray;
+//!
+//! let arr = DecimalArray::<i64>::from_slice(&[12345, 67890], 10, 2);
+//! assert_eq!(format!("{}", arr), "DecimalArray [2 values] (precision: 10, scale: 2, nulls: 0)\n[123.45, 678.90]");
+//! ```
+
+use std::fmt::{Display, Formatter};
+
+use crate::enums::shape_dim::ShapeDim;
+use crate::traits::concatenate::Concatenate;
+use crate::traits::print::MAX_PREVIEW;
+use crate::traits::shape::Shape;
+use crate::traits::type_unions::Integer;
+use crate::{Bitmask, Buffer, Length, MaskedArray, Offset, impl_array_ref_deref};
+use vec64::Vec64;
+
+/// # DecimalArray
+///
+/// Arrow-compatible, 64-byte-aligned fixed-point decimal array with optional null mask.
+///
+/// Represents exact numeric values with configurable precision and scale, backed
+/// by an integer buffer (for e.g., monetary, accounting, and high-precision
+/// numeric data) where floating-point approximation is not acceptable.
+///
+/// ## Fields
+/// - `data`: backing buffer of unscaled integer values (`Buffer<T>`).
+/// - `null_mask`: optional bit-packed bitmap (`1 = valid`, `0 = null`).
+/// - `precision`: total number of significant digits (u8).
+/// - `scale`: digits after the decimal point (i8). Positive scale shifts
+///   the point left, negative scale appends trailing zeros.
+///
+/// ## Type parameters
+/// `T` is one of `i32` (Decimal32), `i64` (Decimal64), or `i128` (Decimal128),
+/// determining the maximum value range that can be represented.
+///
+/// ## Example
+/// ```ignore
+/// use minarrow::{DecimalArray, MaskedArray};
+///
+/// let arr = DecimalArray::<i64>::from_slice(&[12345, -67890], 10, 2);
+/// assert_eq!(arr.len(), 2);
+/// assert_eq!(arr.precision, 10);
+/// assert_eq!(arr.scale, 2);
+/// ```
+#[derive(PartialEq, Clone, Debug)]
+pub struct DecimalArray<T> {
+    /// Backing buffer of unscaled integer values (Arrow-compatible).
+    pub data: Buffer<T>,
+    /// Optional null mask (bit-packed, 1=valid, 0=null).
+    pub null_mask: Option<Bitmask>,
+    /// Total number of significant digits.
+    pub precision: u8,
+    /// Digits after the decimal point. Positive shifts the point left,
+    /// negative appends trailing zeros.
+    pub scale: i8,
+}
+
+impl<T: Default> Default for DecimalArray<T> {
+    fn default() -> Self {
+        Self {
+            data: Buffer::default(),
+            null_mask: None,
+            precision: 0,
+            scale: 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+impl<T: Integer> DecimalArray<T> {
+    /// Constructs a new array from existing data and null mask with the given
+    /// precision and scale.
+    #[inline]
+    pub fn new(
+        data: impl Into<Buffer<T>>,
+        null_mask: Option<Bitmask>,
+        precision: u8,
+        scale: i8,
+    ) -> Self {
+        let data: Buffer<T> = data.into();
+        crate::utils::validate_null_mask_len(data.len(), &null_mask);
+        Self {
+            data,
+            null_mask,
+            precision,
+            scale,
+        }
+    }
+
+    /// Constructs an array with reserved capacity and optional null mask.
+    ///
+    /// ## Arguments
+    /// - `cap` - capacity (number of elements) to reserve for the backing buffer.
+    /// - `nullable` - if true, allocates a null-mask bit vector.
+    /// - `precision` - total significant digits.
+    /// - `scale` - digits after the decimal point.
+    #[inline]
+    pub fn with_capacity(cap: usize, nullable: bool, precision: u8, scale: i8) -> Self {
+        Self {
+            data: Vec64::with_capacity(cap).into(),
+            null_mask: if nullable {
+                Some(Bitmask::new_set_all(cap, true))
+            } else {
+                None
+            },
+            precision,
+            scale,
+        }
+    }
+
+    /// Constructs a contiguous DecimalArray from a slice with the given
+    /// precision and scale. The null mask must be applied after construction
+    /// if needed.
+    #[inline]
+    pub fn from_slice(slice: &[T], precision: u8, scale: i8) -> Self {
+        Self {
+            data: Vec64(slice.to_vec_in(vec64::Vec64Alloc::default())).into(),
+            null_mask: None,
+            precision,
+            scale,
+        }
+    }
+
+    /// Constructs from an already 64-byte-aligned buffer, taking ownership
+    /// without copying.
+    #[inline]
+    pub fn from_vec64(
+        data: Vec64<T>,
+        null_mask: Option<Bitmask>,
+        precision: u8,
+        scale: i8,
+    ) -> Self {
+        Self {
+            data: data.into(),
+            null_mask,
+            precision,
+            scale,
+        }
+    }
+
+    /// Constructs from a standard `Vec<T>`, aligning to 64-byte boundaries
+    /// where needed.
+    #[inline]
+    pub fn from_vec(data: Vec<T>, precision: u8, scale: i8) -> Self {
+        Self::from_vec64(data.into(), None, precision, scale)
+    }
+
+    // TODO(TSK376): Add `arrow_type(&self) -> ArrowType` method once
+    // ArrowType::Decimal32/64/128(u8, i8) variants are available.
+    // Implementation: match TypeId::of::<T>() returning the variant for
+    // i32 -> Decimal32, i64 -> Decimal64, i128 -> Decimal128, each
+    // carrying (self.precision, self.scale).
+}
+
+// ---------------------------------------------------------------------------
+// MaskedArray implementation
+// ---------------------------------------------------------------------------
+//
+// DecimalArray implements MaskedArray manually because precision and scale
+// metadata must propagate through slice_clone, split, and be validated in
+// append_array. The impl_masked_array! macro supports only one extra field
+// via its $extra_field parameter, which is insufficient for two metadata fields.
+
+impl<T: Integer> MaskedArray for DecimalArray<T> {
+    type T = T;
+    type Container = Buffer<T>;
+    type LogicalType = T;
+    type CopyType<'a> = T where Self: 'a;
+
+    fn data(&self) -> &Buffer<T> {
+        &self.data
+    }
+
+    fn delete_range(&mut self, start: usize, end: usize) {
+        self.data.delete_range(start, end);
+        if let Some(mask) = &mut self.null_mask {
+            mask.delete_range(start, end);
+        }
+    }
+
+    #[inline]
+    fn push(&mut self, value: T) {
+        self.data_mut().push(value);
+        let idx = self.len() - 1;
+        if let Some(nm) = &mut self.null_mask {
+            nm.set(idx, true);
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn push_unchecked(&mut self, value: T) {
+        let idx = self.len();
+        unsafe {
+            self.set_unchecked(idx, value);
+            if let Some(mask) = self.null_mask_mut() {
+                mask.set_unchecked(idx, true);
+            }
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn null_mask(&self) -> Option<&Bitmask> {
+        self.null_mask.as_ref()
+    }
+
+    /// Returns a copy of `[offset, offset+len)` with precision and scale
+    /// propagated from the source array.
+    fn slice_clone(&self, offset: usize, len: usize) -> Self {
+        assert!(offset + len <= self.data.len(), "slice out of bounds");
+
+        let data = Vec64::from_slice(&self.data[offset..offset + len]);
+        let null_mask = self.null_mask.as_ref().map(|m| m.slice_clone(offset, len));
+
+        Self {
+            data: data.into(),
+            null_mask,
+            precision: self.precision,
+            scale: self.scale,
+        }
+    }
+
+    #[inline(always)]
+    fn tuple_ref<'a>(&'a self, offset: Offset, len: Length) -> (&'a Self, Offset, Length) {
+        (self, offset, len)
+    }
+
+    fn null_mask_mut(&mut self) -> Option<&mut Bitmask> {
+        self.null_mask.as_mut()
+    }
+
+    fn set_null_mask(&mut self, mask: Option<Bitmask>) {
+        self.null_mask = mask;
+    }
+
+    fn data_mut(&mut self) -> &mut Buffer<T> {
+        &mut self.data
+    }
+
+    #[inline]
+    fn iter(&self) -> impl Iterator<Item = T> + '_
+    where
+        T: Copy,
+    {
+        (0..self.len()).map(move |i| self.data()[i])
+    }
+
+    #[inline]
+    fn iter_opt(&self) -> impl Iterator<Item = Option<T>> + '_
+    where
+        T: Copy,
+    {
+        (0..self.len()).map(move |i| {
+            if self.is_null(i) {
+                None
+            } else {
+                Some(self.data()[i])
+            }
+        })
+    }
+
+    #[inline]
+    fn iter_range(&self, offset: usize, len: usize) -> impl Iterator<Item = T> + '_
+    where
+        T: Copy,
+    {
+        (offset..offset + len).map(move |i| self.data()[i])
+    }
+
+    #[inline]
+    fn iter_opt_range(&self, offset: usize, len: usize) -> impl Iterator<Item = Option<T>> + '_
+    where
+        T: Copy,
+    {
+        (offset..offset + len).map(move |i| {
+            if self.is_null(i) {
+                None
+            } else {
+                Some(self.data()[i])
+            }
+        })
+    }
+
+    #[inline]
+    fn get(&self, idx: usize) -> Option<T> {
+        if idx >= self.len() {
+            return None;
+        }
+        if self.is_null(idx) {
+            None
+        } else {
+            self.data().get(idx).copied()
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn get_unchecked(&self, idx: usize) -> Option<T> {
+        if let Some(mask) = self.null_mask() {
+            if !mask.get(idx) {
+                return None;
+            }
+        }
+        Some(unsafe { *self.data().get_unchecked(idx) })
+    }
+
+    #[inline]
+    fn set(&mut self, idx: usize, value: T) {
+        assert!(idx < self.len(), "index out of bounds");
+        let data = self.data_mut().as_mut_slice();
+        data[idx] = value;
+        if let Some(mask) = self.null_mask_mut() {
+            mask.set(idx, true);
+        }
+    }
+
+    #[inline(always)]
+    unsafe fn set_unchecked(&mut self, idx: usize, value: T) {
+        let data = self.data_mut().as_mut_slice();
+        data[idx] = value;
+        if let Some(mask) = self.null_mask_mut() {
+            unsafe { mask.set_unchecked(idx, true) };
+        }
+    }
+
+    fn resize(&mut self, n: usize, value: T) {
+        self.data.resize(n, value)
+    }
+
+    /// Appends all values and null mask from `other` to `self`.
+    ///
+    /// Panics if precision or scale differ between the two arrays, because
+    /// concatenating values with different decimal semantics produces
+    /// incorrect results.
+    fn append_array(&mut self, other: &Self) {
+        assert!(
+            self.precision == other.precision && self.scale == other.scale,
+            "DecimalArray::append_array: precision/scale mismatch (self: p={} s={}, other: p={} s={})",
+            self.precision, self.scale, other.precision, other.scale
+        );
+
+        let orig_len = self.len();
+        let other_len = other.len();
+
+        if other_len == 0 {
+            return;
+        }
+
+        self.data_mut().extend_from_slice(other.data());
+
+        match (self.null_mask_mut(), other.null_mask()) {
+            (Some(self_mask), Some(other_mask)) => {
+                self_mask.extend_from_bitmask(other_mask);
+            }
+            (Some(self_mask), None) => {
+                for i in orig_len..(orig_len + other_len) {
+                    self_mask.set(i, true);
+                }
+            }
+            (None, Some(other_mask)) => {
+                let mut mask = Bitmask::new_set_all(orig_len + other_len, true);
+                for i in 0..other_len {
+                    mask.set(orig_len + i, other_mask.get(i));
+                }
+                self.set_null_mask(Some(mask));
+            }
+            (None, None) => {}
+        }
+    }
+
+    fn append_range(
+        &mut self,
+        other: &Self,
+        offset: usize,
+        len: usize,
+    ) -> Result<(), crate::enums::error::MinarrowError> {
+        if len == 0 {
+            return Ok(());
+        }
+        if offset + len > other.len() {
+            return Err(crate::enums::error::MinarrowError::IndexError(format!(
+                "append_range: offset {} + len {} exceeds source length {}",
+                offset,
+                len,
+                other.len()
+            )));
+        }
+        assert!(
+            self.precision == other.precision && self.scale == other.scale,
+            "DecimalArray::append_range: precision/scale mismatch (self: p={} s={}, other: p={} s={})",
+            self.precision, self.scale, other.precision, other.scale
+        );
+
+        let orig_len = self.len();
+        self.data_mut()
+            .extend_from_slice(&other.data()[offset..offset + len]);
+
+        match (self.null_mask_mut(), other.null_mask()) {
+            (Some(self_mask), Some(other_mask)) => {
+                self_mask.extend_from_bitmask_range(other_mask, offset, len);
+            }
+            (Some(self_mask), None) => {
+                self_mask.resize(orig_len + len, true);
+            }
+            (None, Some(other_mask)) => {
+                let mut mask = Bitmask::new_set_all(orig_len, true);
+                mask.extend_from_bitmask_range(other_mask, offset, len);
+                self.set_null_mask(Some(mask));
+            }
+            (None, None) => {}
+        }
+        Ok(())
+    }
+
+    fn insert_rows(
+        &mut self,
+        index: usize,
+        other: &Self,
+    ) -> Result<(), crate::enums::error::MinarrowError> {
+        let orig_len = self.len();
+        let other_len = other.len();
+
+        if index > orig_len {
+            return Err(crate::enums::error::MinarrowError::IndexError(format!(
+                "Index {} out of bounds for array of length {}",
+                index, orig_len
+            )));
+        }
+        if other_len == 0 {
+            return Ok(());
+        }
+
+        assert!(
+            self.precision == other.precision && self.scale == other.scale,
+            "DecimalArray::insert_rows: precision/scale mismatch (self: p={} s={}, other: p={} s={})",
+            self.precision, self.scale, other.precision, other.scale
+        );
+
+        self.data.resize(orig_len + other_len, Default::default());
+        for i in (index..orig_len).rev() {
+            unsafe {
+                let val = *self.data.as_ref().get_unchecked(i);
+                *self.data.as_mut().get_unchecked_mut(i + other_len) = val;
+            }
+        }
+        for i in 0..other_len {
+            unsafe {
+                let val = *other.data.as_ref().get_unchecked(i);
+                *self.data.as_mut().get_unchecked_mut(index + i) = val;
+            }
+        }
+
+        match (self.null_mask_mut(), other.null_mask()) {
+            (Some(self_mask), Some(other_mask)) => {
+                self_mask.resize(orig_len + other_len, true);
+                for i in (index..orig_len).rev() {
+                    unsafe {
+                        let bit = self_mask.get_unchecked(i);
+                        self_mask.set_unchecked(i + other_len, bit);
+                    }
+                }
+                for i in 0..other_len {
+                    unsafe {
+                        let bit = other_mask.get_unchecked(i);
+                        self_mask.set_unchecked(index + i, bit);
+                    }
+                }
+            }
+            (Some(self_mask), None) => {
+                self_mask.resize(orig_len + other_len, true);
+                for i in (index..orig_len).rev() {
+                    unsafe {
+                        let bit = self_mask.get_unchecked(i);
+                        self_mask.set_unchecked(i + other_len, bit);
+                    }
+                }
+                for i in index..(index + other_len) {
+                    unsafe {
+                        self_mask.set_unchecked(i, true);
+                    }
+                }
+            }
+            (None, Some(other_mask)) => {
+                let mut mask = Bitmask::new_set_all(orig_len + other_len, true);
+                for i in 0..other_len {
+                    unsafe {
+                        let bit = other_mask.get_unchecked(i);
+                        mask.set_unchecked(index + i, bit);
+                    }
+                }
+                self.set_null_mask(Some(mask));
+            }
+            (None, None) => {}
+        }
+        Ok(())
+    }
+
+    /// Splits this array at the specified index, consuming self and returning
+    /// two arrays. Both halves inherit the source's precision and scale.
+    fn split(
+        mut self,
+        index: usize,
+    ) -> Result<(Self, Self), crate::enums::error::MinarrowError> {
+        let len = self.len();
+        if index == 0 || index >= len {
+            return Err(crate::enums::error::MinarrowError::IndexError(format!(
+                "Split index {} must be > 0 and < array length {}",
+                index, len
+            )));
+        }
+
+        let precision = self.precision;
+        let scale = self.scale;
+
+        let after_data = self.data.split_off(index);
+        let after_mask = if let Some(ref mut mask) = self.null_mask {
+            Some(mask.split_off(index))
+        } else {
+            None
+        };
+
+        let before = Self {
+            data: self.data,
+            null_mask: self.null_mask,
+            precision,
+            scale,
+        };
+        let after = Self {
+            data: after_data,
+            null_mask: after_mask,
+            precision,
+            scale,
+        };
+
+        Ok((before, after))
+    }
+
+    fn extend_from_iter_with_capacity<I>(&mut self, iter: I, additional_capacity: usize)
+    where
+        I: Iterator<Item = T>,
+    {
+        self.data.reserve(additional_capacity);
+        let values: Vec<T> = iter.collect();
+        let start_len = self.len();
+        self.data.resize(start_len + values.len(), Default::default());
+        for (i, value) in values.iter().enumerate() {
+            unsafe { self.set_unchecked(start_len + i, *value) };
+        }
+    }
+
+    fn extend_from_slice(&mut self, slice: &[T]) {
+        let start_len = self.len();
+        self.data.reserve(slice.len());
+        self.data.resize(start_len + slice.len(), Default::default());
+        for (i, value) in slice.iter().enumerate() {
+            unsafe { self.set_unchecked(start_len + i, *value) };
+        }
+    }
+
+    /// Creates a new array filled with the specified value repeated `count` times.
+    ///
+    /// The resulting array has precision=0 and scale=0 because the MaskedArray
+    /// trait signature does not carry decimal metadata. Use the constructors
+    /// for arrays with specific precision and scale.
+    fn fill(value: T, count: usize) -> Self {
+        let mut array = Self::default();
+        array.data.reserve(count);
+        array.data.resize(count, Default::default());
+        for i in 0..count {
+            unsafe { array.set_unchecked(i, value) };
+        }
+        array
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AsRef / AsMut / Deref / DerefMut
+// ---------------------------------------------------------------------------
+
+impl_array_ref_deref!(DecimalArray<T>);
+
+// ---------------------------------------------------------------------------
+// Display - scale-aware formatting
+// ---------------------------------------------------------------------------
+
+/// Formats an unscaled integer value as a decimal string, applying the given scale.
+///
+/// Applies the decimal point at the position determined by scale. When scale is
+/// zero, returns the integer without a decimal point. When scale is positive,
+/// inserts the decimal point `scale` digits from the right, padding with leading
+/// zeros if the value has fewer digits than scale. When scale is negative,
+/// appends `|scale|` trailing zeros.
+fn format_decimal_value<T: Integer + Display>(raw: T, scale: i8) -> String {
+    let raw_str = format!("{}", raw);
+
+    if scale == 0 {
+        return raw_str;
+    }
+
+    if scale < 0 {
+        let zeros = (-scale) as usize;
+        return format!("{}{}", raw_str, "0".repeat(zeros));
+    }
+
+    let scale_usize = scale as usize;
+    let (is_negative, digits) = if raw_str.starts_with('-') {
+        (true, &raw_str[1..])
+    } else {
+        (false, raw_str.as_str())
+    };
+
+    // Pad with leading zeros when the digit count is <= scale
+    let padded = if digits.len() <= scale_usize {
+        format!("{:0>width$}", digits, width = scale_usize + 1)
+    } else {
+        digits.to_string()
+    };
+
+    let split_pos = padded.len() - scale_usize;
+    let (int_part, frac_part) = padded.split_at(split_pos);
+
+    if is_negative {
+        format!("-{}.{}", int_part, frac_part)
+    } else {
+        format!("{}.{}", int_part, frac_part)
+    }
+}
+
+impl<T> Display for DecimalArray<T>
+where
+    T: Integer + Display,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let len = self.len();
+        let nulls = self.null_count();
+
+        writeln!(
+            f,
+            "DecimalArray [{} values] (precision: {}, scale: {}, nulls: {})",
+            len, self.precision, self.scale, nulls
+        )?;
+
+        write!(f, "[")?;
+
+        for i in 0..usize::min(len, MAX_PREVIEW) {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+
+            match self.get(i) {
+                Some(val) => write!(f, "{}", format_decimal_value(val, self.scale))?,
+                None => write!(f, "null")?,
+            }
+        }
+
+        if len > MAX_PREVIEW {
+            write!(f, ", ... ({} total)", len)?;
+        }
+
+        write!(f, "]")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape
+// ---------------------------------------------------------------------------
+
+impl<T: Integer> Shape for DecimalArray<T> {
+    fn shape(&self) -> ShapeDim {
+        ShapeDim::Rank1(self.len())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concatenate - validates matching scale
+// ---------------------------------------------------------------------------
+
+impl<T: Integer> Concatenate for DecimalArray<T> {
+    fn concat(
+        mut self,
+        other: Self,
+    ) -> core::result::Result<Self, crate::enums::error::MinarrowError> {
+        if self.scale != other.scale {
+            return Err(crate::enums::error::MinarrowError::IncompatibleTypeError {
+                from: "DecimalArray",
+                to: "DecimalArray",
+                message: Some(format!(
+                    "scale mismatch: {} vs {}",
+                    self.scale, other.scale
+                )),
+            });
+        }
+        // Take the wider precision to accommodate both operands
+        self.precision = self.precision.max(other.precision);
+        self.append_array(&other);
+        Ok(self)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parallel iterators (feature-gated)
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "parallel_proc")]
+impl<T> DecimalArray<T>
+where
+    T: Integer + Send + Sync + Copy + 'static,
+{
+    /// Parallel iterator over the backing buffer.
+    ///
+    /// Yields `&T` for every entry, regardless of null status. Consult the
+    /// null-mask separately for null awareness.
+    #[inline]
+    pub fn par_iter(&self) -> rayon::slice::Iter<'_, T> {
+        self.data.par_iter()
+    }
+
+    /// Parallel iterator with null awareness.
+    ///
+    /// Yields `None` for null entries and `Some(&T)` for valid values.
+    #[inline]
+    pub fn par_iter_opt(
+        &self,
+    ) -> impl rayon::prelude::ParallelIterator<Item = Option<&T>> + '_ {
+        use rayon::prelude::*;
+        let nmask = self.null_mask.as_ref();
+        self.data.par_iter().enumerate().map(move |(idx, val)| {
+            if nmask.map(|m| !m.get(idx)).unwrap_or(false) {
+                None
+            } else {
+                Some(val)
+            }
+        })
+    }
+
+    /// Parallel mutable iterator over the backing buffer.
+    ///
+    /// Zero-copy iteration giving mutable access to underlying values.
+    #[inline]
+    pub fn par_iter_mut(&mut self) -> rayon::slice::IterMut<'_, T> {
+        self.data.par_iter_mut()
+    }
+
+    /// Parallel iterator over a range of rows with null awareness.
+    ///
+    /// Iterates in parallel over the window `[start, end)`, yielding `None`
+    /// for null entries and `Some(&T)` for valid values.
+    #[inline]
+    pub fn par_iter_range(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> impl rayon::prelude::ParallelIterator<Item = Option<&T>> + '_
+    where
+        for<'r> &'r T: Send,
+    {
+        use rayon::prelude::*;
+        let nmask = self.null_mask.as_ref();
+        let data = &self.data;
+        debug_assert!(start <= end && end <= data.len());
+        (start..end).into_par_iter().map(move |i| {
+            if nmask.map(|m| !m.get(i)).unwrap_or(false) {
+                None
+            } else {
+                Some(&data[i])
+            }
+        })
+    }
+
+    /// Parallel iterator over a range of rows with null awareness.
+    ///
+    /// Iterates in parallel over the window `[start, end)`, yielding `None`
+    /// for null entries and `Some(&T)` for valid values.
+    pub fn par_iter_range_opt(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> impl rayon::prelude::ParallelIterator<Item = Option<&T>> + '_ {
+        use rayon::prelude::*;
+        let nmask = self.null_mask.as_ref();
+        let data = &self.data;
+        (start..end).into_par_iter().map(move |i| {
+            if nmask.map(|m| !m.get(i)).unwrap_or(false) {
+                None
+            } else {
+                Some(&data[i])
+            }
+        })
+    }
+
+    /// Unchecked parallel iterator over a range of rows.
+    ///
+    /// Iterates in parallel over the window `[start, end)` without bounds checks,
+    /// yielding `&T` for every entry regardless of null status.
+    /// Caller must ensure `[start, end)` is within bounds.
+    #[inline]
+    pub unsafe fn par_iter_range_unchecked(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> impl rayon::prelude::ParallelIterator<Item = &T> + '_ {
+        use rayon::prelude::*;
+        let data = &self.data;
+        (start..end)
+            .into_par_iter()
+            .map(move |i| unsafe { data.get_unchecked(i) })
+    }
+
+    /// Unchecked parallel iterator over a range with null awareness.
+    ///
+    /// Iterates in parallel over the window `[start, end)` without bounds checks
+    /// but honouring the null-mask, yielding `None` for null entries and
+    /// `Some(&T)` for valid values. Caller must ensure `[start, end)` is within bounds.
+    #[inline]
+    pub unsafe fn par_iter_range_opt_unchecked(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> impl rayon::prelude::ParallelIterator<Item = Option<&T>> + '_
+    where
+        for<'r> &'r T: Send,
+    {
+        use rayon::prelude::*;
+        let nmask = self.null_mask.as_ref();
+        let data = &self.data;
+        (start..end).into_par_iter().map(move |i| unsafe {
+            if nmask.map(|m| !m.get_unchecked(i)).unwrap_or(false) {
+                None
+            } else {
+                Some(data.get_unchecked(i))
+            }
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::structs::bitmask::Bitmask;
+    use crate::traits::masked_array::MaskedArray;
+    use crate::vec64;
+
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_default() {
+        let arr = DecimalArray::<i32>::default();
+        assert_eq!(arr.data.len(), 0);
+        assert!(arr.null_mask.is_none());
+        assert_eq!(arr.precision, 0);
+        assert_eq!(arr.scale, 0);
+    }
+
+    #[test]
+    fn test_with_capacity() {
+        let mut arr = DecimalArray::<i64>::with_capacity(8, true, 10, 2);
+        assert_eq!(arr.data.len(), 0);
+        assert!(arr.data.capacity() >= 8);
+        assert!(arr.null_mask.is_some());
+        assert_eq!(arr.precision, 10);
+        assert_eq!(arr.scale, 2);
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push(100);
+        arr.push(200);
+        assert_eq!(arr.null_count(), 0);
+
+        arr.push_null();
+        assert_eq!(arr.null_count(), 1);
+    }
+
+    #[test]
+    fn test_from_slice() {
+        let arr = DecimalArray::<i32>::from_slice(&[12345, 67890], 10, 2);
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr.precision, 10);
+        assert_eq!(arr.scale, 2);
+        assert_eq!(arr.get(0), Some(12345));
+        assert_eq!(arr.get(1), Some(67890));
+    }
+
+    #[test]
+    fn test_from_vec() {
+        let arr = DecimalArray::<i64>::from_vec(vec![100, 200, 300], 5, 1);
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr.precision, 5);
+        assert_eq!(arr.scale, 1);
+    }
+
+    #[test]
+    fn test_new_with_null_mask() {
+        let data = vec64![10i32, 20, 30];
+        let mut mask = Bitmask::new_set_all(3, true);
+        mask.set(1, false);
+        let arr = DecimalArray::new(data, Some(mask), 5, 2);
+        assert_eq!(arr.get(0), Some(10));
+        assert_eq!(arr.get(1), None);
+        assert_eq!(arr.get(2), Some(30));
+    }
+
+    // -----------------------------------------------------------------------
+    // Push, get, set
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_push_and_get_no_null_mask() {
+        let mut arr = DecimalArray::<i64>::with_capacity(4, false, 10, 2);
+        arr.push(12345);
+        arr.push(-67890);
+        assert_eq!(arr.get(0), Some(12345));
+        assert_eq!(arr.get(1), Some(-67890));
+        assert!(!arr.is_null(0));
+        assert!(!arr.is_null(1));
+    }
+
+    #[test]
+    fn test_push_and_get_with_null_mask() {
+        let mut arr = DecimalArray::<i32>::with_capacity(3, true, 5, 1);
+        arr.push(42);
+        arr.push_null();
+        arr.push(7);
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr.get(0), Some(42));
+        assert_eq!(arr.get(1), None);
+        assert_eq!(arr.get(2), Some(7));
+        assert!(!arr.is_null(0));
+        assert!(arr.is_null(1));
+        assert!(!arr.is_null(2));
+    }
+
+    #[test]
+    fn test_push_null_auto_mask() {
+        let mut arr = DecimalArray::<i32>::from_slice(&[], 10, 2);
+        arr.push_null();
+        assert_eq!(arr.data, vec64![0]);
+        assert!(arr.is_null(0));
+        assert!(arr.null_mask.is_some());
+    }
+
+    #[test]
+    fn test_set_and_set_null() {
+        let mut arr = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+        arr.push(100);
+        arr.push(200);
+        arr.push(300);
+        arr.set(1, 222);
+        assert_eq!(arr.get(1), Some(222));
+        arr.set_null(2);
+        assert_eq!(arr.get(2), None);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_out_of_bounds() {
+        let arr = DecimalArray::<i64>::from_slice(&[], 10, 2);
+        assert_eq!(arr.get(0), None);
+        assert_eq!(arr.get(100), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Bulk operations
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bulk_push_nulls() {
+        let mut arr = DecimalArray::<i32>::with_capacity(8, true, 10, 2);
+        arr.push(19);
+        arr.push_nulls(3);
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr.get(0), Some(19));
+        assert_eq!(arr.get(1), None);
+        assert_eq!(arr.get(3), None);
+        assert!(arr.is_null(2));
+    }
+
+    #[test]
+    fn test_extend_from_slice() {
+        let mut arr = DecimalArray::<i32>::with_capacity(10, false, 10, 2);
+        arr.push(100);
+        arr.extend_from_slice(&[200, 300, 400]);
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr.get(0), Some(100));
+        assert_eq!(arr.get(3), Some(400));
+    }
+
+    #[test]
+    fn test_extend_from_iter_with_capacity() {
+        let mut arr = DecimalArray::<i64>::with_capacity(3, false, 10, 2);
+        arr.extend_from_iter_with_capacity(vec![10i64, 20, 30].into_iter(), 3);
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr.get(0), Some(10));
+        assert_eq!(arr.get(2), Some(30));
+    }
+
+    #[test]
+    fn test_fill() {
+        let arr = DecimalArray::<i32>::fill(42, 100);
+        assert_eq!(arr.len(), 100);
+        for i in 0..100 {
+            assert_eq!(arr.get(i), Some(42));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Slice clone - precision/scale propagation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_slice_clone_propagates_precision_scale() {
+        let mut arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 3);
+        arr.null_mask = Some(Bitmask::new_set_all(5, true));
+        arr.set_null(3);
+
+        let sliced = arr.slice_clone(1, 3);
+        assert_eq!(sliced.len(), 3);
+        assert_eq!(sliced.precision, 10);
+        assert_eq!(sliced.scale, 3);
+        assert_eq!(sliced.get(0), Some(20));
+        assert_eq!(sliced.get(1), Some(30));
+        assert_eq!(sliced.get(2), None);
+        assert_eq!(sliced.null_count(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Append array - precision/scale validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_append_array_matching_metadata() {
+        let mut arr1 = DecimalArray::<i32>::from_slice(&[10, 20, 30], 10, 2);
+        let arr2 = DecimalArray::<i32>::from_slice(&[40, 50], 10, 2);
+        arr1.append_array(&arr2);
+        assert_eq!(arr1.len(), 5);
+        assert_eq!(arr1.get(0), Some(10));
+        assert_eq!(arr1.get(4), Some(50));
+    }
+
+    #[test]
+    #[should_panic(expected = "precision/scale mismatch")]
+    fn test_append_array_precision_mismatch_panics() {
+        let mut arr1 = DecimalArray::<i32>::from_slice(&[10], 10, 2);
+        let arr2 = DecimalArray::<i32>::from_slice(&[20], 5, 2);
+        arr1.append_array(&arr2);
+    }
+
+    #[test]
+    #[should_panic(expected = "precision/scale mismatch")]
+    fn test_append_array_scale_mismatch_panics() {
+        let mut arr1 = DecimalArray::<i32>::from_slice(&[10], 10, 2);
+        let arr2 = DecimalArray::<i32>::from_slice(&[20], 10, 3);
+        arr1.append_array(&arr2);
+    }
+
+    #[test]
+    fn test_append_array_with_nulls() {
+        let mut arr1 = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+        arr1.push(60);
+        arr1.push_null();
+        arr1.push(70);
+
+        let mut arr2 = DecimalArray::<i32>::with_capacity(2, true, 10, 2);
+        arr2.push_null();
+        arr2.push(80);
+
+        arr1.append_array(&arr2);
+        assert_eq!(arr1.len(), 5);
+        let vals: Vec<Option<i32>> = (0..arr1.len()).map(|i| arr1.get(i)).collect();
+        assert_eq!(vals, vec![Some(60), None, Some(70), None, Some(80)]);
+        assert_eq!(arr1.null_count(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Split - precision/scale propagation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_split_propagates_precision_scale() {
+        let arr = DecimalArray::<i64>::from_slice(&[100, 200, 300, 400], 12, 4);
+        let (left, right) = arr.split(2).unwrap();
+        assert_eq!(left.len(), 2);
+        assert_eq!(right.len(), 2);
+        assert_eq!(left.precision, 12);
+        assert_eq!(left.scale, 4);
+        assert_eq!(right.precision, 12);
+        assert_eq!(right.scale, 4);
+        assert_eq!(left.get(0), Some(100));
+        assert_eq!(right.get(0), Some(300));
+    }
+
+    // -----------------------------------------------------------------------
+    // Delete range
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_delete_range() {
+        let mut arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 2);
+        arr.delete_range(1, 3);
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr.get(0), Some(10));
+        assert_eq!(arr.get(1), Some(40));
+        assert_eq!(arr.get(2), Some(50));
+    }
+
+    // -----------------------------------------------------------------------
+    // Insert rows
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_insert_rows() {
+        let mut arr = DecimalArray::<i32>::from_slice(&[10, 40, 50], 10, 2);
+        let insert = DecimalArray::<i32>::from_slice(&[20, 30], 10, 2);
+        arr.insert_rows(1, &insert).unwrap();
+        assert_eq!(arr.len(), 5);
+        let vals: Vec<Option<i32>> = (0..5).map(|i| arr.get(i)).collect();
+        assert_eq!(
+            vals,
+            vec![Some(10), Some(20), Some(30), Some(40), Some(50)]
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Display - scale-aware formatting
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_format_decimal_value_positive_scale() {
+        assert_eq!(format_decimal_value(12345i64, 2), "123.45");
+        assert_eq!(format_decimal_value(-12345i64, 2), "-123.45");
+        assert_eq!(format_decimal_value(5i32, 2), "0.05");
+        assert_eq!(format_decimal_value(50i32, 2), "0.50");
+        assert_eq!(format_decimal_value(0i32, 3), "0.000");
+        assert_eq!(format_decimal_value(-1i64, 1), "-0.1");
+    }
+
+    #[test]
+    fn test_format_decimal_value_zero_scale() {
+        assert_eq!(format_decimal_value(12345i64, 0), "12345");
+        assert_eq!(format_decimal_value(-99i32, 0), "-99");
+        assert_eq!(format_decimal_value(0i32, 0), "0");
+    }
+
+    #[test]
+    fn test_format_decimal_value_negative_scale() {
+        assert_eq!(format_decimal_value(12345i64, -2), "1234500");
+        assert_eq!(format_decimal_value(-5i32, -3), "-5000");
+        assert_eq!(format_decimal_value(0i32, -1), "00");
+    }
+
+    #[test]
+    fn test_display_positive_scale() {
+        let arr = DecimalArray::<i64>::from_slice(&[12345, -67890, 5], 10, 2);
+        let display = format!("{}", arr);
+        assert!(display.contains("123.45"));
+        assert!(display.contains("-678.90"));
+        assert!(display.contains("0.05"));
+        assert!(display.contains("precision: 10"));
+        assert!(display.contains("scale: 2"));
+    }
+
+    #[test]
+    fn test_display_zero_scale() {
+        let arr = DecimalArray::<i32>::from_slice(&[100, 200], 5, 0);
+        let display = format!("{}", arr);
+        assert!(display.contains("100"));
+        assert!(display.contains("200"));
+    }
+
+    #[test]
+    fn test_display_negative_scale() {
+        let arr = DecimalArray::<i32>::from_slice(&[12345], 10, -2);
+        let display = format!("{}", arr);
+        assert!(display.contains("1234500"));
+    }
+
+    #[test]
+    fn test_display_with_nulls() {
+        let mut arr = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+        arr.push(12345);
+        arr.push_null();
+        arr.push(67890);
+        let display = format!("{}", arr);
+        assert!(display.contains("null"));
+        assert!(display.contains("nulls: 1"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Shape
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_shape() {
+        let arr = DecimalArray::<i32>::from_slice(&[1, 2, 3], 5, 0);
+        assert_eq!(arr.shape(), ShapeDim::Rank1(3));
+    }
+
+    // -----------------------------------------------------------------------
+    // Concatenate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_concat_matching_scale() {
+        let arr1 = DecimalArray::<i32>::from_slice(&[100, 200], 10, 2);
+        let arr2 = DecimalArray::<i32>::from_slice(&[300, 400], 10, 2);
+        let result = arr1.concat(arr2).unwrap();
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get(0), Some(100));
+        assert_eq!(result.get(3), Some(400));
+        assert_eq!(result.precision, 10);
+        assert_eq!(result.scale, 2);
+    }
+
+    #[test]
+    fn test_concat_takes_max_precision() {
+        let arr1 = DecimalArray::<i64>::from_slice(&[100], 8, 2);
+        let arr2 = DecimalArray::<i64>::from_slice(&[200], 12, 2);
+        let result = arr1.concat(arr2).unwrap();
+        assert_eq!(result.precision, 12);
+    }
+
+    #[test]
+    fn test_concat_mismatched_scale_errors() {
+        let arr1 = DecimalArray::<i32>::from_slice(&[100], 10, 2);
+        let arr2 = DecimalArray::<i32>::from_slice(&[200], 10, 3);
+        let result = arr1.concat(arr2);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            format!("{}", err).contains("scale mismatch"),
+            "Expected scale mismatch error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_concat_with_nulls() {
+        let mut arr1 = DecimalArray::<i32>::with_capacity(2, true, 10, 2);
+        arr1.push(10);
+        arr1.push_null();
+
+        let mut arr2 = DecimalArray::<i32>::with_capacity(2, true, 10, 2);
+        arr2.push_null();
+        arr2.push(40);
+
+        let result = arr1.concat(arr2).unwrap();
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get(0), Some(10));
+        assert_eq!(result.get(1), None);
+        assert_eq!(result.get(2), None);
+        assert_eq!(result.get(3), Some(40));
+        assert_eq!(result.null_count(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // Is empty and len
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_empty_and_len() {
+        let mut arr = DecimalArray::<i32>::from_slice(&[], 10, 2);
+        assert!(arr.is_empty());
+        arr.push(1);
+        assert!(!arr.is_empty());
+        assert_eq!(arr.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Null mask replace
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_null_mask_replace() {
+        let mut arr = DecimalArray::<i32>::from_slice(&[9], 10, 2);
+        let mut mask = Bitmask::new_set_all(1, false);
+        mask.set(0, true);
+        arr.set_null_mask(Some(mask));
+        assert!(!arr.is_null(0));
+    }
+
+    // -----------------------------------------------------------------------
+    // i128 type
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_decimal128_basic() {
+        let mut arr = DecimalArray::<i128>::with_capacity(4, true, 38, 10);
+        arr.push(123456789012345);
+        arr.push(-987654321098765);
+        arr.push_null();
+        arr.push(0);
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr.get(0), Some(123456789012345));
+        assert_eq!(arr.get(1), Some(-987654321098765));
+        assert_eq!(arr.get(2), None);
+        assert_eq!(arr.get(3), Some(0));
+        assert_eq!(arr.precision, 38);
+        assert_eq!(arr.scale, 10);
+    }
+
+    #[test]
+    fn test_decimal128_from_slice() {
+        let arr = DecimalArray::<i128>::from_slice(&[100i128, 200, 300], 38, 18);
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr.precision, 38);
+        assert_eq!(arr.scale, 18);
+    }
+
+    #[test]
+    fn test_decimal128_display() {
+        let arr = DecimalArray::<i128>::from_slice(&[12345i128], 38, 2);
+        let display = format!("{}", arr);
+        assert!(display.contains("123.45"));
+    }
+
+    #[test]
+    fn test_decimal128_concat() {
+        let arr1 = DecimalArray::<i128>::from_slice(&[100], 38, 10);
+        let arr2 = DecimalArray::<i128>::from_slice(&[200], 38, 10);
+        let result = arr1.concat(arr2).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get(0), Some(100));
+        assert_eq!(result.get(1), Some(200));
+    }
+
+    #[test]
+    fn test_decimal128_slice_clone() {
+        let arr = DecimalArray::<i128>::from_slice(&[10, 20, 30, 40], 38, 5);
+        let sliced = arr.slice_clone(1, 2);
+        assert_eq!(sliced.len(), 2);
+        assert_eq!(sliced.precision, 38);
+        assert_eq!(sliced.scale, 5);
+        assert_eq!(sliced.get(0), Some(20));
+        assert_eq!(sliced.get(1), Some(30));
+    }
+
+    // -----------------------------------------------------------------------
+    // i128 trait impls
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_i128_integer_trait() {
+        use crate::traits::type_unions::Integer;
+        let val: i128 = 42;
+        assert_eq!(val.to_usize(), 42usize);
+        assert_eq!(i128::from_usize(99), 99i128);
+    }
+
+    #[test]
+    fn test_i128_numeric_trait() {
+        use crate::traits::type_unions::Numeric;
+        fn is_numeric<T: Numeric>(_: T) {}
+        is_numeric(42i128);
+    }
+
+    #[test]
+    fn test_i128_primitive_trait() {
+        use crate::traits::type_unions::Primitive;
+        fn is_primitive<T: Primitive>(_: T) {}
+        is_primitive(42i128);
+    }
+
+    // -----------------------------------------------------------------------
+    // DecimalArray<i32> and DecimalArray<i64> also compile
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_decimal32_basic() {
+        let arr = DecimalArray::<i32>::from_slice(&[12345, -67890], 9, 4);
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr.get(0), Some(12345));
+        assert_eq!(arr.get(1), Some(-67890));
+        assert_eq!(arr.precision, 9);
+        assert_eq!(arr.scale, 4);
+    }
+
+    #[test]
+    fn test_decimal64_basic() {
+        let arr = DecimalArray::<i64>::from_slice(&[1234567890, -9876543210], 18, 6);
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr.get(0), Some(1234567890));
+        assert_eq!(arr.get(1), Some(-9876543210));
+        assert_eq!(arr.precision, 18);
+        assert_eq!(arr.scale, 6);
+    }
+
+    // -----------------------------------------------------------------------
+    // Extend from slice with nulls
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_extend_from_slice_with_nulls() {
+        let mut arr = DecimalArray::<i32>::with_capacity(10, true, 10, 2);
+        arr.push(100);
+        arr.push_null();
+
+        arr.extend_from_slice(&[200, 300, 400]);
+
+        assert_eq!(arr.len(), 5);
+        assert_eq!(arr.get(0), Some(100));
+        assert_eq!(arr.get(1), None);
+        assert_eq!(arr.get(2), Some(200));
+        assert_eq!(arr.get(3), Some(300));
+        assert_eq!(arr.get(4), Some(400));
+    }
+
+    // -----------------------------------------------------------------------
+    // Append range
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_append_range() {
+        let mut arr1 = DecimalArray::<i32>::from_slice(&[10, 20], 10, 2);
+        let arr2 = DecimalArray::<i32>::from_slice(&[30, 40, 50, 60], 10, 2);
+        arr1.append_range(&arr2, 1, 2).unwrap();
+        assert_eq!(arr1.len(), 4);
+        assert_eq!(arr1.get(2), Some(40));
+        assert_eq!(arr1.get(3), Some(50));
+    }
+
+    #[test]
+    fn test_append_range_out_of_bounds() {
+        let mut arr1 = DecimalArray::<i32>::from_slice(&[10], 10, 2);
+        let arr2 = DecimalArray::<i32>::from_slice(&[20, 30], 10, 2);
+        let result = arr1.append_range(&arr2, 1, 5);
+        assert!(result.is_err());
+    }
+}

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -42,6 +42,8 @@
 //! - `len` reflects the **logical** number of elements in the view.
 
 use std::fmt::{self, Debug, Display, Formatter};
+#[cfg(feature = "decimal")]
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use crate::enums::error::MinarrowError;
@@ -386,6 +388,12 @@ impl ArrayV {
                 NumericArray::UInt8(a) => cast_slice!(a),
                 #[cfg(feature = "extended_numeric_types")]
                 NumericArray::UInt16(a) => cast_slice!(a),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => cast_slice!(a),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => cast_slice!(a),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => cast_slice!(a),
                 NumericArray::Null => {
                     Err(KernelError::UnsupportedType("null numeric array".into()))
                 }
@@ -535,6 +543,27 @@ impl ArrayV {
                 NumericArray::UInt16(arr) => {
                     let (d, m) = gather_idx_prim!(self, arr, indices, u16);
                     Array::from_uint16(IntegerArray::new(d, m))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    let (d, m) = gather_idx_prim!(self, arr, indices, i32);
+                    Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    let (d, m) = gather_idx_prim!(self, arr, indices, i64);
+                    Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    let (d, m) = gather_idx_prim!(self, arr, indices, i128);
+                    Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
                 }
                 NumericArray::Null => Array::Null,
             },
@@ -745,6 +774,27 @@ impl ArrayV {
                 NumericArray::UInt16(arr) => {
                     let (d, m) = gather_pad_prim!(self, arr, indices, pad, u16);
                     Array::from_uint16(IntegerArray::new(d, m))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    let (d, m) = gather_pad_prim!(self, arr, indices, pad, i32);
+                    Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    let (d, m) = gather_pad_prim!(self, arr, indices, pad, i64);
+                    Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    let (d, m) = gather_pad_prim!(self, arr, indices, pad, i128);
+                    Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
                 }
                 NumericArray::Null => Array::Null,
             },
@@ -1015,6 +1065,27 @@ impl ArrayV {
                 NumericArray::UInt16(arr) => {
                     let (d, m) = gather_mask_prim!(self, arr, mask, kept, u16);
                     Array::from_uint16(IntegerArray::new(d, m))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    let (d, m) = gather_mask_prim!(self, arr, mask, kept, i32);
+                    Array::NumericArray(NumericArray::Decimal32(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    let (d, m) = gather_mask_prim!(self, arr, mask, kept, i64);
+                    Array::NumericArray(NumericArray::Decimal64(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    let (d, m) = gather_mask_prim!(self, arr, mask, kept, i128);
+                    Array::NumericArray(NumericArray::Decimal128(Arc::new(
+                        crate::DecimalArray::new(d, m, arr.precision, arr.scale),
+                    )))
                 }
                 NumericArray::Null => Array::Null,
             },

--- a/src/structs/views/array_view.rs
+++ b/src/structs/views/array_view.rs
@@ -1715,4 +1715,123 @@ mod tests {
         let empty = view.gather_mask(&Bitmask::new_set_all(4, false));
         assert_eq!(empty.len(), 0);
     }
+
+    // Decimal ArrayV Tests
+
+    #[cfg(feature = "decimal")]
+    mod decimal_view_tests {
+        use super::*;
+        use crate::{DecimalArray, MaskedArray, NumericArray};
+
+        #[test]
+        fn decimal32_view_windowing_and_slice() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 2);
+            let array = Array::from_decimal32(arr);
+            let view = ArrayV::new(array, 1, 3);
+
+            assert_eq!(view.len(), 3);
+            assert_eq!(view.offset, 1);
+            assert_eq!(view.get::<DecimalArray<i32>>(0), Some(20));
+            assert_eq!(view.get::<DecimalArray<i32>>(1), Some(30));
+            assert_eq!(view.get::<DecimalArray<i32>>(2), Some(40));
+            assert_eq!(view.get::<DecimalArray<i32>>(3), None);
+
+            let sub = view.slice(1, 1);
+            assert_eq!(sub.len(), 1);
+            assert_eq!(sub.get::<DecimalArray<i32>>(0), Some(30));
+        }
+
+        #[test]
+        fn decimal64_view_null_count() {
+            let mut arr = DecimalArray::<i64>::with_capacity(4, true, 18, 4);
+            arr.push(100);
+            arr.push_null();
+            arr.push(300);
+            arr.push(400);
+
+            let array = Array::from_decimal64(arr);
+            let view = ArrayV::new(array, 0, 4);
+            assert_eq!(view.null_count(), 1);
+
+            let sub = view.slice(0, 1);
+            assert_eq!(sub.null_count(), 0);
+
+            let sub_with_null = view.slice(1, 1);
+            assert_eq!(sub_with_null.null_count(), 1);
+        }
+
+        #[test]
+        fn decimal128_view_to_array_preserves_metadata() {
+            let arr = DecimalArray::<i128>::from_slice(&[100, 200, 300], 38, 10);
+            let array = Array::from_decimal128(arr);
+            let view = ArrayV::new(array, 1, 2);
+            let materialised = view.to_array();
+
+            if let Array::NumericArray(NumericArray::Decimal128(dec)) = materialised {
+                assert_eq!(dec.len(), 2);
+                assert_eq!(dec.precision, 38);
+                assert_eq!(dec.scale, 10);
+                assert_eq!(dec.get(0), Some(200i128));
+                assert_eq!(dec.get(1), Some(300i128));
+            } else {
+                panic!("Expected Decimal128 Array");
+            }
+        }
+
+        #[test]
+        fn decimal_view_from_array_spans_backing() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20], 10, 2);
+            let array = Array::from_decimal32(arr);
+            let view = ArrayV::from(array);
+            assert!(view.spans_backing());
+            assert_eq!(view.len(), 2);
+        }
+
+        #[cfg(feature = "select")]
+        #[test]
+        fn decimal_gather_indices() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 2);
+            let array = Array::from_decimal32(arr);
+            let view = ArrayV::new(array, 0, 5);
+
+            let gathered = view.gather_indices(&[4, 2, 0]);
+            if let Array::NumericArray(NumericArray::Decimal32(dec)) = gathered {
+                assert_eq!(dec.data.as_slice(), &[50, 30, 10]);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+            } else {
+                panic!("Expected Decimal32 Array");
+            }
+        }
+
+        #[cfg(feature = "select")]
+        #[test]
+        fn decimal_gather_mask_with_nulls() {
+            let mut arr = DecimalArray::<i64>::with_capacity(4, true, 18, 4);
+            arr.push(10);
+            arr.push_null();
+            arr.push(30);
+            arr.push(40);
+
+            let array = Array::from_decimal64(arr);
+            let view = ArrayV::new(array, 0, 4);
+
+            let mut mask = Bitmask::new_set_all(4, false);
+            mask.set(0, true);
+            mask.set(1, true);
+            mask.set(3, true);
+
+            let result = view.gather_mask(&mask);
+            if let Array::NumericArray(NumericArray::Decimal64(dec)) = result {
+                assert_eq!(dec.len(), 3);
+                assert_eq!(dec.get(0), Some(10));
+                assert_eq!(dec.get(1), None);
+                assert_eq!(dec.get(2), Some(40));
+                assert_eq!(dec.precision, 18);
+                assert_eq!(dec.scale, 4);
+            } else {
+                panic!("Expected Decimal64 Array");
+            }
+        }
+    }
 }

--- a/src/structs/views/chunked/super_array_view.rs
+++ b/src/structs/views/chunked/super_array_view.rs
@@ -960,6 +960,192 @@ mod tests {
             panic!("Expected Categorical32 Array");
         }
     }
+
+    // Decimal Array Consolidation Tests
+
+    #[cfg(feature = "decimal")]
+    fn fa_decimal32(name: &str, vals: &[i32], precision: u8, scale: i8) -> FieldArray {
+        let arr = Array::from_decimal32(crate::DecimalArray::from_slice(vals, precision, scale));
+        let field = Field::new(
+            name,
+            ArrowType::Decimal32(precision, scale),
+            false,
+            None,
+        );
+        FieldArray::new(field, arr)
+    }
+
+    #[cfg(feature = "decimal")]
+    fn fa_decimal64(name: &str, vals: &[i64], precision: u8, scale: i8) -> FieldArray {
+        let arr = Array::from_decimal64(crate::DecimalArray::from_slice(vals, precision, scale));
+        let field = Field::new(
+            name,
+            ArrowType::Decimal64(precision, scale),
+            false,
+            None,
+        );
+        FieldArray::new(field, arr)
+    }
+
+    #[cfg(feature = "decimal")]
+    fn fa_decimal128(name: &str, vals: &[i128], precision: u8, scale: i8) -> FieldArray {
+        let arr = Array::from_decimal128(crate::DecimalArray::from_slice(vals, precision, scale));
+        let field = Field::new(
+            name,
+            ArrowType::Decimal128(precision, scale),
+            false,
+            None,
+        );
+        FieldArray::new(field, arr)
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_single_chunk() {
+        let fa1 = fa_decimal32("d", &[10, 20, 30, 40], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1]);
+        let slice = ca.slice(0, 4);
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 4);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[10, 20, 30, 40]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_multiple_chunks() {
+        let fa1 = fa_decimal32("d", &[10, 20], 10, 2);
+        let fa2 = fa_decimal32("d", &[30, 40, 50], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(0, 5);
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 5);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[10, 20, 30, 40, 50]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_with_offset() {
+        let fa1 = fa_decimal32("d", &[100, 200, 300, 400, 500], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1]);
+        let slice = ca.slice(1, 3); // [200, 300, 400]
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 3);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[200, 300, 400]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal32_cross_chunk_slice() {
+        let fa1 = fa_decimal32("d", &[10, 20], 10, 2);
+        let fa2 = fa_decimal32("d", &[30, 40], 10, 2);
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(1, 2); // [20, 30] spanning chunks
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 2);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[20, 30]);
+            assert_eq!(dec.precision, 10);
+            assert_eq!(dec.scale, 2);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal64_multiple_chunks() {
+        let fa1 = fa_decimal64("d", &[1000i64, 2000], 18, 4);
+        let fa2 = fa_decimal64("d", &[3000i64], 18, 4);
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(0, 3);
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 3);
+        if let Array::NumericArray(NumericArray::Decimal64(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[1000i64, 2000, 3000]);
+            assert_eq!(dec.precision, 18);
+            assert_eq!(dec.scale, 4);
+        } else {
+            panic!("Expected Decimal64 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal128_with_offset() {
+        let fa1 = fa_decimal128("d", &[10i128, 20, 30, 40, 50], 38, 10);
+        let ca = SuperArray::from_chunks(vec![fa1]);
+        let slice = ca.slice(2, 2); // [30, 40]
+        let arr = slice.consolidate();
+
+        assert_eq!(arr.len(), 2);
+        if let Array::NumericArray(NumericArray::Decimal128(dec)) = arr {
+            assert_eq!(dec.data.as_slice(), &[30i128, 40]);
+            assert_eq!(dec.precision, 38);
+            assert_eq!(dec.scale, 10);
+        } else {
+            panic!("Expected Decimal128 Array");
+        }
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_consolidate_decimal_with_nulls() {
+        use crate::MaskedArray;
+
+        let mut dec_arr = crate::DecimalArray::<i32>::with_capacity(4, true, 10, 2);
+        dec_arr.push(10);
+        dec_arr.push_null();
+        dec_arr.push(30);
+        dec_arr.push(40);
+        let arr1 = Array::from_decimal32(dec_arr);
+        let field = Field::new("d", ArrowType::Decimal32(10, 2), true, None);
+        let fa1 = FieldArray::new(field.clone(), arr1);
+
+        let arr2 = Array::from_decimal32(
+            crate::DecimalArray::<i32>::from_slice(&[50, 60], 10, 2),
+        );
+        let fa2 = FieldArray::new(field.clone(), arr2);
+
+        let ca = SuperArray::from_chunks(vec![fa1, fa2]);
+        let slice = ca.slice(0, 6);
+        let result = slice.consolidate();
+
+        assert_eq!(result.len(), 6);
+        if let Array::NumericArray(NumericArray::Decimal32(dec)) = result {
+            assert_eq!(dec.get(0), Some(10));
+            assert_eq!(dec.get(1), None);
+            assert_eq!(dec.get(2), Some(30));
+            assert_eq!(dec.get(3), Some(40));
+            assert_eq!(dec.get(4), Some(50));
+            assert_eq!(dec.get(5), Some(60));
+            assert_eq!(dec.null_count(), 1);
+        } else {
+            panic!("Expected Decimal32 Array");
+        }
+    }
 }
 
 /// SuperArray -> SuperArrayV conversion

--- a/src/structs/views/collections/numeric_array_view.rs
+++ b/src/structs/views/collections/numeric_array_view.rs
@@ -713,4 +713,113 @@ mod tests {
             _ => panic!("expected Int32 variant"),
         }
     }
+
+    // Decimal NumericArrayV Tests
+
+    #[cfg(feature = "decimal")]
+    mod decimal_view_tests {
+        use super::*;
+        use crate::DecimalArray;
+
+        #[test]
+        fn decimal32_view_get_f64() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40, 50], 10, 2);
+            let numeric = NumericArray::Decimal32(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 1, 3);
+
+            assert_eq!(view.len(), 3);
+            assert_eq!(view.get_f64(0), Some(20.0));
+            assert_eq!(view.get_f64(1), Some(30.0));
+            assert_eq!(view.get_f64(2), Some(40.0));
+            assert_eq!(view.get_f64(3), None);
+        }
+
+        #[test]
+        fn decimal64_view_slice() {
+            let arr = DecimalArray::<i64>::from_slice(&[100, 200, 300, 400], 18, 4);
+            let numeric = NumericArray::Decimal64(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 0, 4);
+            let sub = view.slice(1, 2);
+
+            assert_eq!(sub.len(), 2);
+            assert_eq!(sub.get_f64(0), Some(200.0));
+            assert_eq!(sub.get_f64(1), Some(300.0));
+        }
+
+        #[test]
+        fn decimal128_view_null_count() {
+            let mut arr = DecimalArray::<i128>::with_capacity(4, true, 38, 10);
+            arr.push(10);
+            arr.push_null();
+            arr.push(30);
+            arr.push(40);
+
+            let numeric = NumericArray::Decimal128(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 0, 4);
+            assert_eq!(view.null_count(), 1);
+            assert!(view.has_nulls());
+
+            let no_null_view = view.slice(2, 2);
+            assert_eq!(no_null_view.null_count(), 0);
+            assert!(!no_null_view.has_nulls());
+        }
+
+        #[test]
+        fn decimal_view_to_numeric_array_preserves_metadata() {
+            let arr = DecimalArray::<i32>::from_slice(&[100, 200, 300, 400], 10, 2);
+            let numeric = NumericArray::Decimal32(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 1, 2);
+            let materialised = view.to_numeric_array();
+
+            if let NumericArray::Decimal32(dec) = materialised {
+                assert_eq!(dec.len(), 2);
+                assert_eq!(dec.precision, 10);
+                assert_eq!(dec.scale, 2);
+                assert_eq!(dec.get(0), Some(200));
+                assert_eq!(dec.get(1), Some(300));
+            } else {
+                panic!("Expected Decimal32 variant");
+            }
+        }
+
+        #[test]
+        fn decimal_view_from_numeric_array() {
+            let arr = DecimalArray::<i64>::from_slice(&[10, 20], 18, 6);
+            let numeric = NumericArray::Decimal64(Arc::new(arr));
+            let view = NumericArrayV::from(numeric);
+            assert_eq!(view.len(), 2);
+            assert_eq!(view.offset, 0);
+            assert_eq!(view.get_f64(0), Some(10.0));
+            assert_eq!(view.get_f64(1), Some(20.0));
+        }
+
+        #[test]
+        fn decimal_view_from_array_v() {
+            let arr = DecimalArray::<i32>::from_slice(&[10, 20, 30, 40], 10, 2);
+            let array = crate::Array::from_decimal32(arr);
+            let array_v = crate::ArrayV::new(array, 1, 2);
+            let numeric_v = NumericArrayV::from(array_v);
+
+            assert_eq!(numeric_v.len(), 2);
+            assert_eq!(numeric_v.offset, 1);
+            assert_eq!(numeric_v.get_f64(0), Some(20.0));
+            assert_eq!(numeric_v.get_f64(1), Some(30.0));
+        }
+
+        #[test]
+        fn decimal_view_null_mask_view() {
+            let mut arr = DecimalArray::<i32>::with_capacity(3, true, 10, 2);
+            arr.push(10);
+            arr.push_null();
+            arr.push(30);
+
+            let numeric = NumericArray::Decimal32(Arc::new(arr));
+            let view = NumericArrayV::new(numeric, 0, 3);
+            let mask = view.null_mask_view().expect("should have null mask");
+            assert_eq!(mask.len(), 3);
+            assert!(mask.get(0));
+            assert!(!mask.get(1));
+            assert!(mask.get(2));
+        }
+    }
 }

--- a/src/structs/views/collections/numeric_array_view.rs
+++ b/src/structs/views/collections/numeric_array_view.rs
@@ -155,6 +155,12 @@ impl NumericArrayV {
             NumericArray::UInt64(arr) => arr.get(phys_idx).map(|v| v as f64),
             NumericArray::Float32(arr) => arr.get(phys_idx).map(|v| v as f64),
             NumericArray::Float64(arr) => arr.get(phys_idx),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.get(phys_idx).map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.get(phys_idx).map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.get(phys_idx).map(|v| v as f64),
             NumericArray::Null => None,
             #[cfg(feature = "extended_numeric_types")]
             NumericArray::Int8(arr) => arr.get(phys_idx).map(|v| v as f64),
@@ -181,6 +187,12 @@ impl NumericArrayV {
             NumericArray::UInt64(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
             NumericArray::Float32(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
             NumericArray::Float64(arr) => unsafe { arr.get_unchecked(phys_idx) },
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
             NumericArray::Null => None,
             #[cfg(feature = "extended_numeric_types")]
             NumericArray::Int8(arr) => unsafe { arr.get_unchecked(phys_idx) }.map(|v| v as f64),
@@ -439,6 +451,12 @@ impl Display for NumericArrayV {
             NumericArray::UInt64(_) => "UInt64",
             NumericArray::Float32(_) => "Float32",
             NumericArray::Float64(_) => "Float64",
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(_) => "Decimal32",
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(_) => "Decimal64",
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(_) => "Decimal128",
             NumericArray::Null => "Null",
         };
 

--- a/src/structs/xarray.rs
+++ b/src/structs/xarray.rs
@@ -827,6 +827,15 @@ impl Axis {
                     value.try_f64().and_then(|t| a.data.iter().position(|&v| v as f64 == t)),
                 NumericArray::Float64(a) =>
                     value.try_f64().and_then(|t| a.data.iter().position(|&v| v == t)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) =>
+                    value.try_i32().and_then(|t| a.data.iter().position(|&v| v == t)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) =>
+                    value.try_i64().and_then(|t| a.data.iter().position(|&v| v == t)),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) =>
+                    value.try_i64().and_then(|t| a.data.iter().position(|&v| v == t as i128)),
                 NumericArray::Null => None,
             },
             #[cfg(feature = "datetime")]
@@ -934,6 +943,18 @@ impl Axis {
                 NumericArray::Float64(a) => if let (Some(lo), Some(hi)) = (low.try_f64(), high.try_f64()) {
                     coord_window!(a.data, lo, hi, f64, start, end, count);
                 },
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) => if let (Some(lo), Some(hi)) = (low.try_i64(), high.try_i64()) {
+                    coord_window!(a.data, lo, hi, i64, start, end, count);
+                },
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) => if let (Some(lo), Some(hi)) = (low.try_i64(), high.try_i64()) {
+                    coord_window!(a.data, lo, hi, i64, start, end, count);
+                },
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) => if let (Some(lo), Some(hi)) = (low.try_i64(), high.try_i64()) {
+                    coord_window!(a.data, lo, hi, i64, start, end, count);
+                },
                 NumericArray::Null => {}
             },
             #[cfg(feature = "datetime")]
@@ -1018,6 +1039,15 @@ impl Axis {
                     value.try_f64().and_then(|t| coord_nearest!(a.data, |v| (v as f64 - t).abs())),
                 NumericArray::Float64(a) =>
                     value.try_f64().and_then(|t| coord_nearest!(a.data, |v| (v - t).abs())),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(a) =>
+                    value.try_i64().and_then(|t| coord_nearest!(a.data, |v| (v as i64).abs_diff(t))),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(a) =>
+                    value.try_i64().and_then(|t| coord_nearest!(a.data, |v| v.abs_diff(t))),
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(a) =>
+                    value.try_i64().and_then(|t| coord_nearest!(a.data, |v| (v as i64).abs_diff(t))),
                 NumericArray::Null => None,
             },
             #[cfg(feature = "datetime")]

--- a/src/traits/byte_size.rs
+++ b/src/traits/byte_size.rs
@@ -168,6 +168,22 @@ impl<T> ByteSize for FloatArray<T> {
     }
 }
 
+/// ByteSize for DecimalArray<T>
+#[cfg(feature = "decimal")]
+impl<T> ByteSize for crate::DecimalArray<T> {
+    #[inline]
+    fn est_bytes(&self) -> usize {
+        let data_bytes = self.data.est_bytes();
+        let mask_bytes = self.null_mask.as_ref().map_or(0, |m| m.est_bytes());
+        data_bytes + mask_bytes
+    }
+
+    #[inline]
+    fn logical_bytes(&self) -> usize {
+        self.data.logical_bytes() + self.null_mask.as_ref().map_or(0, |m| m.logical_bytes())
+    }
+}
+
 /// ByteSize for StringArray<T>
 impl<T> ByteSize for StringArray<T> {
     #[inline]
@@ -274,6 +290,12 @@ impl ByteSize for NumericArray {
             NumericArray::UInt64(arr) => arr.est_bytes(),
             NumericArray::Float32(arr) => arr.est_bytes(),
             NumericArray::Float64(arr) => arr.est_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.est_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.est_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.est_bytes(),
             NumericArray::Null => 0,
         }
     }
@@ -294,6 +316,12 @@ impl ByteSize for NumericArray {
             NumericArray::UInt64(arr) => arr.logical_bytes(),
             NumericArray::Float32(arr) => arr.logical_bytes(),
             NumericArray::Float64(arr) => arr.logical_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(arr) => arr.logical_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(arr) => arr.logical_bytes(),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(arr) => arr.logical_bytes(),
             NumericArray::Null => 0,
         }
     }
@@ -518,6 +546,21 @@ impl ByteSize for ArrayV {
                 }
                 NumericArray::Float64(arr) => {
                     len * size_of::<f64>()
+                        + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal32(arr) => {
+                    len * size_of::<i32>()
+                        + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal64(arr) => {
+                    len * size_of::<i64>()
+                        + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
+                }
+                #[cfg(feature = "decimal")]
+                NumericArray::Decimal128(arr) => {
+                    len * size_of::<i128>()
                         + arr.null_mask.as_ref().map_or(0, |_| (len + 7) / 8)
                 }
                 NumericArray::Null => 0,
@@ -879,6 +922,12 @@ impl ByteSize for Scalar {
             // The variant carries no value
             #[cfg(feature = "datetime")]
             Scalar::Interval => 0,
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal32(_, _) => size_of::<i32>(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal64(_, _) => size_of::<i64>(),
+            #[cfg(feature = "decimal")]
+            Scalar::Decimal128(_, _) => size_of::<i128>(),
         }
     }
 }

--- a/src/traits/consolidate.rs
+++ b/src/traits/consolidate.rs
@@ -215,6 +215,18 @@ impl<'a> Consolidate for Vec<crate::aliases::ArrayVT<'a>> {
             Array::NumericArray(NumericArray::UInt8(_)) => gather_numeric!(UInt8, u8),
             #[cfg(feature = "extended_numeric_types")]
             Array::NumericArray(NumericArray::UInt16(_)) => gather_numeric!(UInt16, u16),
+            #[cfg(feature = "decimal")]
+            Array::NumericArray(NumericArray::Decimal32(_)) => {
+                panic!("Consolidate is not yet implemented for DecimalArray")
+            }
+            #[cfg(feature = "decimal")]
+            Array::NumericArray(NumericArray::Decimal64(_)) => {
+                panic!("Consolidate is not yet implemented for DecimalArray")
+            }
+            #[cfg(feature = "decimal")]
+            Array::NumericArray(NumericArray::Decimal128(_)) => {
+                panic!("Consolidate is not yet implemented for DecimalArray")
+            }
             Array::NumericArray(NumericArray::Null) => Array::Null,
 
             Array::TextArray(TextArray::String32(_)) => gather_string!(String32, u32),

--- a/src/traits/consolidate.rs
+++ b/src/traits/consolidate.rs
@@ -200,6 +200,20 @@ impl<'a> Consolidate for Vec<crate::aliases::ArrayVT<'a>> {
             }};
         }
 
+        #[cfg(feature = "decimal")]
+        macro_rules! gather_decimal {
+            ($variant:ident, $T:ty) => {{
+                let views: Vec<crate::aliases::DecimalAVT<'a, $T>> = self
+                    .iter()
+                    .map(|(arr, off, len)| match arr {
+                        Array::NumericArray(NumericArray::$variant(a)) => (a.as_ref(), *off, *len),
+                        _ => panic!("inconsistent NumericArray variants in chunk vector"),
+                    })
+                    .collect();
+                Array::NumericArray(NumericArray::$variant(Arc::new(views.consolidate())))
+            }};
+        }
+
         match self[0].0 {
             Array::NumericArray(NumericArray::Int32(_)) => gather_numeric!(Int32, i32),
             Array::NumericArray(NumericArray::Int64(_)) => gather_numeric!(Int64, i64),
@@ -217,15 +231,15 @@ impl<'a> Consolidate for Vec<crate::aliases::ArrayVT<'a>> {
             Array::NumericArray(NumericArray::UInt16(_)) => gather_numeric!(UInt16, u16),
             #[cfg(feature = "decimal")]
             Array::NumericArray(NumericArray::Decimal32(_)) => {
-                panic!("Consolidate is not yet implemented for DecimalArray")
+                gather_decimal!(Decimal32, i32)
             }
             #[cfg(feature = "decimal")]
             Array::NumericArray(NumericArray::Decimal64(_)) => {
-                panic!("Consolidate is not yet implemented for DecimalArray")
+                gather_decimal!(Decimal64, i64)
             }
             #[cfg(feature = "decimal")]
             Array::NumericArray(NumericArray::Decimal128(_)) => {
-                panic!("Consolidate is not yet implemented for DecimalArray")
+                gather_decimal!(Decimal128, i128)
             }
             Array::NumericArray(NumericArray::Null) => Array::Null,
 

--- a/src/traits/print.rs
+++ b/src/traits/print.rs
@@ -70,6 +70,12 @@ pub(crate) fn value_to_string(arr: &Array, idx: usize) -> String {
             NumericArray::UInt16(a) => a.data[idx].to_string(),
             NumericArray::Float32(a) => format_float(a.data[idx] as f64),
             NumericArray::Float64(a) => format_float(a.data[idx]),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal32(a) => format!("{}", a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal64(a) => format!("{}", a),
+            #[cfg(feature = "decimal")]
+            NumericArray::Decimal128(a) => format!("{}", a),
             NumericArray::Null => "null".into(),
         },
         // ------------------------- boolean ------------------------------

--- a/src/traits/print.rs
+++ b/src/traits/print.rs
@@ -22,6 +22,8 @@ use std::fmt::{self, Display, Formatter};
 use crate::{Array, Buffer, Float, NumericArray, TextArray};
 #[cfg(feature = "datetime")]
 use crate::{DatetimeArray, Integer, TemporalArray};
+#[cfg(feature = "decimal")]
+use crate::structs::variants::decimal::format_decimal_value;
 
 pub(crate) const MAX_PREVIEW: usize = 50;
 
@@ -71,11 +73,11 @@ pub(crate) fn value_to_string(arr: &Array, idx: usize) -> String {
             NumericArray::Float32(a) => format_float(a.data[idx] as f64),
             NumericArray::Float64(a) => format_float(a.data[idx]),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal32(a) => format!("{}", a),
+            NumericArray::Decimal32(a) => format_decimal_value(a.data[idx], a.scale),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal64(a) => format!("{}", a),
+            NumericArray::Decimal64(a) => format_decimal_value(a.data[idx], a.scale),
             #[cfg(feature = "decimal")]
-            NumericArray::Decimal128(a) => format!("{}", a),
+            NumericArray::Decimal128(a) => format_decimal_value(a.data[idx], a.scale),
             NumericArray::Null => "null".into(),
         },
         // ------------------------- boolean ------------------------------
@@ -435,4 +437,80 @@ fn parse_timezone_offset(tz: &str) -> Option<time::UtcOffset> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_positive_scale() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal64(DecimalArray::from_slice(&[12345i64, -67890], 10, 2));
+        assert_eq!(value_to_string(&arr, 0), "123.45");
+        assert_eq!(value_to_string(&arr, 1), "-678.90");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_zero_scale() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal32(DecimalArray::from_slice(&[42i32, 100], 5, 0));
+        assert_eq!(value_to_string(&arr, 0), "42");
+        assert_eq!(value_to_string(&arr, 1), "100");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_negative_scale() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal32(DecimalArray::from_slice(&[123i32], 10, -2));
+        assert_eq!(value_to_string(&arr, 0), "12300");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal_null() {
+        use crate::{Bitmask, DecimalArray};
+        let mut da = DecimalArray::from_slice(&[0i64, 100], 10, 2);
+        da.null_mask = Some(Bitmask::from_bools(&[false, true]));
+        let arr = Array::from_decimal64(da);
+        assert_eq!(value_to_string(&arr, 0), "null");
+        assert_eq!(value_to_string(&arr, 1), "1.00");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_value_to_string_decimal128() {
+        use crate::DecimalArray;
+        let arr = Array::from_decimal128(DecimalArray::from_slice(&[999_999i128], 38, 4));
+        assert_eq!(value_to_string(&arr, 0), "99.9999");
+    }
+
+    #[cfg(feature = "decimal")]
+    #[test]
+    fn test_table_display_with_decimal_column() {
+        use crate::{DecimalArray, FieldArray, Table};
+        use crate::ffi::arrow_dtype::ArrowType;
+        use crate::Field;
+
+        let decimal_arr = DecimalArray::<i64>::from_slice(&[12345, 67890, 100], 10, 2);
+        let arr = Array::from_decimal64(decimal_arr);
+        let field = Field::new(
+            "amount".to_string(),
+            ArrowType::Decimal128(10, 2),
+            false,
+            None,
+        );
+        let table = Table::build(
+            vec![FieldArray::new(field, arr)],
+            3,
+            "test".to_string(),
+        );
+        let display = format!("{}", table);
+        assert!(display.contains("123.45"), "display should contain 123.45, got: {}", display);
+        assert!(display.contains("678.90"), "display should contain 678.90, got: {}", display);
+        assert!(display.contains("1.00"), "display should contain 1.00, got: {}", display);
+    }
 }

--- a/src/traits/type_unions.rs
+++ b/src/traits/type_unions.rs
@@ -55,6 +55,9 @@ pub trait Integer:
 
 impl_usize_conversions!(u8, u16, u32, u64, i8, i16, i32, i64);
 
+#[cfg(feature = "decimal")]
+impl_usize_conversions!(i128);
+
 /// Trait for types valid as numerical.
 ///
 /// Useful when specifying `my_fn::<T: Numeric>() {}`.
@@ -71,6 +74,8 @@ impl Numeric for u8 {}
 impl Numeric for u16 {}
 impl Numeric for u32 {}
 impl Numeric for u64 {}
+#[cfg(feature = "decimal")]
+impl Numeric for i128 {}
 
 /// Trait for types valid as primitive, i.e.., floats, integers, and booleans.
 ///
@@ -87,3 +92,5 @@ impl Primitive for u16 {}
 impl Primitive for u32 {}
 impl Primitive for u64 {}
 impl Primitive for bool {}
+#[cfg(feature = "decimal")]
+impl Primitive for i128 {}

--- a/tests/apache_arrow.rs
+++ b/tests/apache_arrow.rs
@@ -980,3 +980,57 @@ fn rt_arrow_super_table_shared_categorical32() {
     assert_eq!(d0.values(), &["a", "b", "c"]);
     assert_eq!(d1.values(), &["a", "b", "c"]);
 }
+
+// ── Decimal round-trips ─────────────────────────────────────────────────
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_arrow_decimal128() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i128>::from_slice(&[12345, -67890, 0], 10, 2);
+    let a = MArray::from_decimal128(arr);
+    let f = Field::new("dec128", ArrowType::Decimal128(10, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_arrow_decimal128_with_nulls() {
+    use minarrow::{DecimalArray, MaskedArray as _};
+
+    let mut arr = DecimalArray::<i128>::with_capacity(4, true, 10, 2);
+    arr.push(12345);
+    arr.push_null();
+    arr.push(67890);
+    arr.push_null();
+    let a = MArray::from_decimal128(arr);
+    let f = Field::new("dec128_n", ArrowType::Decimal128(10, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_arrow_decimal128_empty() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i128>::from_slice(&[], 10, 2);
+    let a = MArray::from_decimal128(arr);
+    let f = Field::new("dec128_empty", ArrowType::Decimal128(10, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_arrow_decimal128_negative_scale() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i128>::from_slice(&[1000, 2000], 10, -3);
+    let a = MArray::from_decimal128(arr);
+    let f = Field::new("dec128_neg", ArrowType::Decimal128(10, -3), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}

--- a/tests/apache_arrow.rs
+++ b/tests/apache_arrow.rs
@@ -985,6 +985,30 @@ fn rt_arrow_super_table_shared_categorical32() {
 
 #[cfg(feature = "decimal")]
 #[test]
+fn rt_arrow_decimal32() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i32>::from_slice(&[12345, -6789, 0], 9, 2);
+    let a = MArray::from_decimal32(arr);
+    let f = Field::new("dec32", ArrowType::Decimal32(9, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_arrow_decimal64() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i64>::from_slice(&[12345, -67890, 0], 18, 4);
+    let a = MArray::from_decimal64(arr);
+    let f = Field::new("dec64", ArrowType::Decimal64(18, 4), false, None);
+    let fa = FieldArray::new(f, a);
+    round_trip_field_array(fa);
+}
+
+#[cfg(feature = "decimal")]
+#[test]
 fn rt_arrow_decimal128() {
     use minarrow::DecimalArray;
 

--- a/tests/polars.rs
+++ b/tests/polars.rs
@@ -1103,3 +1103,72 @@ fn rt_polars_super_table_shared_categorical32() {
         assert_eq!(d0.values(), d1.values());
     }
 }
+
+// ── Decimal round-trips ─────────────────────────────────────────────────
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_polars_decimal128() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i128>::from_slice(&[12345, -67890, 0], 10, 2);
+    let a = Array::from_decimal128(arr.clone());
+    let f = Field::new("dec128", ArrowType::Decimal128(10, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+
+    // Polars maps decimal to its Decimal dtype, which round-trips as Decimal128
+    // with the same precision and scale.
+    assert_eq!(back.field.name, "dec128");
+    assert_eq!(back.field.dtype, ArrowType::Decimal128(10, 2));
+    assert_eq!(back.array, Array::from_decimal128(arr));
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_polars_decimal128_with_nulls() {
+    use minarrow::{DecimalArray, MaskedArray as _};
+
+    let mut arr = DecimalArray::<i128>::with_capacity(4, true, 10, 2);
+    arr.push(12345);
+    arr.push_null();
+    arr.push(67890);
+    arr.push_null();
+    let a = Array::from_decimal128(arr.clone());
+    let f = Field::new("dec128_n", ArrowType::Decimal128(10, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+
+    assert_eq!(back.field.name, "dec128_n");
+    assert_eq!(back.field.dtype, ArrowType::Decimal128(10, 2));
+    assert_eq!(back.array, Array::from_decimal128(arr));
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_polars_decimal128_bare_array() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i128>::from_slice(&[100, 200, 300], 5, 1);
+    let a = Array::from_decimal128(arr.clone());
+    let s = a.to_polars("prices");
+    let back = Array::from_polars(&s);
+    assert_eq!(back, Array::from_decimal128(arr));
+}
+
+#[cfg(feature = "decimal")]
+#[test]
+fn rt_polars_decimal128_empty() {
+    use minarrow::DecimalArray;
+
+    let arr = DecimalArray::<i128>::from_slice(&[], 10, 2);
+    let a = Array::from_decimal128(arr.clone());
+    let f = Field::new("dec128_empty", ArrowType::Decimal128(10, 2), false, None);
+    let fa = FieldArray::new(f, a);
+    let s = fa.to_polars();
+    let back = FieldArray::from_polars(&s);
+    assert_eq!(back.field.dtype, ArrowType::Decimal128(10, 2));
+    assert_eq!(back.array, Array::from_decimal128(arr));
+}


### PR DESCRIPTION
Add Decimal32, Decimal64, and Decimal128 array support

This feature adds fixed-point Arrow-compliant decimal arrays for exact numeric values where floating-point approximation is not acceptable (for e.g., monetary, accounting, and high-precision numeric columns).

- DecimalArray<T> struct generic over i32/i64/i128 with precision and scale metadata
- Integration across NumericArray, Array, Scalar, Value, Views, SuperArray, and Consolidate
- Arrow C Data Interface import/export with format string round-trips for all three widths
- arrow-rs and Polars bridge round-trips
- Arithmetic kernels with checked overflow, scale reconciliation, and auto-promotion
- Type conversions between decimal and integer/float types, plus width widening and narrowing
- Broadcasting and scale-aware print formatting
- pyo3 zero-copy bridge and minarrow-py pure-Python construction/inspection
- Gated behind #[cfg(feature = "decimal")] without impacting builds that don't have the feature